### PR TITLE
Document constants and mappings.

### DIFF
--- a/tools/amd_build/pyHIPIFY/constants.py
+++ b/tools/amd_build/pyHIPIFY/constants.py
@@ -1,3 +1,11 @@
+""" Constants for annotations in the mapping.
+The constants defined here are used to annotate the mapping tuples in cuda_to_hip_mappings.py.
+They are based on
+https://github.com/ROCm-Developer-Tools/HIP/blob/master/hipify-clang/src/Statistics.h
+and fall in three categories: 1) type of mapping, 2) API of mapping, 3) unsupported
+mapping.
+"""
+
 CONV_VERSION = 0,
 CONV_INIT = 1
 CONV_DEVICE = 2

--- a/tools/amd_build/pyHIPIFY/cuda_to_hip_mappings.py
+++ b/tools/amd_build/pyHIPIFY/cuda_to_hip_mappings.py
@@ -1,5 +1,17 @@
 from constants import *
 
+""" Mapping of CUDA functions, include files, constants, and types to ROCm/HIP equivalents
+
+This closely follows the implementation in hipify-clang
+https://github.com/ROCm-Developer-Tools/HIP/blob/master/hipify-clang/src/CUDA2HipMap.cpp
+and its structure.
+There are different maps for fundamental names, include files, identifies, sparse, and
+PyTorch specific translations.
+Each of the entries in these maps translates a CUDA string to a tuple containing the
+ROCm/HIP string, a type and API annotation and - optionally - an annotation if it is not
+supported in ROCm/HIP yet.
+"""
+
 CUDA_TYPE_NAME_MAP = {
     "CUresult": ("hipError_t", CONV_TYPE, API_DRIVER),
     "cudaError_t": ("hipError_t", CONV_TYPE, API_RUNTIME),


### PR DESCRIPTION
Highlight that these originated from hipify-clang.

