### PR TITLE
Fix default ctor of WelfordData for hip-clang

### DIFF
--- a/aten/src/THC/THCTensorMathReduce.cuh
+++ b/aten/src/THC/THCTensorMathReduce.cuh
@@ -27,9 +27,6 @@ struct WelfordData {
   int count_; // do we need int64_t?
 
   __host__ __device__ WelfordData() {
-    mean_ = T(0);
-    m_2_n_ = T(0);
-    count_ = 0;
   }
 
   __host__ __device__ WelfordData(const U data_) {


### PR DESCRIPTION
WelfordData is used as __shared__ array, which cannot be initialized. cuda-clang and hip-clang
do not allow default ctor of __shared__ variable to initialize data members.

