### PR TITLE
Enable BFloat16 for ops in THC by default

### DIFF
--- a/aten/src/ATen/preprocess_declarations.py
+++ b/aten/src/ATen/preprocess_declarations.py
@@ -76,11 +76,6 @@ def process_types_and_backends(option):
         if 'CPU' in backend_types:
             backend_types['CPU'].discard('BFloat16')
 
-    # special case remove BFloat16 for cuda unless it is explicitly enabled
-    if not option.get('cuda_bfloat16', False):
-        if 'CUDA' in backend_types:
-            backend_types['CUDA'].discard('BFloat16')
-
     # special cases remove bool for cpu and cuda unless it is explicitly enabled
     if not option.get('cpu_bool', False):
         if 'CPU' in backend_types:

--- a/aten/src/THC/CMakeLists.txt
+++ b/aten/src/THC/CMakeLists.txt
@@ -7,7 +7,7 @@ CONFIGURE_FILE(THCGeneral.h.in "${CMAKE_CURRENT_BINARY_DIR}/THCGeneral.h")
 
 set(extra_src)
 # loop over all types
-foreach(THC_TYPE Byte Char Short Int Long Half Float Double)
+foreach(THC_TYPE Byte Char Short Int Long Half Float Double BFloat16)
    # loop over files which need to be split between types (because of long compile times)
    foreach(THC_FILE TensorSort TensorMathCompareT TensorMathPointwise TensorMathCompare TensorMathReduce TensorMasked)
       if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/generated/THC${THC_FILE}${THC_TYPE}.cu")
@@ -24,14 +24,6 @@ foreach(THC_FILE TensorMathCompareT TensorMathCompare TensorMathReduce TensorMas
         "#include <THC/THC${THC_FILE}.cuh>\n#include <THC/THCTensor.hpp>\n\n#include <THC/generic/THC${THC_FILE}.cu>\n#include <THC/THCGenerateBoolType.h>\n")
    endif()
    LIST(APPEND extra_src "${CMAKE_CURRENT_SOURCE_DIR}/generated/THC${THC_FILE}Bool.cu")
