### PR TITLE
Enable atomicAddNoRet() for all gfx targets

### DIFF
--- a/aten/src/THC/THCAtomics.cuh
+++ b/aten/src/THC/THCAtomics.cuh
@@ -301,7 +301,7 @@ static inline __device__ void gpuAtomicAddNoReturn(at::BFloat16 *address, at::BF
 static inline __device__ void gpuAtomicAddNoReturn(double *address, double val) { gpuAtomicAdd(address, val); }
 
 /* Special case fp32 atomic. */
-#if defined(__HIP_PLATFORM_HCC__) && defined(__gfx908__)
+#if defined(__HIP_PLATFORM_HCC__)
 static inline __device__ void gpuAtomicAddNoReturn(float *address, float val) { atomicAddNoRet(address, val); }
 #else
 static inline __device__ void gpuAtomicAddNoReturn(float *address, float val) { gpuAtomicAdd(address, val); }


### PR DESCRIPTION
Enable atomicAddNoRet() for all gfx targets

cc: @jithunnair-amd @jeffdaily