### PR TITLE
Correctly set up sscache inside of the Caffe2 Docker Images.

### DIFF
--- a/.jenkins/caffe2/build.sh
+++ b/.jenkins/caffe2/build.sh
@@ -7,57 +7,7 @@ INSTALL_PREFIX="/usr/local/caffe2"
 LOCAL_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 ROOT_DIR=$(cd "$LOCAL_DIR"/../.. && pwd)
 CMAKE_ARGS=()
-
-
-# Setup SCCACHE
-###############################################################################
-# Setup sccache if SCCACHE_BUCKET is set
-if [ -n "${SCCACHE_BUCKET}" ]; then
-  mkdir -p ./sccache
-
-  SCCACHE="$(which sccache)"
-  if [ -z "${SCCACHE}" ]; then
-    echo "Unable to find sccache..."
-    exit 1
-  fi
-
-  # Setup wrapper scripts
-  for compiler in cc c++ gcc g++ x86_64-linux-gnu-gcc; do
-    (
-      echo "#!/bin/sh"
-      echo "exec $SCCACHE $(which $compiler) \"\$@\""
-    ) > "./sccache/$compiler"
-    chmod +x "./sccache/$compiler"
-  done
-
-  if [[ "${BUILD_ENVIRONMENT}" == *-cuda* ]]; then
-    (
-      echo "#!/bin/sh"
-      echo "exec $SCCACHE $(which nvcc) \"\$@\""
-    ) > "./sccache/nvcc"
-    chmod +x "./sccache/nvcc"
-  fi
-
-  export CACHE_WRAPPER_DIR="$PWD/sccache"
-
-  # CMake must find these wrapper scripts
-  export PATH="$CACHE_WRAPPER_DIR:$PATH"
-fi
-
-# Setup ccache if configured to use it (and not sccache)
-if [ -z "${SCCACHE}" ] && which ccache > /dev/null; then
-  mkdir -p ./ccache
-  ln -sf "$(which ccache)" ./ccache/cc
-  ln -sf "$(which ccache)" ./ccache/c++
-  ln -sf "$(which ccache)" ./ccache/gcc
-  ln -sf "$(which ccache)" ./ccache/g++
-  ln -sf "$(which ccache)" ./ccache/x86_64-linux-gnu-gcc
-  if [[ "${BUILD_ENVIRONMENT}" == *-cuda* ]]; then
-    ln -sf "$(which ccache)" ./ccache/nvcc
-  fi
-  export CACHE_WRAPPER_DIR="$PWD/ccache"
-  export PATH="$CACHE_WRAPPER_DIR:$PATH"
-fi
+SCCACHE="$(which sccache)"
 
 report_compile_cache_stats() {
   if [[ -n "${SCCACHE}" ]]; then

--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -30,15 +30,6 @@ cmake --version
 pip install -r requirements.txt || true
 
 if [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
-  # PyTorch ROCm is based off a Caffe2 dockerfile. In the Caffe2 Dockerfile, the symlinks,
-  # are not set for sccache (they're set in ./.jenkins/caffe2/build.sh)
-  # Set the symlinks here for ROCm builds.
-  for compiler in ("cc" "c++" "gcc" "g++" "clang" "clang++" "hcc")
-  do
-    printf "#!/bin/sh\nexec sccache $(which $compiler) \$*" > "/opt/cache/bin/$compiler"
-    chmod a+x "/opt/cache/bin/$compiler"
-  done
-
   # This is necessary in order to cross compile (or else we'll have missing GPU device).
   export HCC_AMDGPU_TARGET=gfx900
 

--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -30,6 +30,15 @@ cmake --version
 pip install -r requirements.txt || true
 
 if [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
+  # PyTorch ROCm is based off a Caffe2 dockerfile. In the Caffe2 Dockerfile, the symlinks,
+  # are not set for sccache (they're set in ./.jenkins/caffe2/build.sh)
+  # Set the symlinks here for ROCm builds.
+  for compiler in ("cc" "c++" "gcc" "g++" "clang" "clang++" "hcc")
+  do
+    printf "#!/bin/sh\nexec sccache $(which $compiler) \$*" > "/opt/cache/bin/$compiler"
+    chmod a+x "/opt/cache/bin/$compiler"
+  done
+
   # This is necessary in order to cross compile (or else we'll have missing GPU device).
   export HCC_AMDGPU_TARGET=gfx900
 

--- a/docker/caffe2/jenkins/common/install_ccache.sh
+++ b/docker/caffe2/jenkins/common/install_ccache.sh
@@ -18,3 +18,40 @@ popd
 # Install sccache from pre-compiled binary.
 curl https://s3.amazonaws.com/ossci-linux/sccache -o /usr/local/bin/sccache
 chmod a+x /usr/local/bin/sccache
+
+# Setup SCCACHE
+###############################################################################
+mkdir -p ./sccache
+
+SCCACHE="$(which sccache)"
+if [ -z "${SCCACHE}" ]; then
+  echo "Unable to find sccache..."
+  exit 1
+fi
+
+# List of compilers to use sccache on.
+declare -a compilers=("cc" "c++" "gcc" "g++" "x86_64-linux-gnu-gcc")
+
+# If cuda build, add nvcc to sccache.
+if [[ "${BUILD_ENVIRONMENT}" == *-cuda* ]]; then
+  compilers+=("nvcc")
+fi
+
+# If rocm build, add hcc to sccache.
+if [[ "${BUILD_ENVIRONMENT}" == *-rocm* ]]; then
+  compilers+=("hcc")
+fi
+
+# Setup wrapper scripts
+for compiler in "${compilers[@]}"; do
+  (
+    echo "#!/bin/sh"
+    echo "exec $SCCACHE $(which $compiler) \"\$@\""
+  ) > "./sccache/$compiler"
+  chmod +x "./sccache/$compiler"
+done
+
+export CACHE_WRAPPER_DIR="$PWD/sccache"
+
+# CMake must find these wrapper scripts
+export PATH="$CACHE_WRAPPER_DIR:$PATH"


### PR DESCRIPTION
This PR effectively enables the usage of sccache for PyTorch ROCm builds.

Because the PyTorch ROCm builds are created using the Caffe2 ROCm DockerFiles, I've decided to modify the Caffe2 CI process such that sccache is prepared immediately once the docker image is created.  

I've also added support for HCC to sccache here: 
https://github.com/Jorghi12/sccache/tree/hcc_pr