### PR TITLE
Add ROCm5.0/AMDGPU support

### DIFF
--- a/.circleci/docker/common/install_rocm.sh
+++ b/.circleci/docker/common/install_rocm.sh
@@ -30,7 +30,7 @@ ver() {
 }
 
 # Map ROCm version to AMDGPU version
-declare -A AMDGPU_VERSIONS=( ["4.5.2"]="21.40.2" )
+declare -A AMDGPU_VERSIONS=( ["4.5.2"]="21.40.2" ["5.0"]="21.50" )
 
 install_ubuntu() {
     apt-get update


### PR DESCRIPTION
Signed-off-by: Wang, Yanyao <yanyao.wang@amd.com>

The ROCm 5.0 installation failed for missing AMDGPU mapping.
