### PR TITLE
[SOW MS3] Transient mem leak error check fix

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1646,8 +1646,6 @@ except RuntimeError as e:
             _test(1)
 
     # Test that wrap_with_cuda_memory_check successfully detects leak
-    # skip for ROCM. Look into #62533.
-    @skipIfRocm
     def test_cuda_memory_leak_detection(self):
         l = []
 

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1379,6 +1379,7 @@ class CudaMemoryLeakCheck():
                 if not( caching_allocator_discrepancy or driver_discrepancy):
                     # Leak was false positive
                     discrepancy_detected = False
+                    break
 
             if not discrepancy_detected:
                 continue
@@ -1403,7 +1404,7 @@ class CudaMemoryLeakCheck():
                 warnings.warn(msg)
             elif caching_allocator_discrepancy and driver_discrepancy:
                 # A caching allocator discrepancy validated by the driver API is a
-                #   failure (except on ROCm, see below)
+                #   failure
                 msg = ("CUDA driver API confirmed a leak in {}! "
                        "Caching allocator allocated memory was {} and is now reported as {} "
                        "on device {}. "

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1358,18 +1358,30 @@ class CudaMemoryLeakCheck():
         torch.cuda.empty_cache()
 
         for i in range(num_devices):
-            caching_allocator_mem_allocated = torch.cuda.memory_allocated(i)
-            bytes_free, bytes_total = torch.cuda.mem_get_info(i)
-            driver_mem_allocated = bytes_total - bytes_free
 
-            caching_allocator_discrepancy = False
-            driver_discrepancy = False
+            discrepancy_detected = True
 
-            if caching_allocator_mem_allocated > self.caching_allocator_befores[i]:
+            # Query memory multiple tiems to ensure leak was not transient
+            for n in range(3):
+                caching_allocator_mem_allocated = torch.cuda.memory_allocated(i)
+                bytes_free, bytes_total = torch.cuda.mem_get_info(i)
+                driver_mem_allocated = bytes_total - bytes_free
+
+                caching_allocator_discrepancy = False
+                driver_discrepancy = False
+
+                if caching_allocator_mem_allocated > self.caching_allocator_befores[i]:
                 caching_allocator_discrepancy = True
 
-            if driver_mem_allocated > self.driver_befores[i]:
+                if driver_mem_allocated > self.driver_befores[i]:
                 driver_discrepancy = True
+
+                if not( caching_allocator_discrepancy or driver_discrepancy):
+                    # Leak was false positive
+                    discrepancy_detected = False
+
+            if not discrepancy_detected:
+                continue
 
             if caching_allocator_discrepancy and not driver_discrepancy:
                 # Just raises a warning if the leak is not validated by the
@@ -1403,12 +1415,7 @@ class CudaMemoryLeakCheck():
                     self.driver_befores[i],
                     driver_mem_allocated)
 
-                # See #62533
-                # ROCM: Sometimes the transient memory is reported as leaked memory
-                if TEST_WITH_ROCM:
-                    warnings.warn(msg)
-                else:
-                    raise RuntimeError(msg)
+                raise RuntimeError(msg)
 
 @contextmanager
 def skip_exception_type(exc_type):

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1371,10 +1371,10 @@ class CudaMemoryLeakCheck():
                 driver_discrepancy = False
 
                 if caching_allocator_mem_allocated > self.caching_allocator_befores[i]:
-                caching_allocator_discrepancy = True
+                    caching_allocator_discrepancy = True
 
                 if driver_mem_allocated > self.driver_befores[i]:
-                driver_discrepancy = True
+                    driver_discrepancy = True
 
                 if not( caching_allocator_discrepancy or driver_discrepancy):
                     # Leak was false positive


### PR DESCRIPTION
Add retry loop to memory leak check to allow potential transient memory leak to correct itself