### PR TITLE
Small fixes

### DIFF
--- a/aten/src/THC/THCNumerics.cuh
+++ b/aten/src/THC/THCNumerics.cuh
@@ -663,7 +663,7 @@ struct THCNumerics<double> {
   static inline __host__ __device__  double tanh (double a) { return  ::tanh(a); }
   static inline __host__ __device__  double erf  (double a) { return   ::erf(a); }
   static inline __host__ __device__  double erfc (double a) { return  ::erfc(a); }
-  static inline __host__ __device__  double abs  (double a) { return   ::abs(a); }
+  static inline __host__ __device__  double abs  (double a) { return   fabs(a); }
   static inline __host__ __device__  double round(double a) { return ::round(a); }
   static inline __host__ __device__  double frac (double a) { return a - ::trunc(a); }
   static inline __host__ __device__  double cinv (double a) { return 1.0 / a; }

--- a/tools/amd_build/disabled_features.yaml
+++ b/tools/amd_build/disabled_features.yaml
@@ -51,12 +51,6 @@
         }
       },
       {
-        "path": "aten/src/ATen/native/cuda/Distributions.cu",
-        "s_constants": {
-          "#include <nvfunctional>": ""
-        }
-      },
-      {
         "path": "aten/src/THC/THCNumerics.cuh",
         "s_constants": {
           "#ifdef __CUDA_ARCH__": "#if defined(__CUDA_ARCH__) || defined(__HIP_PLATFORM_HCC__)",


### PR DESCRIPTION
* remove a duplicate entry from disabled_features
* fix a long-time warning by doing the right thing (TM) according to C++11 and using fabs() for the double absolute function as opposed to the integer only (and nvcc it seems) abs() function