### PR TITLE
IFU-master-2021-12-13

### DIFF
--- a/test/test_unary_ufuncs.py
+++ b/test/test_unary_ufuncs.py
@@ -13,7 +13,7 @@ import unittest
 from torch._six import inf, nan
 from torch.testing._internal.common_utils import (
     TestCase, run_tests, torch_to_numpy_dtype_dict, numpy_to_torch_dtype_dict,
-    suppress_warnings, TEST_SCIPY, slowTest, skipIfNoSciPy, IS_WINDOWS, gradcheck)
+    suppress_warnings, TEST_SCIPY, slowTest, skipIfNoSciPy, IS_WINDOWS, gradcheck, TEST_WITH_ROCM)
 from torch.testing._internal.common_methods_invocations import (
     unary_ufuncs, _NOTHING)
 from torch.testing._internal.common_device_type import (
@@ -501,7 +501,10 @@ class TestUnaryUfuncs(TestCase):
         else:
             res = op(input, out=output, **kwargs)
             self.assertTrue(res is output)
-            self.assertEqual(output, expected.to(output.dtype))
+            if all([TEST_WITH_ROCM, op.name == "sinc", expected.dtype == torch.complex64, output.dtype == torch.complex128]):
+                self.assertEqual(output, expected.to(output.dtype), atol=1e-6, rtol=1e-6)
+            else:
+                self.assertEqual(output, expected.to(output.dtype))
 
     @ops(unary_ufuncs, dtypes=OpDTypes.supported)
     def test_out_arg_all_dtypes(self, device, dtype, op):


### PR DESCRIPTION
APEX passes all run_rocm unit tests:
[APEX_run_rocm_IFU_2021_12_13.txt](https://github.com/ROCmSoftwarePlatform/pytorch/files/7724200/APEX_run_rocm_IFU_2021_12_13.txt)

APEX rocm_distributed pass all unit tests with the addition of --shm-size=4g in docker run command:
[apex_run_distributed_IFU_2021_12_13.txt](https://github.com/ROCmSoftwarePlatform/pytorch/files/7724202/apex_run_distributed_IFU_2021_12_13.txt)

All Torchvision unit tests pass: 
[torchvision_2021_12_13_IFU.txt](https://github.com/ROCmSoftwarePlatform/pytorch/files/7724203/torchvision_2021_12_13_IFU.txt)


 