### PR TITLE
enable HgemmBatched.

### DIFF
--- a/aten/src/THC/generic/THCTensorMathBlas.cu
+++ b/aten/src/THC/generic/THCTensorMathBlas.cu
@@ -727,7 +727,7 @@ void THCTensor_(baddbmm)(THCState *state, THCTensor *result, THCTensor *t,
 
 #elif defined(THC_REAL_IS_HALF)
 
-#if CUDA_VERSION < 9010
+#if CUDA_VERSION < 9010 and not defined __HIP_PLATFORM_HCC__
   // Currently no HgemmBatched in Cublas
   for (int64_t i = 0; i < num_batches; ++i) {
     THCudaBlas_Hgemm(


### PR DESCRIPTION
The purpose of this PR is to enable HgemmBatched. Because of the inconsistency between CUDA_VERSION and HIP_VERSION, resulting in THCudaBlas_HgemmStridedBatched() not to be called.