### PR TITLE
Fix failing test due to a bug in NumPy when using OpenBLAS

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -1638,7 +1638,12 @@ class TestLinalg(TestCase):
         a = torch.eye(3, dtype=dtype, device=device)
         a[-1, -1] = 0  # make 'a' singular
         for p in norm_types:
-            run_test_case(a, p)
+            try:
+                run_test_case(a, p)
+            except np.linalg.LinAlgError:
+                # Numpy may fail to converge for some BLAS backends (although this is very rare)
+                # See the discussion in https://github.com/pytorch/pytorch/issues/67675
+                pass
 
         # test for 0x0 matrices. NumPy doesn't work for such input, we return 0
         input_sizes = [(0, 0), (2, 5, 0, 0)]


### PR DESCRIPTION
Cherrypicked the changes from master PT
https://github.com/pytorch/pytorch/pull/67679

Fixes https://ontrack-internal.amd.com/browse/SWDEV-320250

Signed-off-by: Jagadish Krishnamoorthy <jagdish.krishna@gmail.com>
