### PR TITLE
[don't merge] rocm only dispatch

### DIFF
--- a/aten/src/ATen/Dispatch.h
+++ b/aten/src/ATen/Dispatch.h
@@ -302,23 +302,12 @@ inline void deprecated_AT_DISPATCH_ALL_TYPES_AND_HALF_AND_COMPLEX() {}
   }()
 
 #ifdef __HIP_PLATFORM_HCC__
-#define AT_DISPATCH_ALL_TYPES_AND_ROCM_BFLOAT16_AND(SCALARTYPE, TYPE, NAME, ...)                             \
-[&] {                                                                                                        \
-  switch (TYPE) {                                                                                            \
-    AT_PRIVATE_CASE_TYPE(at::ScalarType::Byte, uint8_t, __VA_ARGS__)                                         \
-    AT_PRIVATE_CASE_TYPE(at::ScalarType::Char, int8_t, __VA_ARGS__)                                          \
-    AT_PRIVATE_CASE_TYPE(at::ScalarType::Double, double, __VA_ARGS__)                                        \
-    AT_PRIVATE_CASE_TYPE(at::ScalarType::Float, float, __VA_ARGS__)                                          \
-    AT_PRIVATE_CASE_TYPE(at::ScalarType::Int, int32_t, __VA_ARGS__)                                          \
-    AT_PRIVATE_CASE_TYPE(at::ScalarType::Long, int64_t, __VA_ARGS__)                                         \
-    AT_PRIVATE_CASE_TYPE(at::ScalarType::Short, int16_t, __VA_ARGS__)                                        \
-    AT_PRIVATE_CASE_TYPE(at::ScalarType::BFloat16, at::BFloat16, __VA_ARGS__)                                \
-    AT_PRIVATE_CASE_TYPE(SCALARTYPE, decltype(c10::impl::ScalarTypeToCPPType<SCALARTYPE>::t), __VA_ARGS__)   \
-    default:                                                                                                 \
-      AT_ERROR(#NAME, " not implemented for '", toString(TYPE), "'");                                        \
-  }                                                                                                          \
-}()
+#define BFLOAT16_DISPATCH(...)  AT_PRIVATE_CASE_TYPE(at::ScalarType::BFloat16, at::BFloat16, __VA_ARGS__)
 #else
+#define BFLOAT16_DISPATCH(...)
+#endif
+
+// this macro is used to dispatch bfloat16 only on ROCm
 #define AT_DISPATCH_ALL_TYPES_AND_ROCM_BFLOAT16_AND(SCALARTYPE, TYPE, NAME, ...)                             \
 [&] {                                                                                                        \
   switch (TYPE) {                                                                                            \
@@ -330,11 +319,11 @@ inline void deprecated_AT_DISPATCH_ALL_TYPES_AND_HALF_AND_COMPLEX() {}
     AT_PRIVATE_CASE_TYPE(at::ScalarType::Long, int64_t, __VA_ARGS__)                                         \
     AT_PRIVATE_CASE_TYPE(at::ScalarType::Short, int16_t, __VA_ARGS__)                                        \
     AT_PRIVATE_CASE_TYPE(SCALARTYPE, decltype(c10::impl::ScalarTypeToCPPType<SCALARTYPE>::t), __VA_ARGS__)   \
+    BFLOAT16_DISPATCH(__VA_ARGS__)                                                                                      \
     default:                                                                                                 \
       AT_ERROR(#NAME, " not implemented for '", toString(TYPE), "'");                                        \
   }                                                                                                          \
 }()
-#endif
 
 #define AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND(SCALARTYPE, TYPE, NAME, ...)                                     \
   [&] {                                                                                                        \

--- a/aten/src/ATen/Dispatch.h
+++ b/aten/src/ATen/Dispatch.h
@@ -301,6 +301,41 @@ inline void deprecated_AT_DISPATCH_ALL_TYPES_AND_HALF_AND_COMPLEX() {}
     }                                                                                                          \
   }()
 
+#ifdef __HIP_PLATFORM_HCC__
+#define AT_DISPATCH_ALL_TYPES_AND_ROCM_BFLOAT16_AND(SCALARTYPE, TYPE, NAME, ...)                             \
+[&] {                                                                                                        \
+  switch (TYPE) {                                                                                            \
+    AT_PRIVATE_CASE_TYPE(at::ScalarType::Byte, uint8_t, __VA_ARGS__)                                         \
+    AT_PRIVATE_CASE_TYPE(at::ScalarType::Char, int8_t, __VA_ARGS__)                                          \
+    AT_PRIVATE_CASE_TYPE(at::ScalarType::Double, double, __VA_ARGS__)                                        \
+    AT_PRIVATE_CASE_TYPE(at::ScalarType::Float, float, __VA_ARGS__)                                          \
+    AT_PRIVATE_CASE_TYPE(at::ScalarType::Int, int32_t, __VA_ARGS__)                                          \
+    AT_PRIVATE_CASE_TYPE(at::ScalarType::Long, int64_t, __VA_ARGS__)                                         \
+    AT_PRIVATE_CASE_TYPE(at::ScalarType::Short, int16_t, __VA_ARGS__)                                        \
+    AT_PRIVATE_CASE_TYPE(at::ScalarType::BFloat16, at::BFloat16, __VA_ARGS__)                                \
+    AT_PRIVATE_CASE_TYPE(SCALARTYPE, decltype(c10::impl::ScalarTypeToCPPType<SCALARTYPE>::t), __VA_ARGS__)   \
+    default:                                                                                                 \
+      AT_ERROR(#NAME, " not implemented for '", toString(TYPE), "'");                                        \
+  }                                                                                                          \
+}()
+#else
+#define AT_DISPATCH_ALL_TYPES_AND_ROCM_BFLOAT16_AND(SCALARTYPE, TYPE, NAME, ...)                             \
+[&] {                                                                                                        \
+  switch (TYPE) {                                                                                            \
+    AT_PRIVATE_CASE_TYPE(at::ScalarType::Byte, uint8_t, __VA_ARGS__)                                         \
+    AT_PRIVATE_CASE_TYPE(at::ScalarType::Char, int8_t, __VA_ARGS__)                                          \
+    AT_PRIVATE_CASE_TYPE(at::ScalarType::Double, double, __VA_ARGS__)                                        \
+    AT_PRIVATE_CASE_TYPE(at::ScalarType::Float, float, __VA_ARGS__)                                          \
+    AT_PRIVATE_CASE_TYPE(at::ScalarType::Int, int32_t, __VA_ARGS__)                                          \
+    AT_PRIVATE_CASE_TYPE(at::ScalarType::Long, int64_t, __VA_ARGS__)                                         \
+    AT_PRIVATE_CASE_TYPE(at::ScalarType::Short, int16_t, __VA_ARGS__)                                        \
+    AT_PRIVATE_CASE_TYPE(SCALARTYPE, decltype(c10::impl::ScalarTypeToCPPType<SCALARTYPE>::t), __VA_ARGS__)   \
+    default:                                                                                                 \
+      AT_ERROR(#NAME, " not implemented for '", toString(TYPE), "'");                                        \
+  }                                                                                                          \
+}()
+#endif
+
 #define AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND(SCALARTYPE, TYPE, NAME, ...)                                     \
   [&] {                                                                                                        \
     switch (TYPE) {                                                                                            \

--- a/aten/src/ATen/native/cuda/Activation.cu
+++ b/aten/src/ATen/native/cuda/Activation.cu
@@ -288,7 +288,7 @@ void threshold_kernel_impl(TensorIterator& iter, scalar_t threshold, scalar_t va
 }
 
 static void threshold_kernel(TensorIterator& iter, Scalar threshold, Scalar value) {
-  AT_DISPATCH_ALL_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, iter.dtype(), "threshold_cuda", [&] {
+  AT_DISPATCH_ALL_TYPES_AND_ROCM_BFLOAT16_AND(at::ScalarType::Half, iter.dtype(), "threshold_cuda", [&] {
     threshold_kernel_impl<scalar_t>(iter, threshold.to<scalar_t>(), value.to<scalar_t>());
   });
 }


### PR DESCRIPTION
Defines a new macro `AT_DISPATCH_ALL_TYPES_AND_ROCM_BFLOAT16_AND` which dispatches bfloat16 rocm but not cuda. This helps us to stop worrying about CUDA in upstream PRs. Please let me know if you think that there's a better way to compile bfloat16 kernels only on ROCm.