### PR TITLE
remove dynamic initialization warning (#13913) (#13967)

### DIFF
--- a/aten/src/THC/THCTensorMathReduce.cuh
+++ b/aten/src/THC/THCTensorMathReduce.cuh
@@ -27,6 +27,12 @@ struct WelfordData {
   int count_; // do we need int64_t?
 
   __host__ __device__ WelfordData() {
+  }
+
+  // stripping initialization from default constructor to avoid dynamic
+  // initialization warning thrown from using this data structure in CUDA kernel
+  // as static shared memory.
+  __host__ __device__ void reset() {
     mean_ = T(0);
     m_2_n_ = T(0);
     count_ = 0;

--- a/aten/src/THC/generic/THCTensorMathReduce.cu
+++ b/aten/src/THC/generic/THCTensorMathReduce.cu
@@ -89,11 +89,13 @@ void THCTensor_(std)(THCState *state, THCTensor *self_, THCTensor *src, int dime
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, self_, src));
 
+  WelfordData<accreal, scalar_t> init;
+  init.reset();
   if (!THC_reduceDim<scalar_t>(state, self_, src,
                            ModifyWelford<WelfordData<accreal, scalar_t>>{},
                            ReduceWelford<accreal, scalar_t>{},
                            VarianceWelford<accreal, scalar_t>{biased, true},
-                           WelfordData<accreal, scalar_t>{},
+                           init,
                            dimension,
                            keepdim)) {
     THArgCheck(false, 2, CUTORCH_DIM_WARNING);
@@ -106,11 +108,13 @@ void THCTensor_(var)(THCState *state, THCTensor *self_, THCTensor *src, int dime
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, self_, src));
 
+  WelfordData<accreal, scalar_t> init;
+  init.reset();
   if (!THC_reduceDim<scalar_t>(state, self_, src,
                            ModifyWelford<WelfordData<accreal, scalar_t>>{},
                            ReduceWelford<accreal, scalar_t>{},
                            VarianceWelford<accreal, scalar_t>{biased, false},
-                           WelfordData<accreal, scalar_t>{},
+                           init,
                            dimension,
                            keepdim)) {
     THArgCheck(false, 2, CUTORCH_DIM_WARNING);


### PR DESCRIPTION
This is a cherrypick from pytorch master branch. It is needed for hip-clang.

Summary:
removed assignment in default constructor.
removed static shared memory and used dynamic shared memory.
Pull Request resolved: https://github.com/pytorch/pytorch/pull/13967

Differential Revision: D13089996

Pulled By: soumith

fbshipit-source-id: 2a218b909c849bed39636b45a02d10ebc279a0b0

