### PR TITLE
Revert "Replace `internal::GRAIN_SIZE` by `grain_size` (parameter). (…

### DIFF
--- a/aten/src/ATen/TensorIterator.cpp
+++ b/aten/src/ATen/TensorIterator.cpp
@@ -737,7 +737,7 @@ void TensorIteratorBase::for_each(loop2d_t loop, int64_t grain_size) {
   int64_t numel = this->numel();
   if (numel == 0) {
     return;
-  } else if (numel < grain_size || at::get_num_threads() == 1) {
+  } else if (numel < internal::GRAIN_SIZE || at::get_num_threads() == 1) {
     return serial_for_each(loop, {0, numel});
   } else {
     at::parallel_for(0, numel, grain_size, [&](int64_t begin, int64_t end) {


### PR DESCRIPTION
Fixes [SWDEV-315373](https://ontrack-internal.amd.com/browse/SWDEV-315373)

Detectron2 performance drop is fixed by reversal of this commit.
Reversal of this commit also fixing performance of Detectron2 in 4.5 as well.
