### PR TITLE
[SOW MS3]: Enable test_filtering_env_var

### DIFF
--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -450,7 +450,6 @@ instantiate_device_type_tests(TestTesting, globals())
 
 class TestFrameworkUtils(TestCase):
 
-    @skipIfRocm
     @unittest.skipIf(IS_WINDOWS, "Skipping because doesn't work for windows")
     @unittest.skipIf(IS_SANDCASTLE, "Skipping because doesn't work on sandcastle")
     def test_filtering_env_var(self):

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -610,11 +610,6 @@ def instantiate_device_type_tests(generic_test_class, scope, except_for=None, on
 
     # Creates device-specific test cases
     for base in desired_device_type_test_bases:
-        # Special-case for ROCm testing -- only test for 'cuda' i.e. ROCm device by default
-        # The except_for and only_for cases were already checked above. At this point we only need to check 'cuda'.
-        if TEST_WITH_ROCM and base.device_type != 'cuda':
-            continue
-
         class_name = generic_test_class.__name__ + base.device_type.upper()
 
         # type set to Any and suppressed due to unsupport runtime class:


### PR DESCRIPTION
The test "test_filtering_env_var" requires CPU runner along with GPU.
For ROCm, instantiate_device_type_tests() instantiates GPU runner only.
Revert the upstream PR 55069 to instantiate CPU runner along with GPU.

Signed-off-by: Jagadish Krishnamoorthy <jagdish.krishna@gmail.com>

