### PR TITLE
Fix missing  str to int conversion in the commit f71ddd42

### DIFF
--- a/torch/hub.py
+++ b/torch/hub.py
@@ -380,7 +380,7 @@ def _download_url_to_file(url, dst, hash_prefix, progress):
         response = requests.get(url, stream=True)
 
         content_length = response.headers['Content-Length']
-        file_size = content_length
+        file_size = int(content_length)
         u = response.raw
     else:
         u = urlopen(url)


### PR DESCRIPTION
The commit f71ddd42 has made a bunch of changes related to `http requests` which in turn is related to `downloading of data`, where for python2 and and python3, different ways are implemented, and implmentation for python2 is missing a required conversion from `str' to `int`.

This missing `str' to `int` convesrion is causing the testing of pytorch example -`fast_style` to fail in TC.