### PR TITLE
[SOW MS3] Pickle and cuda_test

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -2604,7 +2604,6 @@ torch.cuda.synchronize()
     # Test is flaky on Windows (https://github.com/pytorch/pytorch/issues/57401)
     @unittest.skipIf(IS_WINDOWS, 'Test is flaky on Windows (see issue 57401)')
     @unittest.skipIf(not TEST_CUDNN, 'CUDNN not available')
-    @skipIfRocm
     def test_cudnn_multiple_threads_same_device(self):
         # This function is intended to test the lazy creation and reuse of per-thread
         # cudnn handles on each device in aten/src/ATen/cudnn/Handles.cpp.

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -2933,7 +2933,6 @@ class TestSparse(TestCase):
         self.assertEqual(list(t.coalesce().indices().size()), [2, 1])
         self.assertEqual(list(t.coalesce().values().size()), [1, 3])
 
-    @skipIfRocm
     @coalescedonoff
     @dtypes(torch.double)
     def test_pickle(self, device, dtype, coalesced):

--- a/torch/csrc/serialization.cpp
+++ b/torch/csrc/serialization.cpp
@@ -183,7 +183,17 @@ void THPStorage_writeFileRaw(c10::StorageImpl *self, io fd, bool save_size, uint
   int64_t numel = size_bytes / element_size;
   if (self->device_type() == at::kCPU) {
     data = self->data<uint8_t>();
-#ifdef USE_CUDA
+#if defined(USE_CUDA) && defined(TORCH_HIP_VERSION) && (TORCH_HIP_VERSION >= 301)
+  } else if (self->device_type() == at::kCUDA) {
+    cpu_data = std::unique_ptr<char[]>(new char[size_bytes]);
+    data = (uint8_t*)cpu_data.get();
+    C10_CUDA_CHECK(hipMemcpyWithStream(
+        data,
+        self->data<uint8_t>(),
+        size_bytes,
+        cudaMemcpyDeviceToHost,
+        c10::hip::getCurrentHIPStreamMasqueradingAsCUDA()));
+#elif defined(USE_CUDA)
   } else if (self->device_type() == at::kCUDA) {
     cpu_data = std::unique_ptr<char[]>(new char[size_bytes]);
     data = (uint8_t*)cpu_data.get();
@@ -335,8 +345,15 @@ c10::intrusive_ptr<c10::StorageImpl> THPStorage_readFileRaw(
       }
     }
   }
-
-#ifdef USE_CUDA
+#if defined(USE_CUDA) && defined(TORCH_HIP_VERSION) && (TORCH_HIP_VERSION >= 301)
+  if (storage->device_type() == at::kCUDA) {
+    C10_CUDA_CHECK(hipMemcpyWithStream(storage->data<uint8_t>(),
+          data,
+          nbytes,
+          cudaMemcpyHostToDevice,
+          c10::hip::getCurrentHIPStreamMasqueradingAsCUDA()));
+  }
+#elif defined(USE_CUDA)
   if (storage->device_type() == at::kCUDA) {
     C10_CUDA_CHECK(cudaMemcpy(storage->data<uint8_t>(), data, nbytes, cudaMemcpyHostToDevice));
   }


### PR DESCRIPTION
Fixes serialization synchronization issue 
Enables:
test_cuda test_cudnn_multiple_threads_same_device (main.TestCuda)
test_sparse test_pickle_cuda_float64 (__main__.TestSparseCUDA)