### PR TITLE
[ROCm] Disable TestDataParallelDeviceType tests

### DIFF
--- a/test/distributed/test_data_parallel.py
+++ b/test/distributed/test_data_parallel.py
@@ -17,6 +17,7 @@ from torch.testing._internal.common_utils import run_tests, TestCase
 from torch.testing._internal.common_utils import _assertGradAndGradgradChecks, gradcheck
 from torch.testing._internal.common_utils import dtype2prec_DONTUSE
 from torch.testing._internal.common_utils import sandcastle_skip_if
+from torch.testing._internal.common_utils import TEST_WITH_ROCM
 import torch.nn.functional as F
 
 torch.set_default_dtype(torch.double)
@@ -784,6 +785,7 @@ class TestDataParallelDeviceType(TestCase):
 
     @onlyCUDA
     @skipMeta
+    @sandcastle_skip_if(TEST_WITH_ROCM, "Failing on few archs, temporarily skipped")
     @dtypes(torch.float, torch.double, torch.half)
     def test_data_parallel_module(self, device, dtype):
         l = nn.Linear(10, 5).to(device, dtype)
@@ -796,6 +798,7 @@ class TestDataParallelDeviceType(TestCase):
 
     @onlyCUDA
     @skipMeta
+    @sandcastle_skip_if(TEST_WITH_ROCM, "Failing on few archs, temporarily skipped")
     @dtypes(torch.float, torch.double, torch.half)
     def test_data_parallel_module_kwargs_only(self, device, dtype):
         class Net(nn.Module):
@@ -816,6 +819,7 @@ class TestDataParallelDeviceType(TestCase):
 
     @onlyCUDA
     @skipMeta
+    @sandcastle_skip_if(TEST_WITH_ROCM, "Failing on few archs, temporarily skipped")
     @dtypes(torch.float, torch.double, torch.half)
     def test_data_parallel_module_kwargs_only_empty_list(self, device, dtype):
         class Net(nn.Module):
@@ -836,6 +840,7 @@ class TestDataParallelDeviceType(TestCase):
 
     @onlyCUDA
     @skipMeta
+    @sandcastle_skip_if(TEST_WITH_ROCM, "Failing on few archs, temporarily skipped")
     @dtypes(torch.float, torch.double, torch.half)
     def test_data_parallel_module_kwargs_only_empty_dict(self, device, dtype):
         class Net(nn.Module):
@@ -856,6 +861,7 @@ class TestDataParallelDeviceType(TestCase):
 
     @onlyCUDA
     @skipMeta
+    @sandcastle_skip_if(TEST_WITH_ROCM, "Failing on few archs, temporarily skipped")
     @dtypes(torch.float, torch.double, torch.half)
     def test_data_parallel_module_kwargs_only_empty_tuple(self, device, dtype):
         class Net(nn.Module):


### PR DESCRIPTION
Skips test as per https://ontrack-internal.amd.com/browse/SWDEV-327377
distributed/test_data_parallel  test suite fails, disabling these tests will make the suite pass.
The issue is currently under debug.

Signed-off-by: Jagadish Krishnamoorthy <jagdish.krishna@gmail.com>

