### PR TITLE
[SOW MS3]: Renable test_openmp and tensorexpr for ROCM

### DIFF
--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -65,8 +65,13 @@ fi
 pip_install -r requirements.txt || true
 
 # Enable LLVM dependency for TensorExpr testing
-export USE_LLVM=/opt/llvm
-export LLVM_DIR=/opt/llvm/lib/cmake/llvm
+if [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
+  export USE_LLVM=/opt/rocm/llvm
+  export LLVM_DIR=/opt/rocm/llvm/lib/cmake/llvm
+else
+  export USE_LLVM=/opt/llvm
+  export LLVM_DIR=/opt/llvm/lib/cmake/llvm
+fi
 
 # TODO: Don't install this here
 if ! which conda; then

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -251,7 +251,6 @@ ROCM_BLOCKLIST = [
     "distributed/_shard/test_replicated_tensor",
     "test_determination",
     "test_jit_legacy",
-    "test_openmp",
 ]
 
 RUN_PARALLEL_BLOCKLIST = [


### PR DESCRIPTION
The following 12 tests are being re-enabled for ROCM:

test_openmp test_n_threads (main.TestOpenMP_ParallelFor)
test_openmp test_one_thread (main.TestOpenMP_ParallelFor)
And
test_tensorexpr_pybind test_alloc_in_loop (main.TestTensorExprPyBind)
test_tensorexpr_pybind test_kernel_shape_prop (main.TestTensorExprPyBind)
test_tensorexpr_pybind test_kernel_shape_prop_module (main.TestTensorExprPyBind)
test_tensorexpr_pybind test_kernel_with_custom_lowering (main.TestTensorExprPyBind)
test_tensorexpr_pybind test_kernel_with_expand (main.TestTensorExprPyBind)
test_tensorexpr_pybind test_kernel_with_permute (main.TestTensorExprPyBind)
test_tensorexpr_pybind test_kernel_with_scalar_inputs (main.TestTensorExprPyBind)
test_tensorexpr_pybind test_kernel_with_t (main.TestTensorExprPyBind)
test_tensorexpr_pybind test_kernel_with_tensor_inputs (main.TestTensorExprPyBind)
test_tensorexpr_pybind test_kernel_with_transpose (main.TestTensorExprPyBind)