### PR TITLE
Revert "Temp workaround to skip MIOpen bnorm"

### DIFF
--- a/aten/src/ATen/native/Normalization.cpp
+++ b/aten/src/ATen/native/Normalization.cpp
@@ -451,7 +451,6 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, int64_t> _batch_norm_impl_index(
                  || (!running_mean.defined() && !running_var.defined() && training))
                && detail::getCUDAHooks().compiledWithMIOpen()
                && cudnn_enabled
-               && (!(input.dim() > 3) || !((input.size(2) * input.size(3)) & 3))
                );
 
   if (use_miopen) {


### PR DESCRIPTION
This reverts commit 58cfa4b517a13b32f01429b490106d73320e36fc.

Fixes #{issue number}