-endforeach()
-
-foreach(THC_FILE TensorSort TensorMathReduce TensorMathCompareT TensorMathCompare TensorMathPointwise TensorMasked)
-   if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/generated/THC${THC_FILE}BFloat16.cu")
-      FILE(WRITE "${CMAKE_CURRENT_SOURCE_DIR}/generated/THC${THC_FILE}BFloat16.cu"
-        "#include <THC/THC${THC_FILE}.cuh>\n#include <THC/THCTensor.hpp>\n\n#include <THC/generic/THC${THC_FILE}.cu>\n#include <THC/THCGenerateBFloat16Type.h>\n")
-   endif()
-   LIST(APPEND extra_src "${CMAKE_CURRENT_SOURCE_DIR}/generated/THC${THC_FILE}BFloat16.cu")
 endforeach()
 
 set(ATen_CUDA_SRCS ${ATen_CUDA_SRCS}

--- a/aten/src/THC/generic/THCTensorMathPointwise.cu
+++ b/aten/src/THC/generic/THCTensorMathPointwise.cu
@@ -196,7 +196,7 @@ static void propagate_names_if_named_tensor_enabled(THCTensor* result, THCTensor
 #define IMPLEMENT_CUDA_TENSOR_BASIC_FUNC(NAME, CFUNC, REAL) \
   IMPLEMENT_CUDA_TENSOR_BASIC_FUNC_(NAME, CFUNC, REAL)
 
-#if defined(THC_REAL_IS_FLOAT) || defined(THC_REAL_IS_DOUBLE) || defined(THC_REAL_IS_HALF)
+#if defined(THC_REAL_IS_FLOAT) || defined(THC_REAL_IS_DOUBLE) || defined(THC_REAL_IS_HALF) || defined(THC_REAL_IS_BFLOAT16)
 
 IMPLEMENT_CUDA_TENSOR_BASIC_FUNC(log1p, THCNumerics<scalar_t>::log1p, Real)
 IMPLEMENT_CUDA_TENSOR_BASIC_FUNC(  exp, THCNumerics<scalar_t>::exp,   Real)

--- a/aten/src/THC/generic/THCTensorMathPointwise.h
+++ b/aten/src/THC/generic/THCTensorMathPointwise.h
@@ -13,7 +13,7 @@ THC_API void THCTensor_(cminValue)(THCState *state, THCTensor *self, THCTensor *
 
 #if !defined(THC_REAL_IS_BOOL)
 
-#if defined(THC_REAL_IS_FLOAT) || defined(THC_REAL_IS_DOUBLE) || defined(THC_REAL_IS_HALF)
+#if defined(THC_REAL_IS_FLOAT) || defined(THC_REAL_IS_DOUBLE) || defined(THC_REAL_IS_HALF) || defined(THC_REAL_IS_BFLOAT16)
 
 THC_API void THCTensor_(sigmoid)(THCState *state, THCTensor *self, THCTensor *src);
 THC_API void THCTensor_(log1p)(THCState *state, THCTensor *self, THCTensor *src);

--- a/aten/src/THC/generic/THCTensorMathScan.cu
+++ b/aten/src/THC/generic/THCTensorMathScan.cu
@@ -2,7 +2,7 @@
 #define THC_GENERIC_FILE "THC/generic/THCTensorMathScan.cu"
 #else
 
-#ifndef THC_REAL_IS_HALF
+#if !defined(THC_REAL_IS_HALF) || !defined(THC_REAL_IS_BFLOAT16)
 template<class BinaryFunction>
 __host__ void THCTensor_(scanThrust)(
     THCState *state,
@@ -88,7 +88,7 @@ void THCTensor_(scanDim)(THCState *state, THCTensor *self_, THCTensor *src,
   src = THCTensor_(newContiguous)(state, src);
 
   if (!self->is_empty()) {
-  #ifndef THC_REAL_IS_HALF
+  #if !defined(THC_REAL_IS_HALF) || !defined(THC_REAL_IS_BFLOAT16)
     if (ndim == 1) {
       // thrust does not take an "init"
       THCTensor_(scanThrust)(state, self, src, binary_op);

--- a/aten/src/THC/generic/THCTensorRandom.cu
+++ b/aten/src/THC/generic/THCTensorRandom.cu
@@ -7,7 +7,7 @@
 #include <ATen/Utils.h>
 #include <utility>
 
-#if defined(THC_REAL_IS_FLOAT) || defined(THC_REAL_IS_DOUBLE) || defined(THC_REAL_IS_HALF)
+#if defined(THC_REAL_IS_FLOAT) || defined(THC_REAL_IS_DOUBLE) || defined(THC_REAL_IS_HALF) || defined(THC_REAL_IS_BFLOAT16)
 
 void THCTensor_(multinomialAliasSetup)(THCState *state, THCTensor *_probs, THCudaLongTensor *_J, THCTensor *_q){
   THArgCheck(_probs->dim() == 1, 1,

--- a/aten/src/THC/generic/THCTensorRandom.h
+++ b/aten/src/THC/generic/THCTensorRandom.h
@@ -4,7 +4,7 @@
 
 #include "ATen/core/Generator.h"
 
-#if defined(THC_REAL_IS_FLOAT) || defined(THC_REAL_IS_DOUBLE) || defined(THC_REAL_IS_HALF)
+#if defined(THC_REAL_IS_FLOAT) || defined(THC_REAL_IS_DOUBLE) || defined(THC_REAL_IS_HALF) || defined(THC_REAL_IS_BFLOAT16)
 
 THC_API void THCTensor_(multinomialAliasSetup)(struct THCState *state, THCTensor *probs, THCudaLongTensor *J, THCTensor *q);
 THC_API void THCTensor_(multinomialAliasDraw)(THCState *state, THCudaLongTensor *self, THCTensor *_q, THCudaLongTensor *_J, int n_sample, at::Generator* gen_);

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -347,6 +347,13 @@ class Module(object):
         """
         return self._apply(lambda t: t.half() if t.is_floating_point() else t)
 
+    def bfloat16(self):
+        r"""Casts all floating point parameters and buffers to ``bfloat16`` datatype.
+        Returns:
+            Module: self
+        """
+        return self._apply(lambda t: t.bfloat16() if t.is_floating_point() else t)
+
     def to(self, *args, **kwargs):
         r"""Moves and/or casts the parameters and buffers.
 


### PR DESCRIPTION
This PR removes the check to discard bfloat16 for cuda and enables bfloat16 by default for ops in THC.