### PR TITLE
[hipify] Add '--hip-clang-launch' to favor <<<>>>-based launch.

### DIFF
--- a/tools/amd_build/build_amd.py
+++ b/tools/amd_build/build_amd.py
@@ -29,6 +29,12 @@ parser.add_argument(
     help="The Directory to Store the Hipified Project",
     required=False)
 
+# Hipify using HIP-Clang launch.
+parser.add_argument(
+    '--hip-clang-launch',
+    action='store_true',
+    help=argparse.SUPPRESS)
+
 args = parser.parse_args()
 
 amd_build_dir = os.path.dirname(os.path.realpath(__file__))
@@ -126,4 +132,5 @@ hipify_python.hipify(
     includes=includes,
     ignores=ignores,
     out_of_place_only=args.out_of_place_only,
-    json_settings=json_settings)
+    json_settings=json_settings,
+    hip_clang_launch=args.hip_clang_launch)

--- a/tools/amd_build/pyHIPIFY/hipify_python.py
+++ b/tools/amd_build/pyHIPIFY/hipify_python.py
@@ -246,7 +246,8 @@ def preprocess(
         output_directory,
         all_files,
         show_detailed=False,
-        show_progress=True):
+        show_progress=True,
+        hip_clang_launch=False):
     """
     Call preprocessor on selected files.
 
@@ -258,7 +259,7 @@ def preprocess(
     stats = {"unsupported_calls": [], "kernel_launches": []}
 
     for filepath in all_files:
-        preprocessor(output_directory, filepath, stats)
+        preprocessor(output_directory, filepath, stats, hip_clang_launch)
         # Show what happened
         if show_progress:
             print(
@@ -877,7 +878,7 @@ RE_ANGLE_HEADER = re.compile(r'#include <([^>]+)>')
 RE_THC_GENERIC_FILE = re.compile(r'#define THC_GENERIC_FILE "([^"]+)"')
 RE_CU_SUFFIX = re.compile(r'\.cu\b')  # be careful not to pick up .cuh
 
-def preprocessor(output_directory, filepath, stats):
+def preprocessor(output_directory, filepath, stats, hip_clang_launch):
     """ Executes the CUDA -> HIP conversion on the specified file. """
     fin_path = os.path.join(output_directory, filepath)
     with open(fin_path, 'r') as fin:
@@ -917,7 +918,8 @@ def preprocessor(output_directory, filepath, stats):
             output_source = RE_CU_SUFFIX.sub('.hip', output_source)
 
         # Perform Kernel Launch Replacements
-        output_source = processKernelLaunches(output_source, stats)
+        if not hip_clang_launch:
+            output_source = processKernelLaunches(output_source, stats)
 
         # Disable asserts
         # if not filepath.endswith("THCGeneral.h.in"):
@@ -1086,6 +1088,7 @@ def hipify(
     out_of_place_only=False,
     ignores=(),
     show_progress=True,
+    hip_clang_launch=False,
 ):
     if project_directory == "":
         project_directory = os.getcwd()
@@ -1201,7 +1204,8 @@ def hipify(
         output_directory,
         all_files,
         show_detailed=show_detailed,
-        show_progress=show_progress)
+        show_progress=show_progress,
+        hip_clang_launch=hip_clang_launch)
 
     # copy rccl compat file to c10d
     rccl_compat_file = "rccl1_compat.h"


### PR DESCRIPTION
- With extra parentheses, hcc hits a bug. Although a fix is availble, it
  won't be available until next major release. For hip-clang, as
  hipKernelLaunchGGL is re-implemented using macro, that extra
  parenthese is mandatory for explicitly-instantiated template kernel
  function. As a temporary solution, add a new option
  '--hip-clang-launch' to skip transforming the <<<>>> launch to
  hipKernelLaunchGGL.

