### PR TITLE
[ROCm] Update the magma build to new commit (#60900)

### DIFF
--- a/.circleci/docker/common/install_rocm.sh
+++ b/.circleci/docker/common/install_rocm.sh
@@ -6,7 +6,7 @@ install_magma() {
     # "install" hipMAGMA into /opt/rocm/magma by copying after build
     git clone https://bitbucket.org/icl/magma.git
     pushd magma
-    git checkout 878b1ce02e9cfe4a829be22c8f911e9c0b6bd88f
+    git checkout aed4e285084763113ce5757393d4008e27b5194b
     cp make.inc-examples/make.inc.hip-gcc-mkl make.inc
     echo 'LIBDIR += -L$(MKLROOT)/lib' >> make.inc
     echo 'LIB += -Wl,--enable-new-dtags -Wl,--rpath,/opt/rocm/lib -Wl,--rpath,$(MKLROOT)/lib -Wl,--rpath,/opt/rocm/magma/lib' >> make.inc


### PR DESCRIPTION
Summary:
Magma master branch is updated with all the fixes required for ROCm, so updating the magma build to the new commit for ROCm pyTorch builds.

Pull Request resolved: https://github.com/pytorch/pytorch/pull/60900

Reviewed By: jbschlosser

Differential Revision: D29440587

Pulled By: malfet

fbshipit-source-id: 2ccdf48441dfff3d19c4a478e03ac11a843f8419

Fixes #{issue number}
