### PR TITLE
[WIP][resubmit] Don't #define NUM_THREADS (#68008)

### DIFF
--- a/aten/src/ATen/native/cuda/FunctionOfAMatrixUtilsKernel.cu
+++ b/aten/src/ATen/native/cuda/FunctionOfAMatrixUtilsKernel.cu
@@ -85,7 +85,7 @@ void _compute_linear_combination_internal_kernel(
     }
   };
 
-  _lauch_kernel<num_threads, thread_work_size>(iter.numel(), loop);
+  _lauch_kernel<num_threads(), thread_work_size()>(iter.numel(), loop);
 }
 
 void _compute_linear_combination_cuda_kernel(

--- a/aten/src/ATen/native/cuda/LinearAlgebra.cu
+++ b/aten/src/ATen/native/cuda/LinearAlgebra.cu
@@ -562,7 +562,7 @@ void _unpack_pivots_internal_kernel(
     }
   };
 
-  _launch_kernel<num_threads, thread_work_size>(iter.numel(), loop);
+  _launch_kernel<num_threads(), thread_work_size()>(iter.numel(), loop);
 }
 
 void unpack_pivots_cuda_kernel(

--- a/aten/src/ATen/native/cuda/Loops.cuh
+++ b/aten/src/ATen/native/cuda/Loops.cuh
@@ -8,13 +8,9 @@
 
 #include <thrust/tuple.h>
 
-#define NUM_THREADS (C10_WARP_SIZE * 2)
-#define THREAD_WORK_SIZE 4
-#define BLOCK_WORK_SIZE (THREAD_WORK_SIZE * num_threads)
-
-constexpr int num_threads = NUM_THREADS;
-constexpr int thread_work_size = THREAD_WORK_SIZE;
-constexpr int block_work_size = BLOCK_WORK_SIZE;
+constexpr int num_threads() { return C10_WARP_SIZE * 4; }
+constexpr int thread_work_size() { return 4; }
+constexpr int block_work_size() { return thread_work_size() * num_threads(); }
 
 #include <ATen/native/cuda/MemoryAccess.cuh>
 
@@ -54,15 +50,15 @@ __device__ inline void elementwise_kernel_helper(func_t f, policy_t policy) {
 
   int idx = blockIdx.x;
 
-  return_t results[thread_work_size];
-  args_t args[thread_work_size];
+  return_t results[thread_work_size()];
+  args_t args[thread_work_size()];
 
   // load
   policy.load(args, idx);
 
   // compute
   #pragma unroll
-  for (int i = 0; i < thread_work_size; i++) {
+  for (int i = 0; i < thread_work_size(); i++) {
     if (policy.check_inbounds(i)) {
       results[i] = c10::guts::apply(f, args[i]);
     }
@@ -179,18 +175,18 @@ template <typename T> struct is_tuple: std::false_type {};
 template <typename ...T> struct is_tuple<thrust::tuple<T...>>: std::true_type {};
 
 template <int num_outputs, typename func_t, typename array_t, typename inp_calc_t, typename out_calc_t>
-C10_LAUNCH_BOUNDS_1(num_threads)
+C10_LAUNCH_BOUNDS_1(num_threads())
 __global__ void unrolled_elementwise_kernel_for_multi_outputs(int N, func_t f, array_t data, inp_calc_t ic, out_calc_t oc) {
-  int remaining = N - block_work_size * blockIdx.x;
+  int remaining = N - block_work_size() * blockIdx.x;
   elementwise_kernel_helper(f, memory::policies::multi_outputs_unroll<array_t, inp_calc_t, out_calc_t, num_outputs>(data, remaining, ic, oc));
 }
 
 template <int num_outputs, typename func_t, typename array_t, typename inp_calc_t, typename out_calc_t>
 static inline void launch_unrolled_kernel_for_multi_outputs(int64_t N, const func_t& f, array_t data, inp_calc_t ic, out_calc_t oc) {
   TORCH_INTERNAL_ASSERT(N > 0 && N <= std::numeric_limits<int32_t>::max());
-  int64_t grid = (N + block_work_size - 1) / block_work_size;
+  int64_t grid = (N + block_work_size() - 1) / block_work_size();
   auto stream = at::cuda::getCurrentCUDAStream();
-  unrolled_elementwise_kernel_for_multi_outputs<num_outputs, func_t, array_t><<<grid, num_threads, 0, stream>>>(N, f, data, ic, oc);
+  unrolled_elementwise_kernel_for_multi_outputs<num_outputs, func_t, array_t><<<grid, num_threads(), 0, stream>>>(N, f, data, ic, oc);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 }
 

--- a/aten/src/ATen/native/cuda/MemoryAccess.cuh
+++ b/aten/src/ATen/native/cuda/MemoryAccess.cuh
@@ -59,7 +59,7 @@ struct vectorized_load_helper {
     using arg_t = std::tuple_element_t<arg_index, args_t>;
     // `data` hold the data_ptr for tensors [output, input0, input1, ...], so we
     // need a +1 offset to get the input
-    auto ptr = reinterpret_cast<arg_t *>(self.data[arg_index + 1]) + block_work_size * idx;
+    auto ptr = reinterpret_cast<arg_t *>(self.data[arg_index + 1]) + block_work_size() * idx;
     auto args_accessor = [&args] __device__ (int thread_unroll_idx) -> arg_t & { return std::get<arg_index>(args[thread_unroll_idx]); };
     self.load_single_arg(args_accessor, ptr);
   }
@@ -164,7 +164,7 @@ struct unroll {
     data(data), remaining(remaining), input_offset_calculator(ic), output_offset_calculator(oc), loader(l), storer(s) {}
 
   __device__ inline bool check_inbounds(int thread_work_elem) {
-    return ((threadIdx.x  + thread_work_elem*num_threads) < remaining);
+    return ((threadIdx.x  + thread_work_elem*num_threads()) < remaining);
   }
 
   template<typename args_t>
@@ -172,30 +172,30 @@ struct unroll {
     constexpr int arity = std::tuple_size<args_t>::value;
     int thread_idx = threadIdx.x;
     #pragma unroll
-    for (int i = 0; i < thread_work_size; i++) {
+    for (int i = 0; i < thread_work_size(); i++) {
       if (thread_idx >= remaining) {
         return;
       }
-      int linear_idx = thread_idx + block_work_size * idx;
+      int linear_idx = thread_idx + block_work_size() * idx;
       auto offset = input_offset_calculator.get(linear_idx);
       detail::static_unroll<detail::unroll_load_helper, arity>::with_args(*this, args, offset, loader, i, num_outputs);
-      thread_idx += num_threads;
+      thread_idx += num_threads();
     }
   }
 
   template<typename scalar_t>
   __device__ inline void store(scalar_t *from, int idx) {
     int thread_idx = threadIdx.x;
-    scalar_t *to = reinterpret_cast<scalar_t *>(data[0]) + block_work_size * idx;
+    scalar_t *to = reinterpret_cast<scalar_t *>(data[0]) + block_work_size() * idx;
     #pragma unroll
-    for (int i = 0; i < thread_work_size; i++) {
+    for (int i = 0; i < thread_work_size(); i++) {
       if (thread_idx >= remaining) {
         return;
       }
-      int linear_idx = thread_idx + block_work_size * idx;
+      int linear_idx = thread_idx + block_work_size() * idx;
       int offset = output_offset_calculator.get(linear_idx)[0];
       storer.store(from[i], data[0], offset);
-      thread_idx += num_threads;
+      thread_idx += num_threads();
     }
   }
 };
@@ -208,8 +208,8 @@ struct unroll {
 template <int vec_size, typename data_t>  // vec_size: number of scalars, can be 1, 2, or 4.
 struct vectorized {
 
-  static_assert(thread_work_size % vec_size == 0, "The workload per thread must be a multiple of vec_size");
-  static constexpr int loop_size = thread_work_size / vec_size;
+  static_assert(thread_work_size() % vec_size == 0, "The workload per thread must be a multiple of vec_size");
+  static constexpr int loop_size = thread_work_size() / vec_size;
 
   data_t data;
 
@@ -226,7 +226,7 @@ struct vectorized {
     int thread_idx = threadIdx.x;
     #pragma unroll
     for (int i = 0; i < loop_size; i++) {
-      int index = thread_idx + i * num_threads;
+      int index = thread_idx + i * num_threads();
       vec_t v = from_[index];
       #pragma unroll
       for (int j = 0; j < vec_size; j++) {
@@ -244,12 +244,12 @@ struct vectorized {
   template<typename scalar_t>
   __device__ inline void store(scalar_t *from, int idx) {
     using vec_t = aligned_vector<scalar_t, vec_size>;
-    scalar_t *to = reinterpret_cast<scalar_t *>(data[0]) + block_work_size * idx;
+    scalar_t *to = reinterpret_cast<scalar_t *>(data[0]) + block_work_size() * idx;
     vec_t *to_ = reinterpret_cast<vec_t *>(to);
     int thread_idx = threadIdx.x;
     #pragma unroll
     for (int i = 0; i < loop_size; i++) {
-      int index = thread_idx + i * num_threads;
+      int index = thread_idx + i * num_threads();
       vec_t v;
       for (int j = 0; j < vec_size; j++) {
         v.val[j] = from[vec_size * i + j];
@@ -274,7 +274,7 @@ struct multi_outputs_unroll {
   data(data), remaining(remaining), input_offset_calculator(ic), output_offset_calculator(oc) {}
 
   __device__ inline bool check_inbounds(int thread_work_elem) {
-    return ((threadIdx.x  + thread_work_elem*num_threads) < remaining);
+    return ((threadIdx.x  + thread_work_elem*num_threads()) < remaining);
   }
 
   template<typename args_t>
@@ -282,14 +282,14 @@ struct multi_outputs_unroll {
     constexpr int arity = std::tuple_size<args_t>::value;
     int thread_idx = threadIdx.x;
     #pragma unroll
-    for (int i = 0; i < thread_work_size; i++) {
+    for (int i = 0; i < thread_work_size(); i++) {
       if (thread_idx >= remaining) {
         return;
       }
-      int linear_idx = thread_idx + block_work_size * idx;
+      int linear_idx = thread_idx + block_work_size() * idx;
       auto offset = input_offset_calculator.get(linear_idx);
       detail::static_unroll<detail::unroll_load_helper, arity>::with_args(*this, args, offset, loader, i, num_outputs);
-      thread_idx += num_threads;
+      thread_idx += num_threads();
     }
   }
 
@@ -298,14 +298,14 @@ struct multi_outputs_unroll {
   __device__ inline void store(return_t *from, int idx) {
     int thread_idx = threadIdx.x;
     #pragma unroll
-    for (int i = 0; i < thread_work_size; i++) {
+    for (int i = 0; i < thread_work_size(); i++) {
       if (thread_idx >= this->remaining) {
         return;
       }
-      int linear_idx = thread_idx + block_work_size * idx;
+      int linear_idx = thread_idx + block_work_size() * idx;
       auto offsets = this->output_offset_calculator.get(linear_idx);
       memory::detail::static_unroll<detail::multi_outputs_store_helper, num_outputs>::with_args(this->data, offsets, from[i]);
-      thread_idx += num_threads;
+      thread_idx += num_threads();
     }
   }
 };

--- a/aten/src/ATen/native/cuda/ScatterGatherKernel.cu
+++ b/aten/src/ATen/native/cuda/ScatterGatherKernel.cu
@@ -124,7 +124,7 @@ struct _cuda_scatter_gather_internal_kernel {
 
     };
 
-    _launch_scatter_gather_kernel<num_threads, thread_work_size>(iter.numel(), loop);
+    _launch_scatter_gather_kernel<num_threads(), thread_work_size()>(iter.numel(), loop);
   }
 }; // struct _cuda_scatter_fill_internal_kernel
 
@@ -320,7 +320,7 @@ struct _cuda_scatter_fill_internal_kernel {
 
     };
 
-    _launch_scatter_gather_kernel<num_threads, thread_work_size>(iter.numel(), loop);
+    _launch_scatter_gather_kernel<num_threads(), thread_work_size()>(iter.numel(), loop);
   }
 }; // struct _cuda_scatter_fill_internal_kernel
 

--- a/aten/src/ATen/native/cuda/UnfoldBackwardKernel.cu
+++ b/aten/src/ATen/native/cuda/UnfoldBackwardKernel.cu
@@ -103,7 +103,7 @@ void _unfold_backward_internal_kernel(
       grad_out_data[grad_out_idx_dim * grad_out_dim_stride] = *grad_in_data;
     };
 
-    _launch_unfold_backward_kernel<num_threads, thread_work_size>(iter.numel(), loop);
+    _launch_unfold_backward_kernel<num_threads(), thread_work_size()>(iter.numel(), loop);
   }
   else {
     auto offset_calc = make_offset_calculator<3>(iter);
@@ -138,7 +138,7 @@ void _unfold_backward_internal_kernel(
 
     };
 
-    _launch_unfold_backward_kernel<num_threads, thread_work_size>(iter.numel(), loop);
+    _launch_unfold_backward_kernel<num_threads(), thread_work_size()>(iter.numel(), loop);
   }
 }
 

--- a/aten/src/ATen/test/cuda_vectorized_test.cu
+++ b/aten/src/ATen/test/cuda_vectorized_test.cu
@@ -8,11 +8,13 @@
 using namespace at::native;
 using namespace at::native::memory;
 
-__managed__ double4 buffer1[1024];
-__managed__ double4 buffer2[1024];
+constexpr int buffer_size = 1024;
+
+__managed__ double4 buffer1[buffer_size];
+__managed__ double4 buffer2[buffer_size];
 
 void reset_buffers() {
-  for (int i = 0; i < 1024; i++) {
+  for (int i = 0; i < buffer_size; i++) {
     buffer1[i].x = i;
     buffer1[i].y = i + 0.1;
     buffer1[i].z = i + 0.2;
@@ -74,6 +76,7 @@ TEST(TestVectorizedMemoryAccess, CanVectorizeUpTo) {
 // defined in `ATen/native/cuda/MemoryAccess.cuh`
 template <typename scalar_t, int vec_size>
 __global__ void vectorized_copy(scalar_t *dst, scalar_t *src) {
+  static_assert(vec_size <= thread_work_size() && thread_work_size() % vec_size == 0, "Invalid vec_size");
   using array_t = at::detail::Array<char*, 2>;
   array_t data;
   data[0] = reinterpret_cast<char *>(dst);
@@ -81,9 +84,15 @@ __global__ void vectorized_copy(scalar_t *dst, scalar_t *src) {
   int idx = blockIdx.x;
   using vectorized = policies::vectorized<vec_size, array_t>;
   auto policy = vectorized(data);
-  scalar_t buf[thread_work_size];
+  scalar_t buf[thread_work_size()];
+#if defined(CUDA_VERSION) && CUDA_VERSION < 11000
+  // This fails only on CUDA 10.x, remove this after CUDA 10.x support is dropped
+  scalar_t *buf_ = &buf[0];
+  auto accessor = [&](int index) -> scalar_t & { return buf_[index]; };
+#else
   auto accessor = [&](int index) -> scalar_t & { return buf[index]; };
-  policy.load_single_arg(accessor, src + 256 * blockIdx.x);
+#endif
+  policy.load_single_arg(accessor, src + block_work_size() * blockIdx.x);
   policy.store(buf, idx);
 }
 
@@ -98,7 +107,8 @@ TEST(TestVectorizedMemoryAccess, CopyKernel) {
   // vec4 copy
   reset_buffers();
   cudaDeviceSynchronize();
-  vectorized_copy<double, 4><<<16, 64>>>(b2, b1);
+  constexpr int total_work_size = buffer_size * 4;
+  vectorized_copy<double, 4><<<total_work_size / block_work_size() , num_threads()>>>(b2, b1);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   ASSERT_EQ(cudaSuccess, cudaDeviceSynchronize());
@@ -112,7 +122,7 @@ TEST(TestVectorizedMemoryAccess, CopyKernel) {
   // vec2 copy
   reset_buffers();
   cudaDeviceSynchronize();
-  vectorized_copy<double, 2><<<16, 64>>>(b2, b1);
+  vectorized_copy<double, 2><<<total_work_size / block_work_size() , num_threads()>>>(b2, b1);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   ASSERT_EQ(cudaSuccess, cudaDeviceSynchronize());
@@ -126,7 +136,7 @@ TEST(TestVectorizedMemoryAccess, CopyKernel) {
   // vec1 copy
   reset_buffers();
   cudaDeviceSynchronize();
-  vectorized_copy<double, 1><<<16, 64>>>(b2, b1);
+  vectorized_copy<double, 1><<<total_work_size / block_work_size() , num_threads()>>>(b2, b1);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   ASSERT_EQ(cudaSuccess, cudaDeviceSynchronize());
@@ -136,8 +146,8 @@ TEST(TestVectorizedMemoryAccess, CopyKernel) {
     ASSERT_EQ(buffer1[i].z, buffer2[i].z);
     ASSERT_EQ(buffer1[i].w, buffer2[i].w);
   }
-// Skipping this part until https://github.com/pytorch/pytorch/issues/51863 is resolved
 
+// Skipping this part until https://github.com/pytorch/pytorch/issues/51863 is resolved
 #if 0
   // unaligned
   for (int i = 0; i < 16; i++) {
@@ -146,9 +156,7 @@ TEST(TestVectorizedMemoryAccess, CopyKernel) {
       b2 = reinterpret_cast<double *>(reinterpret_cast<char *>(buffer2) + j);
       cudaGetLastError();
       cudaDeviceSynchronize();
-      vectorized_copy<double, 4><<<1, 64>>>(b2, b1);
-      C10_CUDA_KERNEL_LAUNCH_CHECK();
-
+      vectorized_copy<double, 4><<<1, num_threads()>>>(b2, b1);
       cudaDeviceSynchronize();
       auto err = cudaGetLastError();
       if (i % 16 == 0 && j % 16 == 0) {


### PR DESCRIPTION
Had a conflict while cherry-picking CrossKernel.cu, so kept PyTorch 1.9 version because the kernel was refactored to use NUM_THREADS only after 1.9

To avoid the compilation error with ROCm5.1.

```
23:14:28  [0m[91mIn file included from /var/lib/jenkins/pytorch/aten/src/ATen/native/hip/Indexing.hip:21:
23:14:28  [0m[91mIn file included from /var/lib/jenkins/pytorch/aten/src/ATen/hip/cub.cuh:12:
23:14:28  [0m[91mIn file included from /opt/rocm/include/hipcub/hipcub.hpp:36:
23:14:28  [0m[91mIn file included from /opt/rocm/include/hipcub/backend/rocprim/hipcub.hpp:54:
23:14:28  [0m[91mIn file included from /opt/rocm/include/hipcub/backend/rocprim/warp/warp_merge_sort.hpp:35:
23:14:28  [0m[91m/opt/rocm/include/hipcub/backend/rocprim/warp/../block/block_merge_sort.hpp:171:15: error: expected ')'
23:14:28  [0m[91m          int NUM_THREADS,
23:14:28  [0m[91m              ^
23:14:28  [0m[91m/var/lib/jenkins/pytorch/aten/src/ATen/native/hip/Loops.cuh:13:22: note: expanded from macro 'NUM_THREADS'
23:14:28  [0m[91m#define NUM_THREADS (C10_WARP_SIZE * 2)
23:14:28  [0m[91m                     ^
23:14:28  [0m[91m/var/lib/jenkins/pytorch/c10/macros/Macros.h:303:23: note: expanded from macro 'C10_WARP_SIZE'
23:14:28  [0m[91m#define C10_WARP_SIZE 64
23:14:28  [0m[91m                      ^
23:14:28  [0m[91m/opt/rocm/include/hipcub/backend/rocprim/warp/../block/block_merge_sort.hpp:171:15: note: to match this '('
23:14:28  [0m[91m/var/lib/jenkins/pytorch/aten/src/ATen/native/hip/Loops.cuh:13:21: note: expanded from macro 'NUM_THREADS'
23:14:28  [0m[91m#define NUM_THREADS (C10_WARP_SIZE * 2)
23:14:28  [0m[91m           
```

