### PR TITLE
Fix caffe2/CMakeLists.txt for hip-clang

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -375,7 +375,7 @@ if(USE_ROCM)
   hip_add_library(caffe2_hip ${Caffe2_HIP_SRCS})
 
   # Since PyTorch files contain HIP headers, these flags are required for the necessary definitions to be added.
-  set_target_properties(caffe2_hip PROPERTIES COMPILE_FLAGS ${HIP_HIPCC_FLAGS})
+  set_target_properties(caffe2_hip PROPERTIES COMPILE_FLAGS "${HIP_HIPCC_FLAGS}")
   target_link_libraries(caffe2_hip PUBLIC caffe2)
   target_link_libraries(caffe2_hip PUBLIC ${Caffe2_HIP_DEPENDENCY_LIBS})
 


### PR DESCRIPTION
Without this change, there is cmake error about invalid number of arguments for set_target_properties

