### PR TITLE
[SOW MS3] Enable test_sparse_matmul on floats on ROCm5.3

### DIFF
--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -9,7 +9,7 @@ import unittest
 from torch.testing import make_tensor
 from torch.testing._internal.common_utils import TestCase, run_tests, skipIfRocm, do_test_dtypes, \
     do_test_empty_full, load_tests, TEST_NUMPY, IS_WINDOWS, gradcheck, coalescedonoff, \
-    DeterministicGuard, first_sample, TEST_WITH_ROCM
+    DeterministicGuard, first_sample, TEST_WITH_ROCM, skipIfRocmVersionLessThan
 from torch.testing._internal.common_cuda import TEST_CUDA, _get_torch_cuda_version
 from numbers import Number
 from typing import Dict, Any
@@ -3312,7 +3312,7 @@ class TestSparse(TestCase):
         test_op(4, 100, [3, 4, 2, 3, 5, 2], coalesced)
 
     # TODO: Check after why ROCm's cusparseXcsrgemm2Nnz function doesn't return the same nnz value as CUDA
-    @skipIfRocm
+    @skipIfRocmVersionLessThan((5, 3))
     @coalescedonoff
     @dtypes(*floating_and_complex_types())
     @dtypesIfCUDA(*floating_types_and(*[torch.half] if CUDA11OrLater and SM53OrLater else [],


### PR DESCRIPTION

```
root@0452a021af59:/home/jpvillam/pytorch# export PYTORCH_TEST_WITH_ROCM=1
root@0452a021af59:/home/jpvillam/pytorch# python3 test/test_sparse.py -v -k test_sparse_matmul
test_sparse_matmul_cuda_float32 (__main__.TestSparseCUDA)
This function test `torch.sparse.mm` when both the mat1 and mat2 are sparse tensors. ... ok
test_sparse_matmul_cuda_float64 (__main__.TestSparseCUDA)
This function test `torch.sparse.mm` when both the mat1 and mat2 are sparse tensors. ... ok

----------------------------------------------------------------------
Ran 2 tests in 10.754s

OK
```

Tested on: `compute-artifactory.amd.com:5000/rocm-plus-docker/framework/compute-rocm-dkms-no-npi-hipclang:10473_ubuntu20.04_py3.7_pytorch_sow_ms3_f761bb`
