### PR TITLE
[1.7] Remove MI100(gfx908)-inline asm atomicAddNoReturn code

### DIFF
--- a/aten/src/THC/THCAtomics.cuh
+++ b/aten/src/THC/THCAtomics.cuh
@@ -307,27 +307,8 @@ static inline __device__ void atomicAddNoReturn(double *address, double val) { g
 
 /* Special case fp32 atomic. */
 #ifdef __HIP_PLATFORM_HCC__
-#ifdef __gfx908__
-static inline __device__ bool __hip_is_shared(const __attribute__((address_space(0))) void*) asm("llvm.amdgcn.is.shared");
-#if HIP_VERSION >= 401
-static inline __device__ float atomicAddNoRet_impl(__attribute__((address_space(1))) float*, float) asm("llvm.amdgcn.global.atomic.fadd.f32.p1f32.f32");
-#else
-static inline __device__ void atomicAddNoRet_impl(__attribute__((address_space(1))) float*, float) asm("llvm.amdgcn.global.atomic.fadd.p1f32.f32");
-#endif
-static inline __device__ void gpuAtomicAddNoReturn(float* address, float val) {
-    using FP = __attribute__((address_space(0))) float*;
-    using GP = __attribute__((address_space(1))) float*;
-    using LP = __attribute__((address_space(3))) float*;
-    if (!__hip_is_shared((FP)address))
-        atomicAddNoRet_impl((GP)address, val);
-    else
-        __builtin_amdgcn_ds_faddf((LP)address, val, 0, 0, false);
-}
-static inline __device__ void atomicAddNoReturn(float *address, float val) { gpuAtomicAddNoReturn(address, val); }
-#else
 static inline __device__ void gpuAtomicAddNoReturn(float *address, float val) { atomicAddNoRet(address, val); }
 static inline __device__ void atomicAddNoReturn(float *address, float val) { atomicAddNoRet(address, val); }
-#endif
 #else
 static inline __device__ void gpuAtomicAddNoReturn(float *address, float val) { gpuAtomicAdd(address, val); }
 static inline __device__ void atomicAddNoReturn(float *address, float val) { gpuAtomicAdd(address, val); }


### PR DESCRIPTION
This should help workaround the following error seen during compilation in ROCm4.5

```
:[0m[91mIn file included from /var/lib/jenkins/pytorch/aten/src/ATen/native/hip/AdaptiveMaxPooling2d.hip:4:
19:29:55  [0m[91mIn file included from /var/lib/jenkins/pytorch/aten/src/ATen/hip/HIPApplyUtils.cuh:7:
19:29:55  [0m[91m/var/lib/jenkins/pytorch/aten/src/THH/THHAtomics.cuh:326:35: error: cannot initialize a parameter of type '__shared__ float *' with an rvalue of type 'LP' (aka '__attribute__((address_space(3))) float *')
19:29:55  [0m[91m        __builtin_amdgcn_ds_faddf((LP)address, val, 0, 0, false);
19:29:55  [0m[91m                                  ^~~~~~~~~~~
19:29:55  [0m[91m1 error generated when compiling for gfx908.
19:29:55  [0m[91mCMake Error at torch_hip_generated_AdaptiveMaxPooling2d.hip.o.cmake:200 (message):
19:29:55    Error generating file
19:29:55    /var/lib/jenkins/pytorch/build/caffe2/CMakeFiles/torch_hip.dir/__/aten/src/ATen/native/hip/./torch_hip_generated_AdaptiveMaxPooling2d.hip.o
19:29:55
19:29:55
19:29:55  [0m[91mmake[2]: *** [caffe2/CMakeFiles/torch_hip.dir/__/aten/src/ATen/native/hip/torch_hip_generated_AdaptiveMaxPooling2d.hip.o] Error 1
```