### PR TITLE
Introduce BFloat16 cast option to autocast

### DIFF
--- a/aten/src/ATen/autocast_mode.cpp
+++ b/aten/src/ATen/autocast_mode.cpp
@@ -436,7 +436,7 @@ auto register_out_of_place = c10::import()
   KERNEL(ADD_NS(bmm), "aten::bmm", Tensor (const Tensor &, const Tensor &), fp16)
   KERNEL_UNBOXED_ONLY(ADD_NS(chain_matmul), "aten::chain_matmul", Tensor (TensorList), fp16)
   //bfloat16
-   KERNEL_UNBOXED_ONLY2(ADD_NS(_convolution), "aten::_convolution", Tensor (const Tensor &, const Tensor &, const Tensor &, IntArrayRef, IntArrayRef, IntArrayRef, bool, IntArrayRef, int64_t, bool, bool, bool), bfp16)
+  KERNEL_UNBOXED_ONLY2(ADD_NS(_convolution), "aten::_convolution", Tensor (const Tensor &, const Tensor &, const Tensor &, IntArrayRef, IntArrayRef, IntArrayRef, bool, IntArrayRef, int64_t, bool, bool, bool), bfp16)
   KERNEL_UNBOXED_ONLY2(ADD_NS(_convolution_nogroup), "aten::_convolution_nogroup", Tensor (const Tensor &, const Tensor &, const Tensor &, IntArrayRef, IntArrayRef, IntArrayRef, bool, IntArrayRef), bfp16)
   KERNEL_UNBOXED_ONLY2(ADD_NS(conv1d), "aten::conv1d", Tensor (const Tensor &, const Tensor &, const Tensor &, IntArrayRef, IntArrayRef, IntArrayRef, int64_t), bfp16)
   KERNEL_UNBOXED_ONLY2(ADD_NS(conv2d), "aten::conv2d", Tensor (const Tensor &, const Tensor &, const Tensor &, IntArrayRef, IntArrayRef, IntArrayRef, int64_t), bfp16)

--- a/aten/src/ATen/autocast_mode.cpp
+++ b/aten/src/ATen/autocast_mode.cpp
@@ -23,7 +23,7 @@ void set_enabled(bool new_enabled, at::ScalarType low_precision_type) {
   } else if(low_precision_type == at::kBFloat16) {
     c10::impl::tls_set_dispatch_key_included(DispatchKey::AutocastTensorIdBFloat16, new_enabled);
   } else {
-    TORCH_CHECK(1, "unsupported low_precision_type passed to autocast");
+    TORCH_CHECK(false, "unsupported low_precision_type passed to autocast");
   }
 }
 

