### PR TITLE
[ROCm] use hipCUB chained iterator

### DIFF
--- a/aten/src/ATen/cuda/cub.cuh
+++ b/aten/src/ATen/cuda/cub.cuh
@@ -235,6 +235,17 @@ inline void inclusive_scan(InputIteratorT input, OutputIteratorT output, ScanOpT
   // even though cub is supposed to support tensors with int_max elements, in reality it doesn't,
   // so split at int_max/2
   constexpr int max_cub_size = std::numeric_limits<int>::max() / 2 + 1; // 2**30
+#if defined(USE_ROCM) && (ROCM_VERSION >= 50000)
+  CUB_WRAPPER(NO_ROCM(detail)::hipcub::DeviceScan::InclusiveScan,
+      input,
+      output,
+      scan_op,
+      num_items,
+      at::hip::getCurrentHIPStreamMasqueradingAsCUDA(),
+      false,
+      max_cub_size);
+  C10_HIP_KERNEL_LAUNCH_CHECK();
+#else
   int size_cub = std::min<int64_t>(num_items, max_cub_size);
   CUB_WRAPPER(NO_ROCM(detail)::cub::DeviceScan::InclusiveScan,
       input,
@@ -274,6 +285,7 @@ inline void inclusive_scan(InputIteratorT input, OutputIteratorT output, ScanOpT
         size_cub,
         at::cuda::getCurrentCUDAStream());
   }
+#endif
 }
 
 template<typename InputIteratorT, typename OutputIteratorT, typename ScanOpT, typename InitValueT>
@@ -282,6 +294,18 @@ inline void exclusive_scan(InputIteratorT input, OutputIteratorT output, ScanOpT
   // even though cub is supposed to support tensors with int_max elements, in reality it doesn't,
   // so split at int_max/2
   constexpr int max_cub_size = std::numeric_limits<int>::max() / 2 + 1; // 2**30
+#if defined(USE_ROCM) && (ROCM_VERSION >= 50000)
+  CUB_WRAPPER(NO_ROCM(detail)::hipcub::DeviceScan::ExclusiveScan,
+      input,
+      output,
+      scan_op,
+      init_value,
+      num_items,
+      at::hip::getCurrentHIPStreamMasqueradingAsCUDA(),
+      false,
+      max_cub_size);
+  C10_HIP_KERNEL_LAUNCH_CHECK();
+#else
   int size_cub = std::min<int64_t>(num_items, max_cub_size);
   CUB_WRAPPER(NO_ROCM(detail)::cub::DeviceScan::ExclusiveScan,
       input,
@@ -312,6 +336,7 @@ inline void exclusive_scan(InputIteratorT input, OutputIteratorT output, ScanOpT
         size_cub,
         at::cuda::getCurrentCUDAStream());
   }
+#endif
 }
 
 template<typename InputIteratorT , typename OutputIteratorT , typename NumSelectedIteratorT >

--- a/aten/src/ATen/cuda/cub.cuh
+++ b/aten/src/ATen/cuda/cub.cuh
@@ -231,21 +231,20 @@ struct chained_iterator {
 
 template<typename InputIteratorT, typename OutputIteratorT, typename ScanOpT>
 inline void inclusive_scan(InputIteratorT input, OutputIteratorT output, ScanOpT scan_op, int64_t num_items) {
-  // non synchronizing cub call
-  // even though cub is supposed to support tensors with int_max elements, in reality it doesn't,
-  // so split at int_max/2
-  constexpr int max_cub_size = std::numeric_limits<int>::max() / 2 + 1; // 2**30
 #if defined(USE_ROCM) && (ROCM_VERSION >= 50000)
+  //For ROCm, use hipCUB chained iterators
   CUB_WRAPPER(NO_ROCM(detail)::hipcub::DeviceScan::InclusiveScan,
       input,
       output,
       scan_op,
       num_items,
-      at::hip::getCurrentHIPStreamMasqueradingAsCUDA(),
-      false,
-      max_cub_size);
+      at::cuda::getCurrentCUDAStream());
   C10_HIP_KERNEL_LAUNCH_CHECK();
 #else
+  // non synchronizing cub call
+  // even though cub is supposed to support tensors with int_max elements, in reality it doesn't,
+  // so split at int_max/2
+  constexpr int max_cub_size = std::numeric_limits<int>::max() / 2 + 1; // 2**30
   int size_cub = std::min<int64_t>(num_items, max_cub_size);
   CUB_WRAPPER(NO_ROCM(detail)::cub::DeviceScan::InclusiveScan,
       input,
@@ -290,22 +289,21 @@ inline void inclusive_scan(InputIteratorT input, OutputIteratorT output, ScanOpT
 
 template<typename InputIteratorT, typename OutputIteratorT, typename ScanOpT, typename InitValueT>
 inline void exclusive_scan(InputIteratorT input, OutputIteratorT output, ScanOpT scan_op, InitValueT init_value, int64_t num_items) {
-  // non synchronizing cub call
-  // even though cub is supposed to support tensors with int_max elements, in reality it doesn't,
-  // so split at int_max/2
-  constexpr int max_cub_size = std::numeric_limits<int>::max() / 2 + 1; // 2**30
 #if defined(USE_ROCM) && (ROCM_VERSION >= 50000)
+  //For ROCm, use hipCUB chained iterators
   CUB_WRAPPER(NO_ROCM(detail)::hipcub::DeviceScan::ExclusiveScan,
       input,
       output,
       scan_op,
       init_value,
       num_items,
-      at::hip::getCurrentHIPStreamMasqueradingAsCUDA(),
-      false,
-      max_cub_size);
+      at::cuda::getCurrentCUDAStream());
   C10_HIP_KERNEL_LAUNCH_CHECK();
 #else
+  // non synchronizing cub call
+  // even though cub is supposed to support tensors with int_max elements, in reality it doesn't,
+  // so split at int_max/2
+  constexpr int max_cub_size = std::numeric_limits<int>::max() / 2 + 1; // 2**30
   int size_cub = std::min<int64_t>(num_items, max_cub_size);
   CUB_WRAPPER(NO_ROCM(detail)::cub::DeviceScan::ExclusiveScan,
       input,

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -5964,8 +5964,6 @@ else:
         dst = dst.masked_scatter(mask, src)
         self.assertEqual(dst, torch.tensor([True, True, True], device=device))
 
-    # refer https://github.com/pytorch/pytorch/issues/60190
-    @skipIfRocm
     @onlyCUDA
     @largeTensorTest('30GB')
     def test_masked_scatter_large_tensor(self, device):


### PR DESCRIPTION
[ROCm] use hipCUB chained iterator

For inclusive_scan and exclusive_scan, use hipCUB / rocPRIM's chainted iterator.
Implemented for ROCm 5.0 and above.

