### PR TITLE
Fix warning about ::abs

### DIFF
--- a/aten/src/THC/THCNumerics.cuh
+++ b/aten/src/THC/THCNumerics.cuh
@@ -297,7 +297,7 @@ struct THCNumerics<half> {
   }
 
   static inline __host__ __device__ half abs(half a) {
-    return static_cast<at::Half>(::abs(static_cast<at::Half>(a)));
+    return static_cast<at::Half>(std::abs(static_cast<at::Half>(a)));
   }
 
   static inline __host__ __device__ half round(half a) {


### PR DESCRIPTION
replace ::abs with std::abs to avoid warnings about integer version of abs function is called for
__half.

