### PR TITLE
Rocm3.9 internal testing

### DIFF
--- a/aten/src/THC/THCAtomics.cuh
+++ b/aten/src/THC/THCAtomics.cuh
@@ -309,7 +309,12 @@ static inline __device__ void atomicAddNoReturn(double *address, double val) { g
 #ifdef __HIP_PLATFORM_HCC__
 #ifdef __gfx908__
 static inline __device__ bool __hip_is_shared(const __attribute__((address_space(0))) void*) asm("llvm.amdgcn.is.shared");
+/* return tyre of intrinsic was void in earlier ROCm versions */
+#if HIP_VERSION <= 309
 static inline __device__ void atomicAddNoRet_impl(__attribute__((address_space(1))) float*, float) asm("llvm.amdgcn.global.atomic.fadd.p1f32.f32");
+#else
+static inline __device__ float atomicAddNoRet_impl(__attribute__((address_space(1))) float*, float) asm("llvm.amdgcn.global.atomic.fadd.p1f32.f32");
+#endif
 static inline __device__ void gpuAtomicAddNoReturn(float* address, float val) {
     using FP = __attribute__((address_space(0))) float*;
     using GP = __attribute__((address_space(1))) float*;


### PR DESCRIPTION
Revert the commit caused mGPU perf regression. 
