### PR TITLE
Use the right sudo depending on OS

### DIFF
--- a/.circleci/docker/common/install_user.sh
+++ b/.circleci/docker/common/install_user.sh
@@ -22,5 +22,12 @@ chown jenkins:jenkins /usr/local
 # TODO: Maybe we shouldn't
 echo 'jenkins ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/jenkins
 
+# Work around bug where devtoolset replaces sudo and breaks it.
+if [ -n "$DEVTOOLSET_VERSION" ]; then
+  SUDO=/bin/sudo
+else
+  SUDO=sudo
+fi
+
 # Test that sudo works
-sudo -u jenkins sudo -v
+$SUDO -u jenkins $SUDO -v


### PR DESCRIPTION
Fixes issues such as [SWDEV-339205](https://ontrack-internal.amd.com/browse/SWDEV-339205) for rocm5.3_internal_testing

Use /bin/sudo to avoid issue on CentOS: https://bugzilla.redhat.com/show_bug.cgi?id=1319936