### PR TITLE
Fix maxdim check.

### DIFF
--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -126,7 +126,7 @@ auto ConvParams::use_miopen(const at::Tensor& input) const -> bool {
   return ((input.type().scalarType() == at::kFloat) || (input.type().scalarType() == at::kHalf))
          && detail::getCUDAHooks().compiledWithMIOpen()
          && input.type().is_cuda()
-         && input.dim() > MIOPEN_DIM_MAX
+         && input.dim() <= MIOPEN_DIM_MAX
          && MIOPEN_ENABLED
          ;
 }

--- a/aten/src/ATen/native/Normalization.cpp
+++ b/aten/src/ATen/native/Normalization.cpp
@@ -70,7 +70,7 @@ Tensor batch_norm(
   }
 
   bool use_miopen = (input.type().is_cuda()
-               && input.dim() < MIOPEN_DIM_MAX
+               && input.dim() <= MIOPEN_DIM_MAX
                && input.type().scalarType() != at::kDouble
                && (input.type().scalarType() == weight.type().scalarType())
                && weight.defined() && bias.defined()


### PR DESCRIPTION
The previous maxdim check prevented MIOpen from running on over dimensioned tensors... or anything else.  This is a better.