### PR TITLE
[ROCm] use hipCUB chained iterator

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -5976,8 +5976,6 @@ else:
         dst = dst.masked_scatter(mask, src)
         self.assertEqual(dst, torch.tensor([True, True, True], device=device))
 
-    # refer https://github.com/pytorch/pytorch/issues/60190
-    @skipIfRocm
     @onlyCUDA
     @largeTensorTest('30GB')
     def test_masked_scatter_large_tensor(self, device):


### PR DESCRIPTION
For inclusive_scan and exclusive_scan, use hipCUB / rocPRIM's chainted iterator.
Implemented for ROCm 5.0 and above.

Signed-off-by: Jagadish Krishnamoorthy <jagdish.krishna@gmail.com>

