### PR TITLE
MIOpen: Fix dilation descriptor, Use contiguous buffers, Disable grou…

### DIFF
--- a/aten/src/ATen/miopen/Descriptors.h
+++ b/aten/src/ATen/miopen/Descriptors.h
@@ -124,7 +124,7 @@ struct ConvolutionDescriptor
   void set(miopenDataType_t dataType, int dim, int* pad, int* stride, int * upscale /* aka dilation */, int groups) {
     miopenDataType_t mathType = dataType;
     if (dataType == miopenHalf) mathType = miopenFloat;
-    MIOPEN_CHECK(miopenInitConvolutionDescriptor(mut_desc(), miopenConvolution, *pad, *pad, *stride, *stride, 1, 1));
+    MIOPEN_CHECK(miopenInitConvolutionDescriptor(mut_desc(), miopenConvolution, *pad, *pad, *stride, *stride, *upscale, *upscale));
     MIOPEN_CHECK(miopenSetConvolutionGroupCount(mut_desc(), groups));
   }
 };

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -127,6 +127,7 @@ auto ConvParams::use_miopen(const at::Tensor& input) const -> bool {
          && detail::getCUDAHooks().compiledWithMIOpen()
          && input.type().is_cuda()
          && input.dim() <= MIOPEN_DIM_MAX
+         && (is_dilated() && groups != 1) == false  // dilated group convolutions not supported
          && MIOPEN_ENABLED
          ;
 }

--- a/aten/src/ATen/native/Normalization.cpp
+++ b/aten/src/ATen/native/Normalization.cpp
@@ -82,8 +82,10 @@ Tensor batch_norm(
 
   if (use_miopen) {
     return std::get<0>(at::miopen_batch_norm(
-                        input, weight, bias,
-                        running_mean, running_var,
+                        input.contiguous(), weight.contiguous(),
+                        bias.contiguous(),
+                        running_mean.defined() ? running_mean.contiguous() : running_mean,
+                        running_var.defined() ? running_var.contiguous() : running_var,
                         training, momentum, eps));
   }
 


### PR DESCRIPTION
Fixed up the convolution descriptors to support dilatation.
Fallback from MIOpen to general kernels for dilated group convolutions.
Ensure buffers passed to MIOpen are contiguous. 

