### PR TITLE
global pooling fix

### DIFF
--- a/caffe2/operators/hip/pool_op_miopen.cc
+++ b/caffe2/operators/hip/pool_op_miopen.cc
@@ -208,6 +208,10 @@ class MIOPENPoolGradientOp : public ConvPoolOpBase<HIPContext> {
     W_out = Y.ndim() > 3 ? Y.dim32(3) : 1;
     D_out = Y.ndim() > 4 ? Y.dim32(4) : 1;
 
+    if(global_pooling_){
+      kernel_ = {H, W};
+    }
+    
     CAFFE_ENFORCE(kernel_.size() == 2, "MIOpen supports only 2D pooling");
     MIOPEN_ENFORCE(miopenSet2dPoolingDescriptor(
         pooling_desc_,


### PR DESCRIPTION
This fixes global pooling test failure. This is needed because when kernel size is not passed explicitly, the kernel size would be zero if not set. 

@petrex @ashishfarmer please review.