### PR TITLE
Use -rpath-link to fix libtinfo conflict.

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1247,6 +1247,19 @@ endif()
 
 # ---[ HIP
 if(USE_ROCM)
+  # This prevents linking in the libtinfo from /opt/conda/lib which conflicts with ROCm libtinfo.
+  # Currently only active for Ubuntu 20.04 and greater versions.
+  if(UNIX)
+    execute_process(COMMAND bash -c "cat /etc/os-release | grep VERSION_ID | awk -F\\\" '{print $2}'" OUTPUT_VARIABLE OS_VERSION)
+    if(OS_VERSION VERSION_GREATER_EQUAL "20.04")
+      find_library(LIBTINFO_LOC tinfo NO_CMAKE_PATH NO_CMAKE_ENVIRONMENT_PATH)
+      if(LIBTINFO_LOC)
+        get_filename_component(LIBTINFO_LOC_PARENT ${LIBTINFO_LOC} DIRECTORY)
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-rpath-link,${LIBTINFO_LOC_PARENT}")
+      endif()
+    endif()
+  endif()
+
   include(${CMAKE_CURRENT_LIST_DIR}/public/LoadHIP.cmake)
   if(PYTORCH_FOUND_HIP)
     message(INFO "Compiling with HIP for AMD.")


### PR DESCRIPTION
The ROCm libtinfo6 is conflicting with the libtinfo6
installed in the conda envirnonment in /opt/conda/lib.
This is first in the build rpath and causes issues on
Ubuntu 20.04 when resolving libamd_comgr.so
dependencies. Use -rpath-link to resolve dependencies
where the system libtinfo is found instead. This is
currently active on versions >= 20.04.