--- a/aten/src/ATen/autocast_mode.h
+++ b/aten/src/ATen/autocast_mode.h
@@ -4,7 +4,7 @@ namespace at {
 namespace autocast {
 
 TORCH_API bool is_enabled();
-TORCH_API void set_enabled(bool enabled, at::ScalarType use_fp16);
+TORCH_API void set_enabled(bool enabled, at::ScalarType low_precision_type);
 TORCH_API void clear_cache();
 TORCH_API int increment_nesting();
 TORCH_API int decrement_nesting();

--- a/aten/src/ATen/autocast_mode.h
+++ b/aten/src/ATen/autocast_mode.h
@@ -4,7 +4,7 @@ namespace at {
 namespace autocast {
 
 TORCH_API bool is_enabled();
-TORCH_API void set_enabled(bool enabled);
+TORCH_API void set_enabled(bool enabled, at::ScalarType use_fp16);
 TORCH_API void clear_cache();
 TORCH_API int increment_nesting();
 TORCH_API int decrement_nesting();

--- a/c10/core/DispatchKey.cpp
+++ b/c10/core/DispatchKey.cpp
@@ -40,8 +40,10 @@ const char* toString(DispatchKey t) {
       return "BackendSelect";
     case DispatchKey::TESTING_ONLY_GenericModeTensorId:
       return "TESTING_ONLY_GenericModeTensorId";
-    case DispatchKey::AutocastTensorId:
-      return "AutocastTensorId";
+    case DispatchKey::AutocastTensorIdFP16:
+      return "AutocastTensorIdFP16";
+    case DispatchKey::AutocastTensorIdBFloat16:
+      return "AutocastTensorIdBFloat16";
     case DispatchKey::TESTING_ONLY_GenericWrapperTensorId:
       return "TESTING_ONLY_GenericWrapperTensorId";
     default:

--- a/c10/core/DispatchKey.h
+++ b/c10/core/DispatchKey.h
@@ -129,8 +129,8 @@ enum class DispatchKey : uint8_t {
 
   // Autocasting precedes VariableTypeId, to ensure casts are autograd-exposed
   // and inputs are saved for backward in the post-autocast type.
-  AutocastTensorId,
-
+  AutocastTensorIdFP16,         // at::KHalf
+  AutocastTensorIdBFloat16,     // at::kBFloat16     
   // Here are some reserved pre-autograd keys for user-defined backends, see Note [Private use TensorId]
   PrivateUse1_PreAutogradTensorId,
   PrivateUse2_PreAutogradTensorId,

--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -7,6 +7,7 @@
 #include <torch/csrc/autograd/profiler.h>
 #include <torch/csrc/autograd/python_function.h>
 #include <torch/csrc/autograd/function.h>
+#include <torch/csrc/utils/python_arg_parser.h>
 
 PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject *unused) {
   using namespace torch::autograd::profiler;
@@ -62,12 +63,12 @@ PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject *unused) {
 
 namespace torch { namespace autograd {
 
-static PyObject * set_autocast_enabled(PyObject* _unused, PyObject *arg) {
+static PyObject * set_autocast_enabled(PyObject* _unused, PyObject *args, PyObject *kwargs) {
   HANDLE_TH_ERRORS
-  if (!PyBool_Check(arg)) {
-    throw TypeError("enabled must be a bool (got %s)", Py_TYPE(arg)->tp_name);
-  }
-  at::autocast::set_enabled(arg == Py_True);
+  static PythonArgParser parser({"set_autocast_enabled(bool enabled, ScalarType low_precision_type)"});
+  ParsedArgs<2> parsed_args;
+  auto r = parser.parse(args, kwargs, parsed_args);
+  at::autocast::set_enabled(r.toBool(0), r.scalartype(1));
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
 }
@@ -145,7 +146,7 @@ static PyObject * is_anomaly_mode_enabled(PyObject* _unused, PyObject *arg) {
 static PyMethodDef methods[] = {
   {"set_grad_enabled", (PyCFunction)set_grad_enabled, METH_O, nullptr},
   {"is_grad_enabled", (PyCFunction)is_grad_enabled, METH_NOARGS, nullptr},
-  {"set_autocast_enabled", (PyCFunction)set_autocast_enabled, METH_O, nullptr},
+  {"set_autocast_enabled", (PyCFunction)set_autocast_enabled, METH_VARARGS | METH_KEYWORDS , NULL},
   {"is_autocast_enabled", (PyCFunction)is_autocast_enabled, METH_NOARGS, nullptr},
   {"clear_autocast_cache", (PyCFunction)clear_autocast_cache, METH_NOARGS, nullptr},
   {"autocast_increment_nesting", (PyCFunction)autocast_increment_nesting, METH_NOARGS, nullptr},

--- a/torch/cuda/amp/autocast_mode.py
+++ b/torch/cuda/amp/autocast_mode.py
@@ -109,23 +109,25 @@ class autocast(object):
     Arguments:
         enabled(bool, optional, default=True):  Whether autocasting should be enabled in the region.
     """
-    def __init__(self, enabled=True):
+    def __init__(self, enabled=True, low_precision_type=torch.float16):
         if enabled and not torch.cuda.is_available():
             warnings.warn("torch.cuda.amp.autocast only affects CUDA ops, but CUDA is not available.  Disabling.")
             self._enabled = False
         else:
             self._enabled = enabled
+            #self._use_fp16 = use_fp16
+            self._low_precision_type = low_precision_type
 
     def __enter__(self):
         self.prev = torch.is_autocast_enabled()
-        torch.set_autocast_enabled(self._enabled)
+        torch.set_autocast_enabled(self._enabled, self._low_precision_type)
         torch.autocast_increment_nesting()
 
     def __exit__(self, *args):
         # Drop the cache when we exit to a nesting level that's outside any instance of autocast.
         if torch.autocast_decrement_nesting() == 0:
             torch.clear_autocast_cache()
-        torch.set_autocast_enabled(self.prev)
+        torch.set_autocast_enabled(self.prev, self._low_precision_type)
         return False
 
     def __call__(self, func):

--- a/torch/cuda/amp/autocast_mode.py
+++ b/torch/cuda/amp/autocast_mode.py
@@ -115,7 +115,6 @@ class autocast(object):
             self._enabled = False
         else:
             self._enabled = enabled
-            #self._use_fp16 = use_fp16
             self._low_precision_type = low_precision_type
 
     def __enter__(self):

--- a/torch/testing/_internal/autocast_test_lists.py
+++ b/torch/testing/_internal/autocast_test_lists.py
@@ -60,7 +60,7 @@ class AutocastTestLists(object):
         # The remaining lists organize ops that autocast treats explicitly.
 
         # tuple elements in the list:
-        # [op, op_args, autocast low preicision types, flag[=False] to skip the operator]
+        # (op, op_args, autocast low preicision types, flag[=False] to skip the operator)
         self.torch_fp16_and_bfp16 = [
             ("_convolution", conv_args_fp32[1] + bias_fp32 + ((1, 1), (0, 0), (1, 1), False,
                                                               (0, 0), 1, False, True, True), self._half_types),


### PR DESCRIPTION
Summary

- Introduces a new dispatch key `AutocastTensorIdBFloat16` and renames existing `AutocastTensorId` to `AutocastTensorIdFP16` (to make it explicit).

- Introduce a new cast policy `bfp16` in autocast that uses `AutocastTensorIdBFloat16`. There are other cast policies like `fp32_set_opt_dtype`, `fp32_append_dtype`, `promote` for which ops are registered with FP16 dispatch key. The ops with these cast policies are not registered with BFloat16 dispatch key in this PR since their behavior might differ with bfloat16 and needs more work in doing operator level analysis.

- Registers only gemm and convolution ops with BFloat16 dispatch key.

- Enabled skipped tests on ROCm and also refactored the tests to run with bfloat16 wherever required.

- Change to the python API, can now pass `low_precision_type[=torch.float16, torch.bfloat16]` as argument to run autocast with.
```
with torch.cuda.amp.autocast(low_precision_type = torch.bfloat16):
    output = model(input)
```
