### PR TITLE
Disable in-place sorting on ROCm.

### DIFF
--- a/aten/src/THC/generic/THCTensorSort.cu
+++ b/aten/src/THC/generic/THCTensorSort.cu
@@ -309,7 +309,12 @@ void THCTensor_(sort)(THCState* state,
   int maxSliceSize = 2048;
 #endif
 
+#ifdef __HIP_PLATFORM_HCC__
+  // TODO bitonicSortKVInPlace hangs on ROCm currently.
+  if (0) {
+#else
   if (sliceSize <= maxSliceSize) {
+#endif
     // Fill `indices` (the values) with the
     // slice-relative index.
     THCudaLongTensor_fillSliceWithIndex(state, indices, dim);

--- a/aten/src/THC/generic/THCTensorTopK.cu
+++ b/aten/src/THC/generic/THCTensorTopK.cu
@@ -140,7 +140,12 @@ void THCTensor_(topk)(THCState* state,
   if (sorted) {
     // FIXME: the k/v inplace sort along slice only works for size <=
     // 2048 at the moment
+#ifdef __HIP_PLATFORM_HCC__
+    // TODO bitonicSortKVInPlace hangs on ROCm currently.
+    if (0) {
+#else
     if (sliceSize <= 2048) {
+#endif
       // This avoids any memory allocations and performs all sorting
       // work inplace along the slice
       THCTensor_(sortKeyValueInplace)(state, topK, indices, dim, dir);

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6572,6 +6572,7 @@ class TestTorch(TestCase):
             self.assertEqual([(0, 1, 3, 0)], [z.shape for z in torch.split(x, 0, dim=0)])
 
     # functions that operate over a dimension but don't reduce.
+    @skipIfRocm
     def test_dim_function_empty(self):
         devices = ['cpu'] if not torch.cuda.is_available() else ['cpu', 'cuda']
         for device in devices:


### PR DESCRIPTION
It is known to hang - use the Thrust fallback

