### PR TITLE
Add 'extern "C"' to getRNGState/setRNGState function definitions …

### DIFF
--- a/tools/amd_build/disabled_features.yaml
+++ b/tools/amd_build/disabled_features.yaml
@@ -78,7 +78,9 @@
       {
         "path": "aten/src/THC/THCTensorRandom.cu",
         "s_constants": {
-          "struct curandStateMtgp32*": "curandStateMtgp32*"
+          "struct curandStateMtgp32*": "curandStateMtgp32*",
+          "__host__ void THCRandom_getRNGState": "extern \"C\" __host__ void THCRandom_getRNGState",
+          "__host__ void THCRandom_setRNGState": "extern \"C\" __host__ void THCRandom_setRNGState",
         }
       },
       {


### PR DESCRIPTION
…so that hcc outputs demangled symbols

