### PR TITLE
First step to rocSPARSE: install

### DIFF
--- a/docker/caffe2/jenkins/common/install_rocm.sh
+++ b/docker/caffe2/jenkins/common/install_rocm.sh
@@ -63,6 +63,15 @@ install_rocrand() {
     dpkg -i /opt/rocm/debians/rocrand.deb
 }
 
+# Install rocSPARSE/hipSPARSE that will be released soon - can co-exist w/ hcSPARSE which will be removed soon
+install_hipsparse() {
+    mkdir -p /opt/rocm/debians
+    curl https://s3.amazonaws.com/ossci-linux/rocsparse-0.1.1.0.deb -o /opt/rocm/debians/rocsparse.deb
+    curl https://s3.amazonaws.com/ossci-linux/hipsparse-0.1.1.0.deb -o /opt/rocm/debians/hipsparse.deb
+    dpkg -i /opt/rocm/debians/rocsparse.deb
+    dpkg -i /opt/rocm/debians/hipsparse.deb
+}
+
 # Install Python packages depending on the base OS
 if [ -f /etc/lsb-release ]; then
   install_ubuntu
@@ -76,3 +85,4 @@ fi
 install_hip_thrust
 install_rocrand
 install_hcsparse
+install_hipsparse


### PR DESCRIPTION
This installs rocSPARSE and hipSPARSE in the docker file - it seems to be able to co-exist w/ hcSPARSE in my tests. Once the docker files are updated, we will do the conversion and remove hcSPARSE.