### PR TITLE
skip test_istft_round_trip_with_padding

### DIFF
--- a/test/test_spectral_ops.py
+++ b/test/test_spectral_ops.py
@@ -1196,6 +1196,7 @@ class TestFFT(TestCase):
 
     @onlyOnCPUAndCUDA
     @skipCPUIfNoFFT
+    @skipIfRocm
     @dtypes(torch.double)
     def test_istft_round_trip_with_padding(self, device, dtype):
         """long hop_length or not centered may cause length mismatch in the inversed signal"""


### PR DESCRIPTION
Skipping new test in spectral ops until rocfft fix is added. JIRA: https://ontrack-internal.amd.com/browse/SWDEV-305234