### PR TITLE
Allow for an environment variable to override the location of the pyH…

### DIFF
--- a/tools/amd_build/build_pytorch_amd.py
+++ b/tools/amd_build/build_pytorch_amd.py
@@ -63,9 +63,12 @@ for root, _directories, files in os.walk(os.path.join(out_dir, "torch")):
                 f.flush()
                 os.fsync(f)
 
+# Figure out the path to the Hipify script or default to ROCm directory
+hipify = os.getenv('PYHIPIFY_PATH', "/opt/rocm/bin/hipify-python.py")
+
 # Execute the Hipify Script.
 subprocess.Popen(
-    ["/opt/rocm/bin/hipify-python.py",
+    [hipify,
         "--project-directory", proj_dir,
         "--output-directory", out_dir,
         "--include-dirs"] + include_dirs +


### PR DESCRIPTION
…IPIFY script.

This is helpful for development, where we may want to use a different version of pyHIPIFY than the system one. Also, it'll help in deployment situations of pytorch where the user may not have the necessary priviliges to install pyHIPIFY in a system directory but wants to compile pytorch.

