### PR TITLE
[Do not MERGE] Enable test_data_parallel

### DIFF
--- a/test/distributed/test_data_parallel.py
+++ b/test/distributed/test_data_parallel.py
@@ -12,12 +12,11 @@ from torch import nn
 from torch.cuda.amp import autocast
 import torch.nn.parallel as dp
 from torch.testing._internal.common_cuda import TEST_MULTIGPU, TEST_CUDA
-from torch.testing._internal.common_device_type import instantiate_device_type_tests, dtypes, onlyCUDA, skipMeta
+from torch.testing._internal.common_device_type import dtypes, onlyCUDA
 from torch.testing._internal.common_utils import run_tests, TestCase
 from torch.testing._internal.common_utils import _assertGradAndGradgradChecks, gradcheck
 from torch.testing._internal.common_utils import dtype2prec_DONTUSE
 from torch.testing._internal.common_utils import sandcastle_skip_if
-from torch.testing._internal.common_utils import TEST_WITH_ROCM
 from torch.testing._internal.common_utils import repeat_test_for_types, ALL_TENSORTYPES
 import torch.nn.functional as F
 

--- a/test/distributed/test_data_parallel.py
+++ b/test/distributed/test_data_parallel.py
@@ -18,6 +18,7 @@ from torch.testing._internal.common_utils import _assertGradAndGradgradChecks, g
 from torch.testing._internal.common_utils import dtype2prec_DONTUSE
 from torch.testing._internal.common_utils import sandcastle_skip_if
 from torch.testing._internal.common_utils import TEST_WITH_ROCM
+from torch.testing._internal.common_utils import repeat_test_for_types, ALL_TENSORTYPES
 import torch.nn.functional as F
 
 torch.set_default_dtype(torch.double)
@@ -783,11 +784,10 @@ class TestDataParallel(TestCase):
 
 class TestDataParallelDeviceType(TestCase):
 
-    @onlyCUDA
-    @skipMeta
-    @sandcastle_skip_if(TEST_WITH_ROCM, "Failing on few archs, temporarily skipped")
-    @dtypes(torch.float, torch.double, torch.half)
-    def test_data_parallel_module(self, device, dtype):
+    @sandcastle_skip_if(not TEST_CUDA, "CUDA unavailable")
+    @repeat_test_for_types(ALL_TENSORTYPES)
+    def test_data_parallel_module(self, dtype):
+        device = "cuda"
         l = nn.Linear(10, 5).to(device, dtype)
         i = torch.randn(20, 10, device=device, dtype=dtype)
         expected_out = l(i)
@@ -796,11 +796,10 @@ class TestDataParallelDeviceType(TestCase):
         self.assertEqual(out.get_device(), 0)
         self.assertEqual(out, expected_out, atol=dtype2prec_DONTUSE[dtype], rtol=0)
 
-    @onlyCUDA
-    @skipMeta
-    @sandcastle_skip_if(TEST_WITH_ROCM, "Failing on few archs, temporarily skipped")
-    @dtypes(torch.float, torch.double, torch.half)
-    def test_data_parallel_module_kwargs_only(self, device, dtype):
+    @sandcastle_skip_if(not TEST_CUDA, "CUDA unavailable")
+    @repeat_test_for_types(ALL_TENSORTYPES)
+    def test_data_parallel_module_kwargs_only(self, dtype):
+        device = "cuda"
         class Net(nn.Module):
             def __init__(self):
                 super(Net, self).__init__()
@@ -817,11 +816,10 @@ class TestDataParallelDeviceType(TestCase):
         self.assertEqual(out.get_device(), 0)
         self.assertEqual(out, expected_out, atol=dtype2prec_DONTUSE[dtype], rtol=0)
 
-    @onlyCUDA
-    @skipMeta
-    @sandcastle_skip_if(TEST_WITH_ROCM, "Failing on few archs, temporarily skipped")
-    @dtypes(torch.float, torch.double, torch.half)
-    def test_data_parallel_module_kwargs_only_empty_list(self, device, dtype):
+    @sandcastle_skip_if(not TEST_CUDA, "CUDA unavailable")
+    @repeat_test_for_types(ALL_TENSORTYPES)
+    def test_data_parallel_module_kwargs_only_empty_list(self, dtype):
+        device = "cuda"
         class Net(nn.Module):
             def __init__(self):
                 super(Net, self).__init__()
@@ -838,11 +836,10 @@ class TestDataParallelDeviceType(TestCase):
         self.assertEqual(out.get_device(), 0)
         self.assertEqual(out, expected_out, atol=dtype2prec_DONTUSE[dtype], rtol=0)
 
-    @onlyCUDA
-    @skipMeta
-    @sandcastle_skip_if(TEST_WITH_ROCM, "Failing on few archs, temporarily skipped")
-    @dtypes(torch.float, torch.double, torch.half)
-    def test_data_parallel_module_kwargs_only_empty_dict(self, device, dtype):
+    @sandcastle_skip_if(not TEST_CUDA, "CUDA unavailable")
+    @repeat_test_for_types(ALL_TENSORTYPES)
+    def test_data_parallel_module_kwargs_only_empty_dict(self, dtype):
+        device = "cuda"
         class Net(nn.Module):
             def __init__(self):
                 super(Net, self).__init__()
@@ -859,11 +856,10 @@ class TestDataParallelDeviceType(TestCase):
         self.assertEqual(out.get_device(), 0)
         self.assertEqual(out, expected_out, atol=dtype2prec_DONTUSE[dtype], rtol=0)
 
-    @onlyCUDA
-    @skipMeta
-    @sandcastle_skip_if(TEST_WITH_ROCM, "Failing on few archs, temporarily skipped")
-    @dtypes(torch.float, torch.double, torch.half)
-    def test_data_parallel_module_kwargs_only_empty_tuple(self, device, dtype):
+    @sandcastle_skip_if(not TEST_CUDA, "CUDA unavailable")
+    @repeat_test_for_types(ALL_TENSORTYPES)
+    def test_data_parallel_module_kwargs_only_empty_tuple(self, dtype):
+        device = "cuda"
         class Net(nn.Module):
             def __init__(self):
                 super(Net, self).__init__()
@@ -881,7 +877,7 @@ class TestDataParallelDeviceType(TestCase):
         self.assertEqual(out, expected_out, atol=dtype2prec_DONTUSE[dtype], rtol=0)
 
 
-instantiate_device_type_tests(TestDataParallelDeviceType, globals())
+#instantiate_device_type_tests(TestDataParallelDeviceType, globals())
 
 if __name__ == '__main__':
     run_tests()

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -532,6 +532,20 @@ def shell(command, cwd=None, env=None):
     p = subprocess.Popen(command, universal_newlines=True, cwd=cwd, env=env)
     return wait_for_process(p)
 
+ALL_TENSORTYPES = [torch.float,
+                   torch.double,
+                   torch.half]
+
+def repeat_test_for_types(dtypes):
+    def repeat_helper(f):
+        @wraps(f)
+        def call_helper(self, *args):
+            for dtype in dtypes:
+                with TestCase.subTest(self, dtype=dtype):
+                    f(self, *args, dtype=dtype)
+
+        return call_helper
+    return repeat_helper
 
 def discover_test_cases_recursively(suite_or_case):
     if isinstance(suite_or_case, unittest.TestCase):


### PR DESCRIPTION
 Use the earlier way of repeat_test instead of instantiate_device_type_tests()

ToDo: debug why the newer method of test fails
