### PR TITLE
[SOW MS3] Enable hipSOLVER for test_ops* (#2104)

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -27,7 +27,7 @@ from torch.testing._internal.common_dtype import (
 from torch.testing._internal.common_device_type import \
     (onlyCUDA, onlyNativeDeviceTypes, disablecuDNN, skipCUDAIfNoMagma, skipCUDAIfNoMagmaAndNoCusolver,
      skipCUDAIfNoCusolver, skipCPUIfNoLapack, skipCPUIfNoFFT, skipCUDAIfRocm, skipCUDAIf, precisionOverride,
-     skipCPUIfNoMklSparse,
+     skipCUDAIfNoCusolverAndNoHipsolver, skipCPUIfNoMklSparse,
      toleranceOverride, tol, has_cusolver)
 from torch.testing._internal.common_cuda import (
     CUDA11OrLater, SM53OrLater, SM60OrLater, with_tf32_off, TEST_CUDNN,
@@ -12286,7 +12286,7 @@ op_db: List[OpInfo] = [
            check_batched_forward_grad=False,
            sample_inputs_func=sample_inputs_householder_product,
            decorators=[
-               skipCUDAIfNoCusolver, skipCPUIfNoLapack,
+               skipCUDAIfNoCusolverAndNoHipsolver, skipCPUIfNoLapack,
                DecorateInfo(toleranceOverride({torch.complex64: tol(atol=1e-3, rtol=1e-3)})),
                DecorateInfo(unittest.expectedFailure, 'TestCompositeCompliance', 'test_backward'),
                DecorateInfo(unittest.expectedFailure, 'TestCompositeCompliance', 'test_forward_ad'),
@@ -14954,7 +14954,7 @@ op_db: List[OpInfo] = [
            supports_autograd=False,
            sample_inputs_func=sample_inputs_ormqr,
            error_inputs_func=error_inputs_ormqr,
-           decorators=[skipCUDAIfNoCusolver, skipCPUIfNoLapack],
+           decorators=[skipCUDAIfNoCusolverAndNoHipsolver, skipCPUIfNoLapack],
            skips=(
                # ormqr does not support forward when complex inputs require grad
                DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_dtypes'),


### PR DESCRIPTION
Use skipCUDAIfNoCusolverAndNoHipsolver replacing skipCUDAIfNoCusolver only for decorators list of:
- linalg.householder_product
- ormqr

Fixes [#2104](https://github.com/ROCmSoftwarePlatform/frameworks-internal/issues/2104)

Unit tests results:
test_out_linalg_householder_product_cuda_float32 (__main__.TestCommonCUDA) ... ok (3.980s)
test_conj_view_linalg_householder_product_cuda_complex64 (__main__.TestMathBitsCUDA) ... ok (6.892s)
test_conj_view_ormqr_cuda_complex64 (__main__.TestMathBitsCUDA) ... ok (3.815s)
test_dtypes_linalg_householder_product_cuda (__main__.TestCommonCUDA) ... ok (7.214s)
test_fn_grad_linalg_householder_product_cuda_complex128 (__main__.TestGradientsCUDA) ... ok (7.296s)
test_fn_grad_linalg_householder_product_cuda_float64 (__main__.TestGradientsCUDA) ... ok (6.974s)
test_fn_gradgrad_linalg_householder_product_cuda_complex128 (__main__.TestGradientsCUDA) ... ok (10.860s)
test_fn_gradgrad_linalg_householder_product_cuda_float64 (__main__.TestGradientsCUDA) ... ok (7.819s)
test_forward_mode_AD_linalg_householder_product_cuda_complex128 (__main__.TestGradientsCUDA) ... ok (7.307s)
test_forward_mode_AD_linalg_householder_product_cuda_float64 (__main__.TestGradientsCUDA) ... ok (6.966s)
test_jit_alias_remapping_linalg_householder_product_cuda_float32 (__main__.TestJitCUDA) ... ok (3.453s)
test_neg_view_linalg_householder_product_cuda_float64 (__main__.TestMathBitsCUDA) ... ok (6.868s)
test_neg_view_ormqr_cuda_float64 (__main__.TestMathBitsCUDA) ... ok (3.841s)
test_variant_consistency_eager_linalg_householder_product_cuda_complex64 (__main__.TestCommonCUDA) ... /opt/conda/lib/python3.7/site-packages/torch/_tensor.py:1077: UserWarning: The .grad attribute of a Tensor that 
is not a leaf Tensor is being accessed. Its .grad attribute won't be populated during autograd.backward(). If you indeed want the .grad field to be populated for a non-leaf Tensor, use .retain_grad() on the non-leaf Tensor. If you access the non-leaf Tensor by mistake, make sure you access the leaf Tensor instead. See github.com/pytorch/pytorch/pull/30531 for more informations. (Triggered internally at  /dockerx/sow_ms3/pytorch/build/aten/src/ATen/core/TensorBody.h:477.)  return self._grad ... ok (6.902s)
test_variant_consistency_eager_linalg_householder_product_cuda_float32 (__main__.TestCommonCUDA) ... ok (5.973s)
test_variant_consistency_eager_ormqr_cuda_complex64 (__main__.TestCommonCUDA) ... ok (3.398s)
test_variant_consistency_eager_ormqr_cuda_float32 (__main__.TestCommonCUDA) ... ok (3.643s)
test_variant_consistency_jit_linalg_householder_product_cuda_complex64 (__main__.TestJitCUDA) ... ok (7.733s)
test_variant_consistency_jit_linalg_householder_product_cuda_float32 (__main__.TestJitCUDA) ... ok (8.091s)
test_variant_consistency_jit_ormqr_cuda_complex64 (__main__.TestJitCUDA) ... ok (10.059s)
test_variant_consistency_jit_ormqr_cuda_float32 (__main__.TestJitCUDA) ... ok (7.563s)