### PR TITLE
Specify character encoding when opening source files

### DIFF
--- a/tools/amd_build/build_pytorch_amd.py
+++ b/tools/amd_build/build_pytorch_amd.py
@@ -28,7 +28,7 @@ for root, _, files in os.walk(os.path.join(proj_dir, "aten/src/ATen")):
             filepath = os.path.join(root, filename)
 
             # Add the include header!
-            with open(filepath, "r+") as f:
+            with open(filepath, "r+", encoding='utf-8') as f:
                 txt = f.read()
                 result = '#include "hip/hip_runtime.h"\n%s' % txt
                 f.seek(0)
@@ -50,7 +50,7 @@ for root, _directories, files in os.walk(os.path.join(proj_dir, "torch")):
             if reduce(lambda result, exclude: source.endswith(exclude) or result, ignore_files, False):
                 continue
             # Update contents.
-            with open(source, "r+") as f:
+            with open(source, "r+", encoding='utf-8') as f:
                 contents = f.read()
                 contents = contents.replace("USE_CUDA", "USE_ROCM")
                 contents = contents.replace("CUDA_VERSION", "0")

--- a/tools/amd_build/pyHIPIFY/hipify-python.py
+++ b/tools/amd_build/pyHIPIFY/hipify-python.py
@@ -48,9 +48,9 @@ CAFFE2_TEMPLATE_MAP = {}
 
 def openf(filename, mode):
     if sys.version_info[0] == 3:
-        return open(filename, mode, errors='ignore')
+        return open(filename, mode, errors='ignore', encoding='utf-8')
     else:
-        return open(filename, mode)
+        return open(filename, mode, encoding='utf-8')
 
 
 # Color coding for printing
@@ -715,14 +715,14 @@ def is_caffe2_gpu_file(filepath):
 def preprocessor(filepath, stats, hipify_caffe2):
     """ Executes the CUDA -> HIP conversion on the specified file. """
     fin_path = filepath
-    with open(fin_path, 'r') as fin:
+    with open(fin_path, 'r', encoding='utf-8') as fin:
         output_source = fin.read()
 
     fout_path = get_hip_file_path(filepath, hipify_caffe2)
     if not os.path.exists(os.path.dirname(fout_path)):
         os.makedirs(os.path.dirname(fout_path))
 
-    with open(fout_path, 'w') as fout:
+    with open(fout_path, 'w', encoding='utf-8') as fout:
         # Perform type, method, constant replacements
         for mapping in CUDA_TO_HIP_MAPPINGS:
             for cuda_type, value in mapping.items():


### PR DESCRIPTION
Pytorch source files contain unicode characters.  When locale is not set, e.g. LANG=C, the hipify scripts fail with non-decodable characters.