### PR TITLE
quick-checks: ensure no trailing spaces

### DIFF
--- a/.github/workflows/ifu.yml
+++ b/.github/workflows/ifu.yml
@@ -27,7 +27,7 @@ jobs:
           git config user.email github-actions@github.com
           git remote add upstream https://github.com/pytorch/pytorch
           git fetch upstream master
-          git merge upstream/master 
+          git merge upstream/master
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:

--- a/.github/workflows/ifu_testing.yml
+++ b/.github/workflows/ifu_testing.yml
@@ -20,7 +20,7 @@ jobs:
           git config user.email github-actions@github.com
           git remote add upstream https://github.com/pytorch/pytorch
           git fetch upstream master
-          git merge upstream/master 
+          git merge upstream/master
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:

--- a/cmake/Modules/Findblis.cmake
+++ b/cmake/Modules/Findblis.cmake
@@ -1,7 +1,7 @@
 SET(BLIS_INCLUDE_SEARCH_PATHS
  /usr/include
  /usr/include/blis
- /usr/local/include 
+ /usr/local/include
  /usr/local/include/blis
  /usr/local/opt/blis/include
  /opt/blis/include

--- a/cmake/public/test_atomic.hip
+++ b/cmake/public/test_atomic.hip
@@ -19,7 +19,7 @@ __global__ void sum(float *a, int n)
 
     // Get our global thread ID
     int id = blockIdx.x*blockDim.x+threadIdx.x;
- 
+
     // Make sure we do not go out of bounds
     if (id < n) atomicAddNoReturn(&v[threadIdx.x], a[id]);
 }


### PR DESCRIPTION
Some files unique to our ROCm PyTorch fork had trailing spaces, resulting in CI failures caught by quick-checks action.