### PR TITLE
Update bench.sh

### DIFF
--- a/.jenkins/caffe2/bench.sh
+++ b/.jenkins/caffe2/bench.sh
@@ -44,8 +44,7 @@ if (( $num_gpus >= 4 )); then
     "$PYTHON" "$caffe2_pypath/python/examples/imagenet_trainer.py" --resnext_num_groups 32 --resnext_width_per_group 4 --num_layers 101 --train_data null --batch_size 128 --epoch_size 12800 --num_epochs 2 --num_gpus 4
 fi
 if (( $num_gpus >= 8 )); then
-    "$PYTHON" "$caffe2_pypath/python/examples/imagenet_trainer.py" --resnext_num_groups 32 --resnext_width_per_group 4 --num_layers 101 --train_data null --batch_size 256 --epoch_size 25600 --num_epochs 2 --
-m_gpus 8
+    "$PYTHON" "$caffe2_pypath/python/examples/imagenet_trainer.py" --resnext_num_groups 32 --resnext_width_per_group 4 --num_layers 101 --train_data null --batch_size 256 --epoch_size 25600 --num_epochs 2 --num_gpus 8
 fi
 
 # Shufflenet


### PR DESCRIPTION
corrected typo "--num_gpus 8" and bring back num_gpu in single line as it was going in 2nd line and was throwing error

 /opt/conda/bin/python3.6 /root/.local/lib/python3.6/site-packages/caffe2/python/examples/imagenet_trainer.py --resnext_num_groups 32 --resnext_width_per_group 4 --num_layers 101 --train_data null --batch_size 256 --epoch_size 25600 --num_epochs 2 --

imagenet_trainer.py: error: unrecognized arguments: --

Fixes #{issue number}
