### PR TITLE
[SOW MS3] Re-add CONST_QUALIFIER for rocm version less than 5.3

### DIFF
--- a/aten/src/ATen/native/cuda/linalg/CUDASolver.h
+++ b/aten/src/ATen/native/cuda/linalg/CUDASolver.h
@@ -9,10 +9,10 @@
 
 #if defined(CUDART_VERSION) || defined(ROCM_VERSION) && ROCM_VERSION >= 50200
 
-#ifdef CUDART_VERSION
-#define CONST_QUALIFIER const
+#if defined(CUDART_VERSION) || defined(ROCM_VERSION) && ROCM_VERSION >= 50300
+#define CONST_QUALIFIER CONST_QUALIFIER
 #else
-// hipSOLVER functions in current ROCM (5.2) miss CONST_QUALIFIER qualifiers
+// hipSOLVER functions in ROCM(5.2) do not support CONST_QUALIFIER qualifier
 #define CONST_QUALIFIER
 #endif
 


### PR DESCRIPTION
Const qualifier is only supported in hipSOLVER in ROCM 5.3. Reverting previous const changes and adding a conditional to check for ROCM version.
