### PR TITLE
Temp workaround to skip MIOpen bnorm

### DIFF
--- a/aten/src/ATen/native/Normalization.cpp
+++ b/aten/src/ATen/native/Normalization.cpp
@@ -451,6 +451,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, int64_t> _batch_norm_impl_index(
                  || (!running_mean.defined() && !running_var.defined() && training))
                && detail::getCUDAHooks().compiledWithMIOpen()
                && cudnn_enabled
+               && (!(input.dim() > 3) || !((input.size(2) * input.size(3)) & 3))
                );
 
   if (use_miopen) {


### PR DESCRIPTION
- Skipping MIOpen bnorm when H*W is not a multiple of 4 and picking
  pyTorch native bnorm implementation
- Fix the SSD convergence
- Revert this change after proper fix from MIOpen


** verification test in progress