### PR TITLE
[SOW MS3]: Enable test_batchnorm_cudnn_nhwc 

### DIFF
--- a/aten/src/ATen/native/Normalization.cpp
+++ b/aten/src/ATen/native/Normalization.cpp
@@ -521,7 +521,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, int64_t> _batch_norm_impl_index(
                && cudnn_enabled
                );
 
-  if (use_miopen) {
+  if (use_miopen && input.suggest_memory_format() != MemoryFormat::ChannelsLast && input.suggest_memory_format() != MemoryFormat::ChannelsLast3d) {
     return std::tuple_cat(
              at::miopen_batch_norm(
                input.contiguous(), weight.contiguous(), bias.contiguous(),

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9812,7 +9812,6 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
 
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     @unittest.skipIf(not TEST_CUDNN, "needs cudnn")
-    @skipIfRocm
     def test_batchnorm_cudnn_nhwc(self):
         def run_test(input, grad_output):
             c = input.size(1)


### PR DESCRIPTION
test_nn.py::TestNN::test_batchnorm_cudnn_nhwc test passes by cherry picking change from PR [skip miopen batchnorm if channels_last (NHWC)](https://github.com/ROCmSoftwarePlatform/pytorch/pull/1025)
