### PR TITLE
Re-disabling flaky tests for ROCm

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1341,6 +1341,7 @@ class TestJit(JitTestCase):
         self.assertExpectedGraph(ge.graph)
 
     @skipIfNoTorchVision
+    @skipIfRocm
     def test_alexnet(self):
         x = torch.ones(1, 3, 224, 224)
         trace, _ = torch.jit.get_trace_graph(torchvision.models.AlexNet(), x)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3858,6 +3858,7 @@ class TestNN(NNTestCase):
 
     @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
     @unittest.skipIf(not TEST_CUDNN, 'CUDNN not available')
+    @skipIfRocm
     def test_cudnn_multiple_threads_same_device(self):
         # This function is intended to test the lazy creation and reuse of per-thread
         # cudnn handles on each device in aten/src/ATen/cudnn/Handles.cpp.


### PR DESCRIPTION
as it is flaky on CI

