### PR TITLE
Fix missing .fp32 in atomicAddNoRet_impl decl

### DIFF
--- a/aten/src/THC/THCAtomics.cuh
+++ b/aten/src/THC/THCAtomics.cuh
@@ -309,8 +309,8 @@ static inline __device__ void atomicAddNoReturn(double *address, double val) { g
 #ifdef __HIP_PLATFORM_HCC__
 #ifdef __gfx908__
 static inline __device__ bool __hip_is_shared(const __attribute__((address_space(0))) void*) asm("llvm.amdgcn.is.shared");
-/* return tyre of intrinsic was void in earlier ROCm versions */
-static inline __device__ float atomicAddNoRet_impl(__attribute__((address_space(1))) float*, float) asm("llvm.amdgcn.global.atomic.fadd.p1f32.f32");
+/* return type of intrinsic was void in earlier ROCm versions */
+static inline __device__ float atomicAddNoRet_impl(__attribute__((address_space(1))) float*, float) asm("llvm.amdgcn.global.atomic.fadd.f32.p1f32.f32");
 
 static inline __device__ void gpuAtomicAddNoReturn(float* address, float val) {
     using FP = __attribute__((address_space(0))) float*;


### PR DESCRIPTION
The atomicAddNoRet_impl is missing the return type in declaration name. Although llvm automatically corrects this declaration, it is better to correct this here. Asm should be llvm.amdgcn.global.atomic.fadd.f32.p1f32.f32.