### PR TITLE
Revert "Fix device function decls (#192)"

### DIFF
--- a/caffe2/utils/conversions.h
+++ b/caffe2/utils/conversions.h
@@ -11,7 +11,7 @@
 #include <caffe2/core/hip/common_hip.h>
 #endif
 
-#if defined(__CUDA_ARCH__) || defined(__HIP__)
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
 #define CONVERSIONS_DECL __host__ __device__ inline
 #else
 #define CONVERSIONS_DECL inline

--- a/caffe2/utils/fixed_divisor.h
+++ b/caffe2/utils/fixed_divisor.h
@@ -7,7 +7,7 @@
 #include <cstdio>
 #include <cstdlib>
 
-#if defined(__CUDA_ARCH__) || defined(__HIP__)
+#if defined(__CUDA_ARCH__) || defined(__HIP_ARCH__)
 #define FIXED_DIVISOR_DECL inline __host__ __device__
 #else
 #define FIXED_DIVISOR_DECL inline

--- a/caffe2/utils/math_utils.h
+++ b/caffe2/utils/math_utils.h
@@ -3,7 +3,7 @@
 
 #include "caffe2/core/common.h"
 
-#if defined(__CUDA_ARCH__) || defined(__HIP__)
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
 #define MATH_UTILS_DECL inline __host__ __device__
 #else
 #define MATH_UTILS_DECL inline


### PR DESCRIPTION
This reverts commit 0207b3fd902e8c71c55b7037c2861961ba3831a8.

@jithunnair-amd located this as the culprit for our woes.

@yxsamliu can you comment why we may not have `__HIP__` defined in the "old" setup?

