### PR TITLE
Update related_commits with torchdata

### DIFF
--- a/related_commits
+++ b/related_commits
@@ -4,3 +4,5 @@ ubuntu|pytorch|torchvision|main|369317f45354248582884f6e2f500b7cebea2236|https:/
 centos|pytorch|torchvision|main|369317f45354248582884f6e2f500b7cebea2236|https://github.com/pytorch/vision
 ubuntu|pytorch|torchtext|main|99c2735662a3b3701853e2a76d4c0b1df5bafa70|https://github.com/ROCmSoftwarePlatform/text
 centos|pytorch|torchtext|main|99c2735662a3b3701853e2a76d4c0b1df5bafa70|https://github.com/ROCmSoftwarePlatform/text
+ubuntu|pytorch|torchdata|main|983e87ada583b7a58d13a1a5f047dd9d256155dd|https://github.com/pytorch/data
+centos|pytorch|torchdata|main|983e87ada583b7a58d13a1a5f047dd9d256155dd|https://github.com/pytorch/data


### PR DESCRIPTION
Add torchdata to the related_commits file so it can be used in building/verifying torchtext.