### PR TITLE
Remove -ltinfo from libtorch and use -rpath-link instead.

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1583,7 +1583,7 @@ if(USE_CUDA)
     target_link_libraries(torch_cuda PUBLIC torch_cuda_cu_library)
   endif()
 elseif(USE_ROCM)
-  target_link_libraries(torch PUBLIC torch_hip_library -ltinfo)
+  target_link_libraries(torch PUBLIC torch_hip_library)
 endif()
 
 if(PRINT_CMAKE_DEBUG_INFO)

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1247,6 +1247,19 @@ endif()
 
 # ---[ HIP
 if(USE_ROCM)
+  # This prevents linking in the libtinfo from /opt/conda/lib which conflicts with ROCm libtinfo.
+  # Currently only active for Ubuntu 20.04.
+  if(UNIX)
+    execute_process(COMMAND bash -c "cat /etc/os-release | grep -o -m 1 focal" OUTPUT_VARIABLE OS_FOCAL)
+    if(OS_FOCAL)
+      find_library(LIBTINFO_LOC tinfo NO_CMAKE_PATH NO_CMAKE_ENVIRONMENT_PATH)
+      if(LIBTINFO_LOC)
+        get_filename_component(LIBTINFO_LOC_PARENT ${LIBTINFO_LOC} DIRECTORY)
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-rpath-link,${LIBTINFO_LOC_PARENT}")
+      endif()
+    endif()
+  endif()
+
   include(${CMAKE_CURRENT_LIST_DIR}/public/LoadHIP.cmake)
   if(PYTORCH_FOUND_HIP)
     message(INFO "Compiling with HIP for AMD.")


### PR DESCRIPTION
This prevents linking in the wrong libtinfo in
/opt/conda/lib, which conflicts with the libtinfo
ROCm built with at /usr/lib/x86_64-linux-gnu.
Currently only active for Ubuntu 20.04.
