### PR TITLE
Update torchvision commit to upstream

### DIFF
--- a/related_commits
+++ b/related_commits
@@ -1,4 +1,4 @@
 ubuntu|pytorch|apex|master|95797c8d05895266d4692cd9ba98316a9a2312c6|https://github.com/ROCmSoftwarePlatform/apex
 centos|pytorch|apex|master|95797c8d05895266d4692cd9ba98316a9a2312c6|https://github.com/ROCmSoftwarePlatform/apex
-ubuntu|pytorch|torchvision|master|e828eefa4c326f893ebdd07abae7adc873d6ab63|https://github.com/ROCmSoftwarePlatform/vision
-centos|pytorch|torchvision|master|e828eefa4c326f893ebdd07abae7adc873d6ab63|https://github.com/ROCmSoftwarePlatform/vision
+ubuntu|pytorch|torchvision|master|c359d8d56242997e6209b71524d7a6199ea333b2|https://github.com/pytorch/vision
+centos|pytorch|torchvision|master|c359d8d56242997e6209b71524d7a6199ea333b2|https://github.com/pytorch/vision


### PR DESCRIPTION
 as https://ontrack-internal.amd.com/browse/SWDEV-300538 is fixed

Local testing with some pytorch microbenchmarking workloads reflected unchanged performance compared to ROCm fork commit.

@pruthvistony To be merged only for ROCm4.5.1, to avoid unnecessary churn for ROCm4.5.