### PR TITLE
ROCm 1.8.2 correctly handles asserts.

### DIFF
--- a/tools/amd_build/pyHIPIFY/hipify-python.py
+++ b/tools/amd_build/pyHIPIFY/hipify-python.py
@@ -760,8 +760,8 @@ def preprocessor(filepath, stats, hipify_caffe2):
         output_source = processKernelLaunches(output_source, stats)
 
         # Disable asserts
-        if not filepath.endswith("THCGeneral.h.in"):
-            output_source = disable_asserts(output_source)
+        # if not filepath.endswith("THCGeneral.h.in"):
+        #    output_source = disable_asserts(output_source)
 
         # Replace std:: with non-std:: versions
         output_source = replace_math_functions(output_source)


### PR DESCRIPTION
Assert disabling logic isn't necessary at the moment. Ideally, should be kept to maintain correctness at runtime during assertion executions. Keeping the definition for disable_asserts in case this needs to be re-enabled in the future.

