### PR TITLE
Enable deterministic rocBLAS calls in PyTorch

### DIFF
--- a/aten/src/ATen/cuda/CublasHandlePool.cpp
+++ b/aten/src/ATen/cuda/CublasHandlePool.cpp
@@ -51,6 +51,11 @@ cublasHandle_t getCurrentCUDABlasHandle() {
     TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_DEFAULT_MATH));
   }
 #endif
+#if defined(__HIP_PLATFORM_HCC__) && HIP_VERSION >= 308
+  if (at::globalContext().deterministic()) {
+    TORCH_CUDABLAS_CHECK(rocblas_set_atomics_mode(handle, rocblas_atomics_not_allowed));
+  }
+#endif
   return handle;
 }
 


### PR DESCRIPTION
The PR adds a feature to disable atomics in rocblas calls thereby making the output deterministic. 
The flag can be set in pytorch using `torch.set_deterministic(True)` at python level

cc: @jeffdaily @sunway513 