### PR TITLE
Fix CentOS build script missing full version

### DIFF
--- a/docker/caffe2/jenkins/build.sh
+++ b/docker/caffe2/jenkins/build.sh
@@ -11,7 +11,7 @@ if [ -z "${image}" ]; then
 fi
 
 UBUNTU_VERSION="$(echo "${image}" | perl -n -e'/ubuntu(\d+\.\d+)/ && print $1')"
-CENTOS_VERSION="$(echo "${image}" | perl -n -e'/centos(\d+)/ && print $1')"
+CENTOS_VERSION="$(echo "${image}" | perl -n -e'/centos(\d+\.?\d*\.?\d*)/ && print $1')"
 
 if [ -n "${UBUNTU_VERSION}" ]; then
   OS="ubuntu"

--- a/docker/caffe2/jenkins/common/install_rocm.sh
+++ b/docker/caffe2/jenkins/common/install_rocm.sh
@@ -33,7 +33,6 @@ install_ubuntu() {
 
 install_centos() {
 
-  yum update -y
   yum install -y wget
   yum install -y openblas-devel
 


### PR DESCRIPTION
Using keyword centos7.5 will only capture the version as 7, rather than 7.5. This is causing an issue where CentOS 7.6 images are being created rather than 7.5 images.

