### PR TITLE
Include <iostream> in common_hip.cc for fixing build failure for hip-…

### DIFF
--- a/caffe2/core/hip/common_hip.cc
+++ b/caffe2/core/hip/common_hip.cc
@@ -4,6 +4,7 @@
 #include <atomic>
 #include <cstdlib>
 #include <sstream>
+#include <iostream>
 
 #include "caffe2/core/init.h"
 #include "caffe2/core/logging.h"


### PR DESCRIPTION
…clang

