### PR TITLE
Enable FP16 tests after the compiler precision issue fix

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1547,7 +1547,6 @@ class TestCuda(TestCase):
         counted = t.bincount(minlength=65536)
         self.assertEqual(torch.sum(counted), 10)
 
-    @skipIfRocm
     def test_tiny_half_norm_(self):
         a = torch.arange(25).cuda().float()
         a /= 100000000

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -10782,8 +10782,6 @@ class TestNNDeviceType(NNTestCase):
                 embedding.zero_grad()
                 self.assertEqual(after, pre)
 
-    # test is flaky on ROCm CI
-    @skipCUDAIfRocm
     @dtypesIfCUDA(torch.half, torch.float)
     @dtypes(torch.float)
     def test_softmax_results(self, device, dtype):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -11380,9 +11380,7 @@ class TestNNDeviceType(NNTestCase):
         self.assertEqual(output[1], output[2])
         self.assertTrue(output.data.norm(p=2, dim=1).le(1).all())
 
-    # test is flaky on ROCm CI
     @onlyCUDA
-    @skipCUDAIfRocm
     @dtypes(torch.half, torch.float)
     def test_softmax(self, device, dtype):
         input = torch.rand(32, 100, device=device, dtype=dtype, requires_grad=True)


### PR DESCRIPTION
Enabled tests in this PR:

TestCuda.test_tiny_half_norm_ 
TestNNDeviceTypeCUDA.test_softmax_cuda_float16 
TestNNDeviceTypeCUDA.test_softmax_cuda_float32
TestNNDeviceTypeCUDA.test_softmax_results_cuda_float16 
TestNNDeviceTypeCUDA.test_softmax_results_cuda_float32

