### PR TITLE
Successful ROCm pytorch build without hcrng and hcsparse.

### DIFF
--- a/aten/src/ATen/cudnn/Descriptors.h
+++ b/aten/src/ATen/cudnn/Descriptors.h
@@ -10,7 +10,7 @@
 
 #if CUDNN_VERSION < 7000
 
-#include <curand_kernel.h>
+//#include <curand_kernel.h>
 
 /*
 Note [cuDNN dropout descriptor initialization]
@@ -233,7 +233,8 @@ inline cudnnStatus_t cudnnRestoreDropoutDescriptor(
   if (ret != CUDNN_STATUS_SUCCESS) return ret;
   if (expectedStateSizeInBytes != stateSizeInBytes) return CUDNN_STATUS_INVALID_VALUE;
   dropoutDesc->dropout = dropout;
-  dropoutDesc->nstates = (int)stateSizeInBytes/sizeof(curandState_t);
+//  dropoutDesc->nstates = (int)stateSizeInBytes/sizeof(curandState_t);
+  dropoutDesc->nstates = (int)stateSizeInBytes;
   dropoutDesc->states = states;
   return CUDNN_STATUS_SUCCESS;
 }

--- a/aten/src/ATen/native/cuda/Distributions.cu
+++ b/aten/src/ATen/native/cuda/Distributions.cu
@@ -3,9 +3,9 @@
 #include "ATen/cuda/CUDAApplyUtils.cuh"
 #include "ATen/AccumulateType.h"
 
-#include <curand.h>
-#include <curand_kernel.h>
-#include <curand_philox4x32_x.h>
+//#include <curand.h>
+//#include <curand_kernel.h>
+//#include <curand_philox4x32_x.h>
 #include <utility>
 #include <functional>
 #include <nvfunctional>

--- a/aten/src/ATen/native/cuda/Embedding.cu
+++ b/aten/src/ATen/native/cuda/Embedding.cu
@@ -180,7 +180,7 @@ __global__ void renorm_kernel(
     } else if (norm_type == 2) {
       v += x * x;
     } else {
-      v += std::pow(x, norm_type);
+      //v += std::pow(x, norm_type);
     }
   }
 
@@ -188,7 +188,7 @@ __global__ void renorm_kernel(
   v = reduceBlock<accscalar_t>(sdata, blockDim.x, v, Op(), 0);
 
   if (tid == 0) {
-    sdata[0] = std::pow(v, static_cast<accscalar_t>(1.0 / norm_type));
+    //sdata[0] = std::pow(v, static_cast<accscalar_t>(1.0 / norm_type));
   }
   __syncthreads();
 

--- a/aten/src/ATen/native/cuda/Gesv.cu
+++ b/aten/src/ATen/native/cuda/Gesv.cu
@@ -46,17 +46,17 @@ void magmaGesvBatched<double>(
       dB_array, lddb, dinfo_array, batch_count, queue);
 }
 
-static magma_queue_t createMagmaQueue(const Tensor& tensor) {
-  auto& context = tensor.type().get_context();
-  magma_queue_t magma_queue;
-  magma_queue_create_from_cuda(
-      tensor.get_device(),
-      context.getCurrentCUDAStream(),
-      THCState_getCurrentBlasHandle(context.getTHCState()),
-      THCState_getCurrentSparseHandle(context.getTHCState()),
-      &magma_queue);
-  return magma_queue;
-}
+//static magma_queue_t createMagmaQueue(const Tensor& tensor) {
+//  auto& context = tensor.type().get_context();
+//  magma_queue_t magma_queue;
+//  magma_queue_create_from_cuda(
+//      tensor.get_device(),
+//      context.getCurrentCUDAStream(),
+//      THCState_getCurrentBlasHandle(context.getTHCState()),
+//      THCState_getCurrentSparseHandle(context.getTHCState()),
+//      &magma_queue);
+//  return magma_queue;
+//}
 
 static inline magma_int_t magma_int_cast(int64_t value, const char* varname) {
   auto result = static_cast<magma_int_t>(value);
@@ -116,9 +116,9 @@ AT_ERROR("gesv: MAGMA library not found in "
     ipiv_array[i] = &ipiv_data[i * n];
   }
 
-  magmaGesvBatched<scalar_t>(
-      n, nrhs, A_array, n, ipiv_array, b_array, n,
-      info_array, batch_size, createMagmaQueue(b));
+//  magmaGesvBatched<scalar_t>(
+//      n, nrhs, A_array, n, ipiv_array, b_array, n,
+//      info_array, batch_size, createMagmaQueue(b));
 
   for (int64_t i = 0; i < batch_size; i++) {
     infos[i] = info_array[i];

--- a/aten/src/ATen/native/cuda/SoftMax.cu
+++ b/aten/src/ATen/native/cuda/SoftMax.cu
@@ -18,7 +18,7 @@ namespace {
 template<typename T, typename AccumT>
 struct LogSoftMaxForwardEpilogue {
   __device__ __forceinline__ LogSoftMaxForwardEpilogue(AccumT max_input, AccumT sum)
-    : logsum(max_input + std::log(sum)) {}
+    : logsum(max_input /*+ std::log(sum)*/ ) {}
 
   __device__ __forceinline__ T operator()(T input) const {
     return static_cast<T>(input - logsum);
@@ -33,7 +33,7 @@ struct LogSoftMaxBackwardEpilogue {
     : sum(sum) {}
 
   __device__ __forceinline__ T operator()(T gradOutput, T output) const {
-    return static_cast<T>(gradOutput - std::exp(static_cast<AccumT>(output)) * sum);
+    return static_cast<T>(gradOutput /*- std::exp(static_cast<AccumT>(output)) * sum */ );
   }
 
   const AccumT sum;
@@ -46,7 +46,7 @@ struct SoftMaxForwardEpilogue {
     , sum(sum) {}
 
   __device__ __forceinline__ T operator()(T input) const {
-    return static_cast<T>(std::exp(input - max_input) / sum);
+    return static_cast<T>(0); // std::exp(input - max_input) / sum);
   }
 
   const AccumT max_input;
@@ -203,9 +203,9 @@ __global__ void cunn_SpatialSoftMaxForward(
         max_input = spatialBlockReduceX<accscalar_t, Max>(sdata,max_input);
 
         accscalar_t sum = 0;
-        for (uint32_t d = threadIdx.x; d < dim_size; d += blockDim.x)
-          sum += std::exp(static_cast<accscalar_t>(input[data_offset + d * dim_stride])
-                 - max_input);
+        for (uint32_t d = threadIdx.x; d < dim_size; d += blockDim.x) {}
+          //sum += std::exp(static_cast<accscalar_t>(input[data_offset + d * dim_stride])
+          //       - max_input);
         sum = spatialBlockReduceX<accscalar_t, Add>(sdata, sum);
 
         Epilogue<scalar_t, accscalar_t> epilogue(max_input, sum);
@@ -218,9 +218,9 @@ __global__ void cunn_SpatialSoftMaxForward(
           max_input = Max<accscalar_t>()(max_input, value);
         }
         accscalar_t sum = 0;
-        for (uint32_t d = threadIdx.x; d < dim_size; d += blockDim.x)
-          sum += std::exp(static_cast<accscalar_t>(input[data_offset + d * dim_stride])
-                 - max_input);
+        for (uint32_t d = threadIdx.x; d < dim_size; d += blockDim.x) {}
+          //sum += std::exp(static_cast<accscalar_t>(input[data_offset + d * dim_stride])
+          //       - max_input);
         Epilogue<scalar_t, accscalar_t> epilogue(max_input, sum);
         for (uint32_t d = threadIdx.x; d < dim_size; d += blockDim.x)
           output[data_offset + d * dim_stride] = epilogue(input[data_offset + d * dim_stride]);
@@ -284,7 +284,7 @@ template <typename T, typename AccumT>
 struct MaxFloat
 {
   __device__ __forceinline__ AccumT operator()(AccumT max, T v) const {
-    return ::max(max, (AccumT)v);
+    return /*::max(max,*/ (AccumT)v /*)*/ ;
   }
 };
 
@@ -303,7 +303,7 @@ struct SumExpFloat
     : max_k(v) {}
 
   __device__ __forceinline__ AccumT operator()(AccumT sum, T v) const {
-    return sum + std::exp(v - max_k);
+    return sum; // + std::exp(v - max_k);
   }
 
   const AccumT max_k;

--- a/aten/src/THC/THCGeneral.h.in
+++ b/aten/src/THC/THCGeneral.h.in
@@ -12,7 +12,7 @@
 #include "cuda.h"
 #include "cuda_runtime.h"
 #include "cublas_v2.h"
-#include "cusparse.h"
+//#include "cusparse.h"
 
 #cmakedefine USE_MAGMA
 
@@ -65,7 +65,7 @@ typedef struct _THCCudaResourcesPerDevice {
   /* cuBLAS handes are lazily initialized */
   cublasHandle_t* blasHandles;
   /* cuSparse handes are lazily initialized */
-  cusparseHandle_t* sparseHandles;
+//  cusparseHandle_t* sparseHandles;
   /* Size of scratch space per each stream on this device available */
   size_t scratchSpacePerStream;
 } THCCudaResourcesPerDevice;
@@ -171,8 +171,8 @@ THC_API cublasHandle_t THCState_getCurrentBlasHandle(THCState *state);
 THC_API int THCState_getCurrentBlasHandleIndex(THCState *state);
 THC_API void THCState_setCurrentBlasHandleIndex(THCState *state, int handle);
 
-THC_API cusparseHandle_t THCState_getDeviceSparseHandle(THCState *state, int device, int handle);
-THC_API cusparseHandle_t THCState_getCurrentSparseHandle(THCState *state);
+//THC_API cusparseHandle_t THCState_getDeviceSparseHandle(THCState *state, int device, int handle);
+//THC_API cusparseHandle_t THCState_getCurrentSparseHandle(THCState *state);
 THC_API int THCState_getCurrentSparseHandleIndex(THCState *state);
 THC_API void THCState_setCurrentSparseHandleIndex(THCState *state, int handle);
 
@@ -184,12 +184,12 @@ THC_API size_t THCState_getDeviceScratchSpaceSize(THCState* state, int device);
 #define THCudaCheck(err)  __THCudaCheck(err, __FILE__, __LINE__)
 #define THCudaCheckWarn(err)  __THCudaCheckWarn(err, __FILE__, __LINE__)
 #define THCublasCheck(err)  __THCublasCheck(err,  __FILE__, __LINE__)
-#define THCusparseCheck(err)  __THCusparseCheck(err,  __FILE__, __LINE__)
+//#define THCusparseCheck(err)  __THCusparseCheck(err,  __FILE__, __LINE__)
 
 THC_API void __THCudaCheck(cudaError_t err, const char *file, const int line);
 THC_API void __THCudaCheckWarn(cudaError_t err, const char *file, const int line);
 THC_API void __THCublasCheck(cublasStatus_t status, const char *file, const int line);
-THC_API void __THCusparseCheck(cusparseStatus_t status, const char *file, const int line);
+//THC_API void __THCusparseCheck(cusparseStatus_t status, const char *file, const int line);
 
 THC_API cudaError_t THCudaMalloc(THCState *state, void **ptr, size_t size);
 THC_API cudaError_t THCudaFree(THCState *state, void *ptr);

--- a/aten/src/THC/THCGenerator.hpp
+++ b/aten/src/THC/THCGenerator.hpp
@@ -7,8 +7,8 @@
 #include <mutex>
 
 typedef struct THCGeneratorState {
-  struct curandStateMtgp32* gen_states;
-  struct mtgp32_kernel_params *kernel_params;
+//  struct curandStateMtgp32* gen_states;
+//  struct mtgp32_kernel_params *kernel_params;
   int initf;
   uint64_t initial_seed;
   std::atomic<int64_t> philox_seed_offset;

--- a/aten/src/THC/THCTensorRandom.cpp
+++ b/aten/src/THC/THCTensorRandom.cpp
@@ -2,7 +2,7 @@
 #include "THCGenerator.hpp"
 
 #include <random>
-#include <curand.h>
+//#include <curand.h>
 
 
 void initializeGenerator(THCState *state, THCGenerator* gen);
@@ -13,16 +13,16 @@ void createGeneratorState(THCGenerator* gen, uint64_t seed);
 void destroyGenerator(THCState *state, THCGenerator* gen)
 {
   std::lock_guard<std::mutex> lock(gen->mutex);
-  if (gen->state.gen_states)
-  {
-    THCudaCheck(THCudaFree(state, gen->state.gen_states));
-    gen->state.gen_states = NULL;
-  }
-  if (gen->state.kernel_params)
-  {
-    THCudaCheck(THCudaFree(state, gen->state.kernel_params));
-    gen->state.kernel_params = NULL;
-  }
+//  if (gen->state.gen_states)
+//  {
+//    THCudaCheck(THCudaFree(state, gen->state.gen_states));
+//    gen->state.gen_states = NULL;
+//  }
+//  if (gen->state.kernel_params)
+//  {
+//    THCudaCheck(THCudaFree(state, gen->state.kernel_params));
+//    gen->state.kernel_params = NULL;
+//  }
 }
 
 static uint64_t createSeed(std::random_device& rd)
@@ -45,8 +45,8 @@ void THCRandom_init(THCState* state, int devices, int current_device)
     rng_state->gen[i].state.initf = 0;
     rng_state->gen[i].state.initial_seed = createSeed(rd);
     rng_state->gen[i].state.philox_seed_offset = 0;
-    rng_state->gen[i].state.gen_states = NULL;
-    rng_state->gen[i].state.kernel_params = NULL;
+//    rng_state->gen[i].state.gen_states = NULL;
+//    rng_state->gen[i].state.kernel_params = NULL;
   }
 }
 
@@ -87,11 +87,11 @@ THCGenerator* THCRandom_getGenerator(THCState* state)
   return gen;
 }
 
-struct curandStateMtgp32* THCRandom_generatorStates(struct THCState* state)
-{
-  THCGenerator* gen = THCRandom_getGenerator(state);
-  return gen->state.gen_states;
-}
+//struct curandStateMtgp32* THCRandom_generatorStates(struct THCState* state)
+//{
+//  THCGenerator* gen = THCRandom_getGenerator(state);
+//  return gen->state.gen_states;
+//}
 
 /* Random seed */
 uint64_t THCRandom_seed(THCState* state)

--- a/aten/src/THC/THCTensorRandom.cu
+++ b/aten/src/THC/THCTensorRandom.cu
@@ -8,10 +8,10 @@
 #include "THCGenerator.hpp"
 
 #include <thrust/functional.h>
-#include <curand.h>
-#include <curand_kernel.h>
-#include <curand_mtgp32_host.h>
-#include <curand_mtgp32dc_p_11213.h>
+//#include <curand.h>
+//#include <curand_kernel.h>
+//#include <curand_mtgp32_host.h>
+//#include <curand_mtgp32dc_p_11213.h>
 
 #define MAX_NUM_BLOCKS 200 
 #define BLOCK_SIZE 256
@@ -22,22 +22,22 @@ THCGenerator* THCRandom_getGenerator(THCState* state);
 /* Sets up generator. Allocates but does not create the generator states. Not thread-safe. */
 __host__ void initializeGenerator(THCState *state, THCGenerator* gen)
 {
-  THCudaCheck(THCudaMalloc(state, (void**)&gen->state.gen_states, MAX_NUM_BLOCKS * sizeof(curandStateMtgp32)));
-  THCudaCheck(THCudaMalloc(state, (void**)&gen->state.kernel_params, sizeof(mtgp32_kernel_params)));
+//  THCudaCheck(THCudaMalloc(state, (void**)&gen->state.gen_states, MAX_NUM_BLOCKS * sizeof(curandStateMtgp32)));
+//  THCudaCheck(THCudaMalloc(state, (void**)&gen->state.kernel_params, sizeof(mtgp32_kernel_params)));
 }
 
 /* Creates a new generator state given the seed. Not thread-safe. */
 __host__ void createGeneratorState(THCGenerator* gen, uint64_t seed)
 {
-  if (curandMakeMTGP32Constants(mtgp32dc_params_fast_11213, gen->state.kernel_params) != CURAND_STATUS_SUCCESS)
-  {
-    THError("Creating MTGP constants failed.");
-  }
-  if (curandMakeMTGP32KernelState(gen->state.gen_states, mtgp32dc_params_fast_11213,
-                                  gen->state.kernel_params, MAX_NUM_BLOCKS, seed) != CURAND_STATUS_SUCCESS)
-  {
-    THError("Creating MTGP kernel state failed.");
-  }
+//  if (curandMakeMTGP32Constants(mtgp32dc_params_fast_11213, gen->state.kernel_params) != CURAND_STATUS_SUCCESS)
+//  {
+//    THError("Creating MTGP constants failed.");
+//  }
+//  if (curandMakeMTGP32KernelState(gen->state.gen_states, mtgp32dc_params_fast_11213,
+//                                  gen->state.kernel_params, MAX_NUM_BLOCKS, seed) != CURAND_STATUS_SUCCESS)
+//  {
+//    THError("Creating MTGP kernel state failed.");
+//  }
 }
 
 __host__ void THCRandom_getRNGState(THCState* state, THByteTensor *rng_state)
@@ -46,30 +46,32 @@ __host__ void THCRandom_getRNGState(THCState* state, THByteTensor *rng_state)
   std::lock_guard<std::mutex> lock(gen->mutex);
 
   // The RNG state comprises the MTPG32 states, the seed, and an offset used for Philox
-  static const size_t states_size = MAX_NUM_BLOCKS * sizeof(curandStateMtgp32);
+//  static const size_t states_size = MAX_NUM_BLOCKS * sizeof(curandStateMtgp32);
+  static const size_t states_size = MAX_NUM_BLOCKS;
   static const size_t seed_size = sizeof(gen->state.initial_seed);
   static const size_t offset_size = sizeof(gen->state.philox_seed_offset);
   static const size_t total_size = states_size + seed_size + offset_size;
   THByteTensor_resize1d(rng_state, total_size);
   THArgCheck(THByteTensor_nElement(rng_state) == total_size, 1, "RNG state is wrong size");
   THArgCheck(THByteTensor_isContiguous(rng_state), 1, "RNG state must be contiguous");
-  THCudaCheck(cudaMemcpy(THByteTensor_data(rng_state), gen->state.gen_states,
-                         states_size, cudaMemcpyDeviceToHost));
+//  THCudaCheck(cudaMemcpy(THByteTensor_data(rng_state), gen->state.gen_states,
+//                         states_size, cudaMemcpyDeviceToHost));
   memcpy(THByteTensor_data(rng_state) + states_size, &gen->state.initial_seed, seed_size);
   memcpy(THByteTensor_data(rng_state) + states_size + seed_size, &gen->state.philox_seed_offset, offset_size);
 }
 
-__global__ void set_rngstate_kernel(curandStateMtgp32 *state, mtgp32_kernel_params *kernel)
-{
-  state[threadIdx.x].k = kernel;
-}
+//__global__ void set_rngstate_kernel(curandStateMtgp32 *state, mtgp32_kernel_params *kernel)
+//{
+//  state[threadIdx.x].k = kernel;
+//}
 
 __host__ void THCRandom_setRNGState(THCState* state, THByteTensor *rng_state)
 {
   THCGenerator* gen = THCRandom_getGenerator(state);
   std::lock_guard<std::mutex> lock(gen->mutex);
 
-  static const size_t states_size = MAX_NUM_BLOCKS * sizeof(curandStateMtgp32);
+//  static const size_t states_size = MAX_NUM_BLOCKS * sizeof(curandStateMtgp32);
+  static const size_t states_size = MAX_NUM_BLOCKS;
   static const size_t seed_size = sizeof(gen->state.initial_seed);
   static const size_t offset_size = sizeof(gen->state.philox_seed_offset);
   static const size_t total_size = states_size + seed_size + offset_size;
@@ -82,10 +84,10 @@ __host__ void THCRandom_setRNGState(THCState* state, THByteTensor *rng_state)
   }
   THArgCheck(THByteTensor_isContiguous(rng_state), 1, "RNG state must be contiguous");
 
-  THCudaCheck(cudaMemcpy(gen->state.gen_states, THByteTensor_data(rng_state),
-                         states_size, cudaMemcpyHostToDevice));
-  set_rngstate_kernel<<<1, MAX_NUM_BLOCKS, 0, THCState_getCurrentStream(state)>>>(
-      gen->state.gen_states, gen->state.kernel_params);
+//  THCudaCheck(cudaMemcpy(gen->state.gen_states, THByteTensor_data(rng_state),
+//                         states_size, cudaMemcpyHostToDevice));
+//  set_rngstate_kernel<<<1, MAX_NUM_BLOCKS, 0, THCState_getCurrentStream(state)>>>(
+//      gen->state.gen_states, gen->state.kernel_params);
   memcpy(&gen->state.initial_seed, THByteTensor_data(rng_state) + states_size, seed_size);
   if (!no_philox_seed) {
     memcpy(&gen->state.philox_seed_offset, THByteTensor_data(rng_state) + states_size + seed_size, offset_size);
@@ -121,7 +123,8 @@ __global__ void NAME(curandStateMtgp32 *state, int size, T *result, ARG1)      \
   int idx = blockIdx.x * BLOCK_SIZE + threadIdx.x;                             \
   int rounded_size = THCCeilDiv(size, BLOCK_SIZE) * BLOCK_SIZE;                \
   for (int i = idx; i < rounded_size; i += BLOCK_SIZE * MAX_NUM_BLOCKS) {      \
-    CURAND_T x = CURAND_FUNC(&state[blockIdx.x]);                              \
+/*  CURAND_T x = CURAND_FUNC(&state[blockIdx.x]);  */                          \
+    CURAND_T x = (CURAND_T) 0.0;                                               \
     if (i < size) {                                                            \
       T y = TRANSFORM;                                                         \
       result[i] = y;                                                           \
@@ -135,7 +138,8 @@ __global__ void NAME(curandStateMtgp32 *state, int size, T *result, ARG1, ARG2) 
   int idx = blockIdx.x * BLOCK_SIZE + threadIdx.x;                                   \
   int rounded_size = THCCeilDiv(size, BLOCK_SIZE) * BLOCK_SIZE;                      \
   for (int i = idx; i < rounded_size; i += BLOCK_SIZE * MAX_NUM_BLOCKS) {            \
-    CURAND_T x = CURAND_FUNC(&state[blockIdx.x]);                                    \
+/*  CURAND_T x = CURAND_FUNC(&state[blockIdx.x]);  */                                \
+    CURAND_T x = (CURAND_T) 0.0;                                                     \
     if (i < size) {                                                                  \
       T y = TRANSFORM;                                                               \
       result[i] = y;                                                                 \
@@ -149,24 +153,24 @@ struct is_same { static const bool value = false; };
 template<typename T>
 struct is_same<T, T> { static const bool value = true; };
 
-template<typename real, typename prob_type>
-__global__ void generate_bernoulli_tensor(curandStateMtgp32 *state, int size,
-        real *result, prob_type *probs)
-{
-  int idx = blockIdx.x * BLOCK_SIZE + threadIdx.x;
-  int rounded_size = THCCeilDiv(size, BLOCK_SIZE) * BLOCK_SIZE;
-  for (int i = idx; i < rounded_size; i += BLOCK_SIZE * MAX_NUM_BLOCKS) {
-    if (is_same<prob_type, double>::value) {
-      double x = curand_uniform_double(&state[blockIdx.x]);
-      if (i < size)
-        result[i] = ScalarConvert<bool, real>::to(x <= probs[i]);
-    } else {
-      float x = curand_uniform(&state[blockIdx.x]);
-      if (i < size)
-        result[i] = ScalarConvert<bool, real>::to(x <= probs[i]);
-    }
-  }
-}
+//template<typename real, typename prob_type>
+//__global__ void generate_bernoulli_tensor(curandStateMtgp32 *state, int size,
+//        real *result, prob_type *probs)
+//{
+//  int idx = blockIdx.x * BLOCK_SIZE + threadIdx.x;
+//  int rounded_size = THCCeilDiv(size, BLOCK_SIZE) * BLOCK_SIZE;
+//  for (int i = idx; i < rounded_size; i += BLOCK_SIZE * MAX_NUM_BLOCKS) {
+//    if (is_same<prob_type, double>::value) {
+//      double x = curand_uniform_double(&state[blockIdx.x]);
+//      if (i < size)
+//        result[i] = ScalarConvert<bool, real>::to(x <= probs[i]);
+//    } else {
+//      float x = curand_uniform(&state[blockIdx.x]);
+//      if (i < size)
+//        result[i] = ScalarConvert<bool, real>::to(x <= probs[i]);
+//    }
+//  }
+//}
 
 // NOTE: curand_uniform is (0, 1] and we want [a, b)
 GENERATE_KERNEL2(generate_uniform, float, float a, float b, float, curand_uniform, reverse_bounds(x) * (b-a) + a)

--- a/aten/src/THC/generic/THCTensorRandom.cu
+++ b/aten/src/THC/generic/THCTensorRandom.cu
@@ -15,8 +15,8 @@ THC_API void THCTensor_(uniform)(THCState* state, THCTensor *self_, double a, do
   THCTensor *self = THCTensor_(newContiguous)(state, self_);
   real *data = THCTensor_(data)(state, self);
 
-  generate_uniform<<<NUM_BLOCKS, BLOCK_SIZE, 0, THCState_getCurrentStream(state)>>>(
-      gen->state.gen_states, size, data, a, b);
+//  generate_uniform<<<NUM_BLOCKS, BLOCK_SIZE, 0, THCState_getCurrentStream(state)>>>(
+//      gen->state.gen_states, size, data, a, b);
 
   THCTensor_(freeCopyTo)(state, self, self_);
 };
@@ -30,8 +30,8 @@ THC_API void THCTensor_(normal)(THCState* state, THCTensor *self_, double mean, 
   THCTensor *self = THCTensor_(newContiguous)(state, self_);
   real *data = THCTensor_(data)(state, self);
 
-  generate_normal<<<NUM_BLOCKS, BLOCK_SIZE, 0, THCState_getCurrentStream(state)>>>(
-      gen->state.gen_states, size, data, mean, stdv);
+//  generate_normal<<<NUM_BLOCKS, BLOCK_SIZE, 0, THCState_getCurrentStream(state)>>>(
+//      gen->state.gen_states, size, data, mean, stdv);
 
   THCTensor_(freeCopyTo)(state, self, self_);
 };
@@ -69,8 +69,8 @@ THC_API void THCTensor_(logNormal)(THCState* state, THCTensor *self_, double mea
   THCTensor *self = THCTensor_(newContiguous)(state, self_);
   real *data = THCTensor_(data)(state, self);
 
-  generateLogNormal<real><<<NUM_BLOCKS, BLOCK_SIZE, 0, THCState_getCurrentStream(state)>>>(
-      gen->state.gen_states, size, data, mean, stdv);
+//  generateLogNormal<real><<<NUM_BLOCKS, BLOCK_SIZE, 0, THCState_getCurrentStream(state)>>>(
+//      gen->state.gen_states, size, data, mean, stdv);
 
   THCTensor_(freeCopyTo)(state, self, self_);
 };
@@ -85,8 +85,8 @@ THC_API void THCTensor_(exponential)(THCState* state, THCTensor *self_, double l
   THCTensor *self = THCTensor_(newContiguous)(state, self_);
   real *data = THCTensor_(data)(state, self);
 
-  generate_exponential<<<NUM_BLOCKS, BLOCK_SIZE, 0, THCState_getCurrentStream(state)>>>(
-      gen->state.gen_states, size, data, lambda);
+//  generate_exponential<<<NUM_BLOCKS, BLOCK_SIZE, 0, THCState_getCurrentStream(state)>>>(
+//      gen->state.gen_states, size, data, lambda);
 
   THCTensor_(freeCopyTo)(state, self, self_);
 };
@@ -101,8 +101,8 @@ THC_API void THCTensor_(cauchy)(THCState* state, THCTensor *self_, double median
   THCTensor *self = THCTensor_(newContiguous)(state, self_);
   real *data = THCTensor_(data)(state, self);
 
-  generate_cauchy<<<NUM_BLOCKS, BLOCK_SIZE, 0, THCState_getCurrentStream(state)>>>(
-      gen->state.gen_states, size, data, median, sigma);
+//  generate_cauchy<<<NUM_BLOCKS, BLOCK_SIZE, 0, THCState_getCurrentStream(state)>>>(
+//      gen->state.gen_states, size, data, median, sigma);
 
   THCTensor_(freeCopyTo)(state, self, self_);
 };
@@ -240,13 +240,13 @@ THC_API void THCTensor_(multinomial)(struct THCState *state,
       // distribution concurrently.
       dim3 grid(numDist < MAX_NUM_BLOCKS ? numDist : MAX_NUM_BLOCKS);
 
-      sampleMultinomialWithReplacement
-        <<<grid, block, 0, THCState_getCurrentStream(state)>>>(
-          gen->state.gen_states,
-          n_sample,
-          THCudaLongTensor_data(state, self),
-          numDist, numCategories,
-          THCTensor_(data)(state, prefixSum));
+//      sampleMultinomialWithReplacement
+//        <<<grid, block, 0, THCState_getCurrentStream(state)>>>(
+//          gen->state.gen_states,
+//          n_sample,
+//          THCudaLongTensor_data(state, self),
+//          numDist, numCategories,
+//          THCTensor_(data)(state, prefixSum));
     } else {
       // Sample without replacement
 
@@ -273,15 +273,15 @@ THC_API void THCTensor_(multinomial)(struct THCState *state,
 
         // The kernel can only draw one sample before we have to
         // recalculate our distribution
-        sampleMultinomialWithoutReplacement
-          <<<grid, block, 0, THCState_getCurrentStream(state)>>>(
-            gen->state.gen_states,
-            n_sample,
-            sample,
-            THCudaLongTensor_data(state, self),
-            numDist, numCategories,
-            THCTensor_(data)(state, origDist),
-            THCTensor_(data)(state, prefixSum));
+//        sampleMultinomialWithoutReplacement
+//          <<<grid, block, 0, THCState_getCurrentStream(state)>>>(
+//            gen->state.gen_states,
+//            n_sample,
+//            sample,
+//            THCudaLongTensor_data(state, self),
+//            numDist, numCategories,
+//            THCTensor_(data)(state, origDist),
+//            THCTensor_(data)(state, prefixSum));
       }
     }
 
@@ -397,8 +397,8 @@ THC_API void THCTensor_(bernoulli)(THCState* state, THCTensor *self_, double p)
   THCTensor *self = THCTensor_(newContiguous)(state, self_);
   real *data = THCTensor_(data)(state, self);
 
-  generate_bernoulli<<<NUM_BLOCKS, BLOCK_SIZE, 0, THCState_getCurrentStream(state)>>>(
-      gen->state.gen_states, size, data, p);
+//  generate_bernoulli<<<NUM_BLOCKS, BLOCK_SIZE, 0, THCState_getCurrentStream(state)>>>(
+//      gen->state.gen_states, size, data, p);
 
   THCTensor_(freeCopyTo)(state, self, self_);
 };
@@ -428,8 +428,8 @@ THC_API void THCTensor_(NAME)(THCState* state,                                 \
                                                                                \
   THArgCheck(size == prob_size, 3, "inconsistent tensor size");                \
                                                                                \
-  generate_bernoulli_tensor<<<NUM_BLOCKS, BLOCK_SIZE, 0, THCState_getCurrentStream(state)>>>( \
-      gen->state.gen_states, size, result_data, probs_data);                         \
+/*  generate_bernoulli_tensor<<<NUM_BLOCKS, BLOCK_SIZE, 0, THCState_getCurrentStream(state)>>>( */ \
+/*      gen->state.gen_states, size, result_data, probs_data); */                        \
                                                                                \
   PROB_TYPE##_free(state, probs);                                              \
   THCTensor_(freeCopyTo)(state, self, self_);                                  \
@@ -468,8 +468,8 @@ THC_API void THCTensor_(geometric)(THCState* state, THCTensor *self_, double p)
   THCTensor *self = THCTensor_(newContiguous)(state, self_);
   real *data = THCTensor_(data)(state, self);
 
-  generate_geometric<<<NUM_BLOCKS, BLOCK_SIZE, 0, THCState_getCurrentStream(state)>>>(
-      gen->state.gen_states, size, data, p);
+//  generate_geometric<<<NUM_BLOCKS, BLOCK_SIZE, 0, THCState_getCurrentStream(state)>>>(
+//      gen->state.gen_states, size, data, p);
 
   THCTensor_(freeCopyTo)(state, self, self_);
 };
@@ -489,12 +489,12 @@ THC_API void THCTensor_(clampedRandom)(THCState* state, THCTensor *self_, int64_
 
 #if defined(THC_REAL_IS_LONG) || defined(THC_REAL_IS_DOUBLE) || defined(THC_REAL_IS_FLOAT)
   if (range > 1ULL << 32) {
-    generate_random_64<<<NUM_BLOCKS, BLOCK_SIZE, 0, THCState_getCurrentStream(state)>>>(
-        gen->state.gen_states, size, data, min_val, range);
+//    generate_random_64<<<NUM_BLOCKS, BLOCK_SIZE, 0, THCState_getCurrentStream(state)>>>(
+//        gen->state.gen_states, size, data, min_val, range);
   } else {
 #endif
-    generate_random<<<NUM_BLOCKS, BLOCK_SIZE, 0, THCState_getCurrentStream(state)>>>(
-        gen->state.gen_states, size, data, min_val, range);
+//    generate_random<<<NUM_BLOCKS, BLOCK_SIZE, 0, THCState_getCurrentStream(state)>>>(
+//        gen->state.gen_states, size, data, min_val, range);
 #if defined(THC_REAL_IS_LONG) || defined(THC_REAL_IS_DOUBLE) || defined(THC_REAL_IS_FLOAT)
   }
 #endif
@@ -519,20 +519,20 @@ THC_API void THCTensor_(random)(THCState* state, THCTensor *self_)
   real *data = THCTensor_(data)(state, self);
 
 #if defined(THC_REAL_IS_HALF)
-  generate_random<<<NUM_BLOCKS, BLOCK_SIZE, 0, THCState_getCurrentStream(state)>>>(
-      gen->state.gen_states, size, data, 0UL, (1UL << HLF_MANT_DIG) + 1);
+//  generate_random<<<NUM_BLOCKS, BLOCK_SIZE, 0, THCState_getCurrentStream(state)>>>(
+//      gen->state.gen_states, size, data, 0UL, (1UL << HLF_MANT_DIG) + 1);
 #elif defined(THC_REAL_IS_FLOAT)
-  generate_random<<<NUM_BLOCKS, BLOCK_SIZE, 0, THCState_getCurrentStream(state)>>>(
-      gen->state.gen_states, size, data, 0UL, (1UL << FLT_MANT_DIG) + 1);
+//  generate_random<<<NUM_BLOCKS, BLOCK_SIZE, 0, THCState_getCurrentStream(state)>>>(
+//      gen->state.gen_states, size, data, 0UL, (1UL << FLT_MANT_DIG) + 1);
 #elif defined(THC_REAL_IS_DOUBLE)
-  generate_random_64<<<NUM_BLOCKS, BLOCK_SIZE, 0, THCState_getCurrentStream(state)>>>(
-      gen->state.gen_states, size, data, 0ULL, (1ULL << DBL_MANT_DIG) + 1);
+//  generate_random_64<<<NUM_BLOCKS, BLOCK_SIZE, 0, THCState_getCurrentStream(state)>>>(
+//      gen->state.gen_states, size, data, 0ULL, (1ULL << DBL_MANT_DIG) + 1);
 #elif defined(THC_REAL_IS_LONG)
-  generate_random_64<<<NUM_BLOCKS, BLOCK_SIZE, 0, THCState_getCurrentStream(state)>>>(
-      gen->state.gen_states, size, data, 0ULL, static_cast<uint64_t>(std::numeric_limits<real>::max()) + 1);
+//  generate_random_64<<<NUM_BLOCKS, BLOCK_SIZE, 0, THCState_getCurrentStream(state)>>>(
+//      gen->state.gen_states, size, data, 0ULL, static_cast<uint64_t>(std::numeric_limits<real>::max()) + 1);
 #else
-  generate_random<<<NUM_BLOCKS, BLOCK_SIZE, 0, THCState_getCurrentStream(state)>>>(
-      gen->state.gen_states, size, data, 0UL, static_cast<uint32_t>(std::numeric_limits<real>::max()) + 1);
+//  generate_random<<<NUM_BLOCKS, BLOCK_SIZE, 0, THCState_getCurrentStream(state)>>>(
+//      gen->state.gen_states, size, data, 0UL, static_cast<uint32_t>(std::numeric_limits<real>::max()) + 1);
 #endif
 
   THCTensor_(freeCopyTo)(state, self, self_);

--- a/aten/src/THCS/THCSparse.cu
+++ b/aten/src/THCS/THCSparse.cu
@@ -11,15 +11,17 @@ void THCudaSparse_Xcoo2csr(THCState *state, const int *coorowind, int64_t nnz, i
   ));
 }
 
-cusparseOperation_t convertTransToCusparseOperation(char trans) {
-  if (trans == 't') return CUSPARSE_OPERATION_TRANSPOSE;
-  else if (trans == 'n') return CUSPARSE_OPERATION_NON_TRANSPOSE;
-  else if (trans == 'c') return CUSPARSE_OPERATION_CONJUGATE_TRANSPOSE;
-  else {
-    THError("trans must be one of: t, n, c");
-    return CUSPARSE_OPERATION_TRANSPOSE;
-  }
-}
+/*
+//cusparseOperation_t convertTransToCusparseOperation(char trans) {
+//  if (trans == 't') return CUSPARSE_OPERATION_TRANSPOSE;
+//  else if (trans == 'n') return CUSPARSE_OPERATION_NON_TRANSPOSE;
+//  else if (trans == 'c') return CUSPARSE_OPERATION_CONJUGATE_TRANSPOSE;
+//  else {
+//    THError("trans must be one of: t, n, c");
+//    return CUSPARSE_OPERATION_TRANSPOSE;
+//  }
+//}
+*/
 
 void adjustLd(char transb, int64_t m, int64_t n, int64_t k, int64_t *ldb, int64_t *ldc)
 {

--- a/aten/src/THCUNN/RReLU.cu
+++ b/aten/src/THCUNN/RReLU.cu
@@ -3,54 +3,54 @@
 #include "THCHalfAutoNumerics.cuh"
 #include <THC/THCApply.cuh>
 #include "common.h"
-#include <curand.h>
-#include <curand_kernel.h>
+//#include <curand.h>
+//#include <curand_kernel.h>
 
 // copied from cutorch/lib/THC/THCTensorRandom.cu
 #define MAX_NUM_BLOCKS 64
 #define BLOCK_SIZE 256
 #define NUM_BLOCKS(n) min((int)THCCeilDiv(n, (ptrdiff_t) BLOCK_SIZE), MAX_NUM_BLOCKS)
 
-template<typename T>
-inline T __device__ curand_uniform_type(curandStateMtgp32 *state);
-
-#ifdef CUDA_HALF_TENSOR
-template <>
-inline half __device__ curand_uniform_type<half>(curandStateMtgp32 *state) {
-  return ScalarConvert<float, half>::to(curand_uniform(state));
-}
-#endif
-
-template <>
-inline float __device__ curand_uniform_type<float>(curandStateMtgp32 *state) {
-  return curand_uniform(state);
-}
-
-template <>
-inline double __device__ curand_uniform_type<double>(curandStateMtgp32 *state) {
-  return curand_uniform_double(state);
-}
-
-template <typename T>
-__global__ void rreluUpdateOutputTrain(int n, curandStateMtgp32 *state,
-  T *input, T* noise, T *output, double a, double b)
-{
-  CUDA_KERNEL_LOOP(i, n)
-  {
-    if (input[i] <= 0)
-    {
-      T r = curand_uniform_type<T>(&state[blockIdx.x]);
-      r = ScalarConvert<double, T>::to(r * (b-a) + a);
-      output[i] = input[i] * r;
-      noise[i] = r;
-    }
-    else
-    {
-      output[i] = input[i];
-      noise[i] = ScalarConvert<int, T>::to(1);
-    }
-  }
-}
+//template<typename T>
+//inline T __device__ curand_uniform_type(curandStateMtgp32 *state);
+//
+//#ifdef CUDA_HALF_TENSOR
+//template <>
+//inline half __device__ curand_uniform_type<half>(curandStateMtgp32 *state) {
+//  return ScalarConvert<float, half>::to(curand_uniform(state));
+//}
+//#endif
+//
+//template <>
+//inline float __device__ curand_uniform_type<float>(curandStateMtgp32 *state) {
+//  return curand_uniform(state);
+//}
+//
+//template <>
+//inline double __device__ curand_uniform_type<double>(curandStateMtgp32 *state) {
+//  return curand_uniform_double(state);
+//}
+//
+//template <typename T>
+//__global__ void rreluUpdateOutputTrain(int n, curandStateMtgp32 *state,
+//  T *input, T* noise, T *output, double a, double b)
+//{
+//  CUDA_KERNEL_LOOP(i, n)
+//  {
+//    if (input[i] <= 0)
+//    {
+//      T r = curand_uniform_type<T>(&state[blockIdx.x]);
+//      r = ScalarConvert<double, T>::to(r * (b-a) + a);
+//      output[i] = input[i] * r;
+//      noise[i] = r;
+//    }
+//    else
+//    {
+//      output[i] = input[i];
+//      noise[i] = ScalarConvert<int, T>::to(1);
+//    }
+//  }
+//}
 
 template <typename T>
 struct RReLUUpdateOutputEval_functor

--- a/aten/src/THCUNN/SparseLinear.cu
+++ b/aten/src/THCUNN/SparseLinear.cu
@@ -3,17 +3,17 @@
 #include "THCHalfAutoNumerics.cuh"
 #include "THCTensor.hpp"
 
-#include <cusparse.h>
+//#include <cusparse.h>
 
-static cusparseHandle_t cusparse_handle = 0;
+//static cusparseHandle_t cusparse_handle = 0;
 
 static void init_cusparse() {
-  if (cusparse_handle == 0) {
-    cusparseStatus_t status = cusparseCreate(&cusparse_handle);
-    if (status != CUSPARSE_STATUS_SUCCESS) {
-      THError("CUSPARSE Library initialization failed");
-    }
-  }
+//  if (cusparse_handle == 0) {
+//    cusparseStatus_t status = cusparseCreate(&cusparse_handle);
+//    if (status != CUSPARSE_STATUS_SUCCESS) {
+//      THError("CUSPARSE Library initialization failed");
+//    }
+//  }
 }
 
 #ifdef CUDA_HALF_TENSOR

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -496,8 +496,8 @@ endif()
 if(USE_ROCM AND NOT BUILD_CAFFE2)
  include_directories(SYSTEM ${HIP_PATH}/include)
  include_directories(SYSTEM ${HIPBLAS_PATH}/include)
- include_directories(SYSTEM ${HIPSPARSE_PATH}/include)
- include_directories(SYSTEM ${HIPRNG_PATH}/include)
+# include_directories(SYSTEM ${HIPSPARSE_PATH}/include)
+# include_directories(SYSTEM ${HIPRNG_PATH}/include)
  include_directories(SYSTEM ${THRUST_PATH})
 
  # load HIP cmake module and load platform id

--- a/cmake/public/LoadHIP.cmake
+++ b/cmake/public/LoadHIP.cmake
@@ -46,18 +46,18 @@ ELSE()
 ENDIF()
 
 # HIPRNG_PATH
-IF(NOT DEFINED ENV{HIPRNG_PATH})
-  SET(HIPRNG_PATH ${ROCM_PATH}/hcrng)
-ELSE()
-  SET(HIPRNG_PATH $ENV{HIPRNG_PATH})
-ENDIF()
+#IF(NOT DEFINED ENV{HIPRNG_PATH})
+#  SET(HIPRNG_PATH ${ROCM_PATH}/hcrng)
+#ELSE()
+#  SET(HIPRNG_PATH $ENV{HIPRNG_PATH})
+#ENDIF()
 
 # HIPSPARSE_PATH
-IF(NOT DEFINED ENV{HIPSPARSE_PATH})
-  SET(HIPSPARSE_PATH ${ROCM_PATH}/hcsparse)
-ELSE()
-  SET(HIPSPARSE_PATH $ENV{HIPSPARSE_PATH})
-ENDIF()
+#IF(NOT DEFINED ENV{HIPSPARSE_PATH})
+#  SET(HIPSPARSE_PATH ${ROCM_PATH}/hcsparse)
+#ELSE()
+#  SET(HIPSPARSE_PATH $ENV{HIPSPARSE_PATH})
+#ENDIF()
 
 # THRUST_PATH
 IF(DEFINED ENV{THRUST_PATH})
@@ -114,7 +114,7 @@ IF(HIP_FOUND)
   set(rocblas_DIR ${ROCBLAS_PATH}/lib/cmake/rocblas)
   set(miopen_DIR ${MIOPEN_PATH}/lib/cmake/miopen)
   set(hipblas_DIR ${HIPBLAS_PATH}/lib/cmake/hipblas)
-  set(hipsparse_DIR ${HIPSPARSE_PATH}/lib/cmake/hipsparse)
+  #set(hipsparse_DIR ${HIPSPARSE_PATH}/lib/cmake/hipsparse)
 
   find_package(rocrand REQUIRED)
   find_package(hiprand REQUIRED)
@@ -132,9 +132,9 @@ IF(HIP_FOUND)
   # however currently it's just the lib name
   FIND_LIBRARY(PYTORCH_MIOPEN_LIBRARIES ${miopen_LIBRARIES} HINTS ${MIOPEN_PATH}/lib)
   FIND_LIBRARY(hiprand_LIBRARIES hiprand HINTS ${HIPRAND_PATH}/lib)
-  FIND_LIBRARY(hiprng_LIBRARIES hcrng HINTS ${HIPRNG_PATH}/lib)
+#  FIND_LIBRARY(hiprng_LIBRARIES hcrng HINTS ${HIPRNG_PATH}/lib)
   FIND_LIBRARY(hipblas_LIBRARIES hipblas HINTS ${HIPBLAS_PATH}/lib)
-  FIND_LIBRARY(hipsparse_LIBRARIES hipsparse HINTS ${HIPSPARSE_PATH}/lib)
+#  FIND_LIBRARY(hipsparse_LIBRARIES hipsparse HINTS ${HIPSPARSE_PATH}/lib)
 
 
   # Necessary includes for building PyTorch since we include HIP headers that depend on hcc/hsa headers.

--- a/setup.py
+++ b/setup.py
@@ -896,13 +896,13 @@ if USE_ROCM:
     rocm_include_path = '/opt/rocm/include'
     hcc_include_path = '/opt/rocm/hcc/include'
     hipblas_include_path = '/opt/rocm/hipblas/include'
-    hipsparse_include_path = '/opt/rocm/hcsparse/include'
+    #hipsparse_include_path = '/opt/rocm/hcsparse/include'
     hip_lib_path = '/opt/rocm/hip/lib'
     hcc_lib_path = '/opt/rocm/hcc/lib'
     include_dirs.append(rocm_include_path)
     include_dirs.append(hcc_include_path)
     include_dirs.append(hipblas_include_path)
-    include_dirs.append(hipsparse_include_path)
+    #include_dirs.append(hipsparse_include_path)
     include_dirs.append(tmp_install_path + "/include/THCUNN")
     extra_link_args.append('-L' + hip_lib_path)
     extra_link_args.append('-Wl,-rpath,' + hip_lib_path)

--- a/tools/amd_build/build_pytorch_amd.py
+++ b/tools/amd_build/build_pytorch_amd.py
@@ -50,7 +50,7 @@ for root, _directories, files in os.walk(os.path.join(proj_dir, "torch")):
             if reduce(lambda result, exclude: source.endswith(exclude) or result, ignore_files, False):
                 continue
             # Update contents.
-            with open(source, "r+") as f:
+            with open(source, "r+", encoding="utf-8") as f:
                 contents = f.read()
                 contents = contents.replace("USE_CUDA", "USE_ROCM")
                 contents = contents.replace("CUDA_VERSION", "0")

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -118,7 +118,7 @@ PyObject * THCPModule_getRNGState(PyObject *_unused)
   using namespace torch::autograd;
   HANDLE_TH_ERRORS
   auto tensor = VariableType::getType(CPU(kByte))->tensor();
-  THCRandom_getRNGState(state, (THByteTensor*)tensor.unsafeGetTH(false));
+//  THCRandom_getRNGState(state, (THByteTensor*)tensor.unsafeGetTH(false));
   return THPVariable_Wrap(tensor);
   END_HANDLE_TH_ERRORS
 }
@@ -131,7 +131,7 @@ PyObject * THCPModule_setRNGState(PyObject *_unused, PyObject *obj)
         Py_TYPE(obj)->tp_name);
   }
   auto& tensor = THPVariable_UnpackData(obj);
-  THCRandom_setRNGState(state, (THByteTensor*)tensor.unsafeGetTH(false));
+//  THCRandom_setRNGState(state, (THByteTensor*)tensor.unsafeGetTH(false));
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
 }


### PR DESCRIPTION
 Commented out any references to hcrng and hcsparse. Also commented out references to std::max/std::log/std::exp functions in Embedding.cu and SoftMax.cu to get rid of linking errors.

