### PR TITLE
Hardcode getNumGPUs() to 1 for ROCm builds …

### DIFF
--- a/tools/amd_build/disabled_features.yaml
+++ b/tools/amd_build/disabled_features.yaml
@@ -117,6 +117,22 @@
         "s_constants": {
             "RoiPooling2d_backward_kernel<<<": "RoiPooling2d_backward_kernel<float><<<"
         }
+      },
+      {
+        "path": "aten/src/ATen/CUDAStream.cpp",
+        "s_constants": {
+            # FIXME: ROCm currently does not support multi-GPU setup; and getNumGPUs runs into a seg fault
+            # ROCm Pytorch issue: https://github.com/ROCmSoftwarePlatform/pytorch/issues/31
+            "getCUDAHooks().getNumGPUs()": "1",
+        }
+      },
+      {
+        "path": "aten/src/ATen/Context.h",
+        "s_constants": {
+            # FIXME: ROCm currently does not support multi-GPU setup; and getNumGPUs runs into a seg fault
+            # ROCm Pytorch issue: https://github.com/ROCmSoftwarePlatform/pytorch/issues/31
+            "detail::getCUDAHooks().getNumGPUs()": "1",
+        }
       }
     ],
   "disabled_modules": [


### PR DESCRIPTION
… since it currently doesn't work for multi-GPU setup anyway, and gives a seg fault on call to getNumGPUs()

