### PR TITLE
[rocm5.3_internal_testing] Install miopenkernels package for CentOS

### DIFF
--- a/.circleci/docker/common/install_rocm.sh
+++ b/.circleci/docker/common/install_rocm.sh
@@ -135,6 +135,15 @@ install_centos() {
                    rocprofiler-dev \
                    roctracer-dev
 
+  # precompiled miopen kernels; search for all unversioned packages
+  # if search fails it will abort this script; use true to avoid case where search fails
+  MIOPENKERNELS=$(yum -q search miopenkernels | grep miopenkernels- | awk '{print $1}'| grep -F kdb. || true)
+  if [[ "x${MIOPENKERNELS}" = x ]]; then
+    echo "miopenkernels package not available"
+  else
+    yum install -y ${MIOPENKERNELS}
+  fi
+
   install_magma
 
   # Cleanup


### PR DESCRIPTION
We already install the miopenkernels packages for Ubuntu. Need to do the same for CentOS.