### PR TITLE
Update kineto submodule to use commit with mutex fix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -135,7 +135,7 @@
 	url = https://github.com/NVIDIA/cudnn-frontend.git
 [submodule "third_party/kineto"]
     path = third_party/kineto
-    url = https://github.com/pytorch/kineto
+    url = https://github.com/ROCmSoftwarePlatform/kineto
 [submodule "third_party/pocketfft"]
 	path = third_party/pocketfft
 	url = https://github.com/mreineck/pocketfft


### PR DESCRIPTION
Fixes https://ontrack-internal.amd.com/browse/SWDEV-337213:
Compilation error: 
```
[2022-05-16T08:06:50.333Z] [0m[91mIn file included from /var/lib/jenkins/pytorch/third_party/kineto/libkineto/src/RoctracerActivityApi.cpp:3:
[2022-05-16T08:06:50.333Z] [0m[91m/var/lib/jenkins/pytorch/third_party/kineto/libkineto/src/RoctracerActivityApi.h:163:8: error: mutex in namespace std does not name a type
[2022-05-16T08:06:50.333Z] [0m[91m  163 |   std::mutex mutex_;
[2022-05-16T08:06:50.333Z] [0m[91m      |        ^~~~~
[2022-05-16T08:06:50.333Z] [0m[91m/var/lib/jenkins/pytorch/third_party/kineto/libkineto/src/RoctracerActivityApi.h:26:1: note: std::mutex is defined in header <mutex>; did you forget to #include <mutex>?
[2022-05-16T08:06:50.333Z] [0m[91m   25 | #include "RoctracerActivityBuffer.h"
[2022-05-16T08:06:50.333Z] [0m[91m  +++ |+#include <mutex>
[2022-05-16T08:06:50.333Z] 26 
```
