### PR TITLE
Use BLIS/libflame for the ROCm Ubuntu docker

### DIFF
--- a/docker/caffe2/jenkins/common/install_rocm_blis.sh
+++ b/docker/caffe2/jenkins/common/install_rocm_blis.sh
@@ -5,7 +5,26 @@ set -ex
 install_ubuntu() {
     apt-get update
     apt-get install -y wget
-    apt-get install -y libopenblas-dev
+    
+    # AMD's official BLAS library is BLIS (https://github.com/flame/blis) from UT Austin's FLAME group)
+    wget https://github.com/flame/blis/archive/0.7.0.tar.gz
+    tar xzf 0.7.0.tar.gz
+    pushd blis-0.7.0
+    ./configure --enable-blas --enable-shared --enable-static -t openmp x86_64
+    make -j
+    make install
+    popd
+
+    # we need an accompanying LAPACK
+    wget https://github.com/flame/libflame/archive/5.2.0.tar.gz
+    tar xzf 5.2.0.tar.gz
+    pushd libflame-5.2.0
+    ./configure --enable-dynamic-build --enable-lapack2flame --enable-max-arg-list-hack --enable-supermatrix \
+    --disable-ldim-alignment --enable-multithreading=openmp --disable-autodetect-f77-ldflags \
+    --disable-autodetect-f77-name-mangling
+    make -j
+    make install
+    popd
 
     # Need the libc++1 and libc++abi1 libraries to allow torch._C to load at runtime
     apt-get install -y libc++1
@@ -37,7 +56,26 @@ install_centos() {
 
   yum update -y
   yum install -y wget
-  yum install -y openblas-devel
+
+  # AMD's official BLAS library is BLIS (https://github.com/flame/blis) from UT Austin's FLAME group)
+  wget https://github.com/flame/blis/archive/0.7.0.tar.gz
+  tar xzf 0.7.0.tar.gz
+  pushd blis-0.7.0
+  ./configure --enable-blas --enable-shared --enable-static -t openmp x86_64
+  make -j
+  make install
+  popd
+
+  # we need an accompanying LAPACK
+  wget https://github.com/flame/libflame/archive/5.2.0.tar.gz
+  tar xzf 5.2.0.tar.gz
+  pushd libflame-5.2.0
+  ./configure --enable-dynamic-build --enable-lapack2flame --enable-max-arg-list-hack --enable-supermatrix \
+  --disable-ldim-alignment --enable-multithreading=openmp --disable-autodetect-f77-ldflags \
+  --disable-autodetect-f77-name-mangling
+  make -j
+  make install
+  popd
 
   # Need the libc++1 and libc++abi1 libraries to allow torch._C to load at runtime
   yum install -y libc++1

--- a/docker/pytorch/cpu-only/Dockerfile
+++ b/docker/pytorch/cpu-only/Dockerfile
@@ -37,7 +37,7 @@ RUN mkdir /opt/ccache && ccache --set-config=cache_dir=/opt/ccache
 ENV PATH /opt/conda/bin:$PATH
 
 FROM dev-base as conda
-RUN curl -v -o ~/miniconda.sh -O https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
+RUN wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh && \
     chmod +x ~/miniconda.sh && \
     ~/miniconda.sh -b -p /opt/conda && \
     rm ~/miniconda.sh && \


### PR DESCRIPTION
BLIS and libflame are AMD's preferred CPU BLAS and LAPACK libraries, respectively.
Use them on the Ubuntu ROCm docker by building from the latest releases.
