### PR TITLE
Add support for miopen version in test_autocast_rnn

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -3057,7 +3057,7 @@ torch.cuda.synchronize()
                 # Autocast wrapper requires at::_cudnn_rnn is autograd-exposed.  This check can't guarantee
                 # at::_cudnn_rnn is autograd-exposed, but if it fires, it indicates some funny business has
                 # occurred and we should double check that at::_cudnn_rnn remains autograd-exposed.
-                self.assertEqual(out.grad_fn.name(), "CudnnRnnBackward0")
+                self.assertEqual(out.grad_fn.name(), "CudnnRnnBackward0" if not TEST_WITH_ROCM else "MiopenRnnBackward0")
                 out.sum().backward()
                 grads = [p.grad.clone() for p in rnn.parameters()]
 

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -3057,7 +3057,7 @@ torch.cuda.synchronize()
                 # Autocast wrapper requires at::_cudnn_rnn is autograd-exposed.  This check can't guarantee
                 # at::_cudnn_rnn is autograd-exposed, but if it fires, it indicates some funny business has
                 # occurred and we should double check that at::_cudnn_rnn remains autograd-exposed.
-                self.assertEqual(out.grad_fn.name(), "CudnnRnnBackward0" if not TEST_WITH_ROCM else "MiopenRnnBackward0")
+                self.assertEqual(True, out.grad_fn.name() in ("CudnnRnnBackward0", "MiopenRnnBackward0"))
                 out.sum().backward()
                 grads = [p.grad.clone() for p in rnn.parameters()]
 


### PR DESCRIPTION
This test currently only handles the cudnn case. This commit addresses the assertion passes in the miopen case