### PR TITLE
[don't merge] Cuda bfloat16 skip test

### DIFF
--- a/aten/src/ATen/Dispatch.h
+++ b/aten/src/ATen/Dispatch.h
@@ -20,6 +20,17 @@
     return __VA_ARGS__();                                               \
   }
 
+#if !defined(__HIP_PLATFORM_HCC__)
+#define AT_SKIP_BFLOAT16_IF_NOT_ROCM(SCALARTYPE, NAME, ...)                              \
+  if(std::is_same<SCALAR, at::BFloat16>::value){                                         \
+    AT_ERROR(#NAME, " not implemented for '", toString(at::ScalarType::BFloat16), "'");  \
+  } else {                                                                               \
+    __VA_ARGS__()                                                                        \
+  }
+#else
+#define AT_SKIP_BFLOAT16_IF_NOT_ROCM(SCALARTYPE, NAME, ...) __VA_ARGS__()
+#endif
+
 namespace detail {
 
 inline at::ScalarType scalar_type(at::ScalarType s) {

--- a/aten/src/ATen/Dispatch.h
+++ b/aten/src/ATen/Dispatch.h
@@ -22,7 +22,7 @@
 
 #if !defined(__HIP_PLATFORM_HCC__)
 #define AT_SKIP_BFLOAT16_IF_NOT_ROCM(SCALARTYPE, NAME, ...)                              \
-  if(std::is_same<SCALAR, at::BFloat16>::value){                                         \
+  if(std::is_same<SCALARTYPE, at::BFloat16>::value){                                         \
     AT_ERROR(#NAME, " not implemented for '", toString(at::ScalarType::BFloat16), "'");  \
   } else {                                                                               \
     __VA_ARGS__()                                                                        \


### PR DESCRIPTION
Introducing `AT_SKIP_BFLOAT16_IF_NOT_ROCM` macro to skip bfloat16 on cuda. I am enclosing the body of the lambda function in the dispatch macro in an other lambda function and passing the new lambda to `AT_SKIP_BFLOAT16_IF_NOT_ROCM` macro.