### PR TITLE
Revert "Load torch_global_deps for Windows (#35177)" (#35355)

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -79,11 +79,10 @@ if platform.system() == 'Windows':
 
 # See Note [Global dependencies]
 def _load_global_deps():
-    ext_dict = {'Darwin': '.dylib', 'Windows': '.dll'}
-    cur_platform = platform.system()
-    lib_name_prefix = '' if cur_platform == 'Windows' else 'lib'
-    lib_name_suffix = ext_dict.get(cur_platform, '.so')
-    lib_name = lib_name_prefix + 'torch_global_deps' + lib_name_suffix
+    if platform.system() == 'Windows':
+        return
+
+    lib_name = 'libtorch_global_deps' + ('.dylib' if platform.system() == 'Darwin' else '.so')
     here = os.path.abspath(__file__)
     lib_path = os.path.join(os.path.dirname(here), 'lib', lib_name)
 


### PR DESCRIPTION
Summary:
This reverts commit d7a7bcb0428273fa54a836b52e750608ebe7e4de.

The previous commit is not useful because torch_global_deps doesn't include any external dependencies.
Pull Request resolved: https://github.com/pytorch/pytorch/pull/35355

Differential Revision: D20653036

Pulled By: ezyang

fbshipit-source-id: 6d2e2f90952ca865b27b649a6ff9114ada8ea78c

