### PR TITLE
Rocfft issue

### DIFF
--- a/aten/src/ATen/native/cuda/CuFFTPlanCache.h
+++ b/aten/src/ATen/native/cuda/CuFFTPlanCache.h
@@ -255,7 +255,13 @@ public:
     // Since cuFFT has limited non-unit stride support and various constraints, we
     // use a flag to keep track throughout this function to see if we need to
     // input = input.clone();
+
+#ifdef __HIP_PLATFORM_HCC__
+    // hipfft clobers input
+    clone_input = true; 
+#else
     clone_input = false;
+#endif
 
     // For half, base strides on the real part of real-to-complex and
     // complex-to-real transforms are not supported. Since our output is always

--- a/aten/src/ATen/native/cuda/CuFFTPlanCache.h
+++ b/aten/src/ATen/native/cuda/CuFFTPlanCache.h
@@ -257,7 +257,7 @@ public:
     // input = input.clone();
 
 #ifdef __HIP_PLATFORM_HCC__
-    // hipfft clobers input
+    // clone input to avoid issues with hipfft clobering the input and failing tests
     clone_input = true; 
 #else
     clone_input = false;

--- a/test/test_spectral_ops.py
+++ b/test/test_spectral_ops.py
@@ -598,7 +598,6 @@ class TestFFT(TestCase):
         _test_complex((40, 60, 3, 80), 3, lambda x: x.transpose(2, 0).select(0, 2)[5:55, :, 10:])
         _test_complex((30, 55, 50, 22), 3, lambda x: x[:, 3:53, 15:40, 1:21])
 
-    @skipCUDAIfRocm
     @skipCPUIfNoMkl
     @onlyOnCPUAndCUDA
     @dtypes(torch.double)
@@ -679,7 +678,6 @@ class TestFFT(TestCase):
                         self.assertEqual(torch.backends.cuda.cufft_plan_cache.max_size, 11)  # default is cuda:1
 
     # passes on ROCm w/ python 2.7, fails w/ python 3.6
-    @skipCUDAIfRocm
     @skipCPUIfNoMkl
     @dtypes(torch.double)
     def test_stft(self, device, dtype):
@@ -747,7 +745,6 @@ class TestFFT(TestCase):
         _test((10,), 5, 4, win_sizes=(1, 1), expected_error=RuntimeError)
 
 
-    @skipCUDAIfRocm
     @skipCPUIfNoMkl
     @dtypes(torch.double, torch.cdouble)
     def test_complex_stft_roundtrip(self, device, dtype):
@@ -789,7 +786,6 @@ class TestFFT(TestCase):
                                       length=x.size(-1), **common_kwargs)
             self.assertEqual(x_roundtrip, x)
 
-    @skipCUDAIfRocm
     @skipCPUIfNoMkl
     @dtypes(torch.double, torch.cdouble)
     def test_stft_roundtrip_complex_window(self, device, dtype):
@@ -850,7 +846,6 @@ class TestFFT(TestCase):
             actual = torch.stft(*args, window=window, center=False)
             self.assertEqual(actual, expected)
 
-    @skipCUDAIfRocm
     @skipCPUIfNoMkl
     @dtypes(torch.cdouble)
     def test_complex_stft_real_equiv(self, device, dtype):


### PR DESCRIPTION
This PR enable some failing unit tests for fft in pytorch.  

The reason these tests were failing was due to hipfft clobbering inputs causing a mismatch in tests that were checking that applying ffts and their reverse would get you back to the input.  

We solve this by cloning the input using an existing flag on the ROCM platform.

There PR doesnot enable all fft tests. There are other issues that need to be resolved before that can happen.
