### PR TITLE
Fix for BF16 datatype

### DIFF
--- a/c10/util/BFloat16.h
+++ b/c10/util/BFloat16.h
@@ -47,14 +47,11 @@ namespace detail {
   inline C10_HOST_DEVICE uint16_t round_to_nearest_even(float src) {
 #ifdef __HIP_PLATFORM_HCC__
     if (src != src) {
-      return UINT16_C(0x7FC0);
-    }
 #else
     if (std::isnan(src)) {
-      return UINT16_C(0x7FC0);
-    }
 #endif
-    else {
+      return UINT16_C(0x7FC0);
+    } else {
       union {
         uint32_t U32;
         float F32;

--- a/c10/util/BFloat16.h
+++ b/c10/util/BFloat16.h
@@ -45,9 +45,16 @@ namespace detail {
   }
 
   inline C10_HOST_DEVICE uint16_t round_to_nearest_even(float src) {
+#ifdef __HIP_PLATFORM_HCC__
+    if (src != src) {
+      return 0x7FC0;
+    }
+#else
     if (std::isnan(src)) {
       return 0x7FC0;
-    } else {
+    }
+#endif
+    else {
       union {
         uint32_t U32;
         float F32;

--- a/c10/util/BFloat16.h
+++ b/c10/util/BFloat16.h
@@ -47,11 +47,11 @@ namespace detail {
   inline C10_HOST_DEVICE uint16_t round_to_nearest_even(float src) {
 #ifdef __HIP_PLATFORM_HCC__
     if (src != src) {
-      return 0x7FC0;
+      return UINT16_C(0x7FC0);
     }
 #else
     if (std::isnan(src)) {
-      return 0x7FC0;
+      return UINT16_C(0x7FC0);
     }
 #endif
     else {
@@ -61,7 +61,7 @@ namespace detail {
       };
 
       F32 = src;
-      uint32_t rounding_bias = ((U32 >> 16) & 1) + 0x7FFF;
+      uint32_t rounding_bias = ((U32 >> 16) & 1) + UINT32_C(0x7FFF);
       return static_cast<uint16_t>((U32 + rounding_bias) >> 16);
     }
   }


### PR DESCRIPTION
This PR fixes the BF16 datatype conversions by:
1. Avoiding use of std:: calls in device code
2. Explicitly using macros for const values with fixed width bitpattern