### PR TITLE
ROCM: Escape RPATH when linking with hipcc

### DIFF
--- a/tools/build_pytorch_libs.sh
+++ b/tools/build_pytorch_libs.sh
@@ -97,7 +97,11 @@ if [[ $(uname) == 'Darwin' ]]; then
     LDFLAGS="$LDFLAGS -Wl,-rpath,@loader_path"
     LD_POSTFIX=".dylib"
 else
-    LDFLAGS="$LDFLAGS -Wl,-rpath,\$ORIGIN"
+    if [[ $USE_ROCM -eq 1 ]]; then
+        LDFLAGS="$LDFLAGS -Wl,-rpath,\\\\\\\$ORIGIN"
+    else
+        LDFLAGS="$LDFLAGS -Wl,-rpath,\$ORIGIN"
+    fi
 fi
 CPP_FLAGS=" -std=c++11 "
 GLOO_FLAGS=""


### PR DESCRIPTION
The hipcc linker_helper is stripping $ORIGIN from the RPATH.
RPATH must be set as intended or some symbols will not be found at runtime.