### PR TITLE
[SOW MS3] Remove test_sharded_tensor from ROCM_BLOCKLIST

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -234,7 +234,6 @@ ROCM_BLOCKLIST = [
     "distributed/_shard/sharding_spec/test_sharding_spec",
     "distributed/_shard/sharding_plan/test_sharding_plan",
     "distributed/_shard/sharded_tensor/test_megatron_prototype",
-    "distributed/_shard/sharded_tensor/test_sharded_tensor",
     "distributed/_shard/sharded_tensor/test_sharded_tensor_reshard",
     "distributed/_shard/sharded_tensor/ops/test_chunk",
     "distributed/_shard/sharded_tensor/ops/test_elementwise_ops",


### PR DESCRIPTION
Enables:
```
distributed/_sharded_tensor/test_sharded_tensor.test_empty
distributed/_sharded_tensor/test_sharded_tensor.test_serialize_and_deserialize
```
from SOW MS3 unit test parity list
which were moved to `distributed/_shard/sharded_tensor/test_sharded_tensor`























