### PR TITLE
Release/1.10 UT fixes

### DIFF
--- a/.circleci/docker/common/install_conda.sh
+++ b/.circleci/docker/common/install_conda.sh
@@ -121,9 +121,9 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
   # Install numba only on python-3.8 or below
   # For numba issue see https://github.com/pytorch/pytorch/issues/51511
   if [[ $(python -c "import sys; print(int(sys.version_info < (3, 9)))") == "1" ]]; then
-    as_jenkins pip install --progress-bar off numba librosa>=0.6.2
+    as_jenkins pip install --progress-bar off numba "librosa>=0.6.2<0.9.0"
   else
-    as_jenkins pip install --progress-bar off numba==0.49.0 librosa>=0.6.2
+    as_jenkins pip install --progress-bar off numba==0.49.0 "librosa>=0.6.2,<0.9.0"
   fi
 
   # Update scikit-learn to a python-3.8 compatible version

--- a/.circleci/docker/common/install_conda.sh
+++ b/.circleci/docker/common/install_conda.sh
@@ -73,11 +73,10 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
   # Install PyTorch conda deps, as per https://github.com/pytorch/pytorch README
   # DO NOT install cmake here as it would install a version newer than 3.10, but
   # we want to pin to version 3.10.
-  SCIPY_VERSION=1.1.0
+  SCIPY_VERSION=1.6.3
   if [ "$ANACONDA_PYTHON_VERSION" = "3.9" ]; then
     # Install llvm-8 as it is required to compile llvmlite-0.30.0 from source
     conda_install numpy=1.19.2 astunparse pyyaml mkl mkl-include setuptools cffi future six llvmdev=8.0.0 -c conda-forge
-    SCIPY_VERSION=1.6.0
   elif [ "$ANACONDA_PYTHON_VERSION" = "3.8" ]; then
     # Install llvm-8 as it is required to compile llvmlite-0.30.0 from source
     conda_install numpy=1.18.5 astunparse pyyaml mkl mkl-include setuptools cffi future six llvmdev=8.0.0

--- a/.jenkins/pytorch/macos-test.sh
+++ b/.jenkins/pytorch/macos-test.sh
@@ -7,7 +7,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/macos-common.sh"
 export PYTORCH_TEST_SKIP_NOARCH=1
 
 conda install -y six
-pip install -q hypothesis "expecttest==0.1.3" "librosa>=0.6.2" "numba<=0.49.1" psutil "scipy==1.6.3"
+pip install -q hypothesis "expecttest==0.1.3" "librosa>=0.6.2,<0.9.0" "numba<=0.49.1" psutil "scipy==1.6.3"
 
 # TODO move this to docker
 pip install unittest-xml-reporting pytest

--- a/.jenkins/pytorch/win-test-helpers/setup_pytorch_env.bat
+++ b/.jenkins/pytorch/win-test-helpers/setup_pytorch_env.bat
@@ -37,7 +37,7 @@ if %errorlevel% neq 0 ( exit /b %errorlevel% )
 popd
 
 :: The version is fixed to avoid flakiness: https://github.com/pytorch/pytorch/issues/31136
-pip install "ninja==1.10.0.post1" future "hypothesis==4.53.2" "expecttest==0.1.3" "librosa>=0.6.2" psutil pillow unittest-xml-reporting pytest
+pip install "ninja==1.10.0.post1" future "hypothesis==4.53.2" "expecttest==0.1.3" "librosa>=0.6.2,<0.9.0" psutil pillow unittest-xml-reporting pytest
 
 :: Only the CPU tests run coverage, which I know is not super clear: https://github.com/pytorch/pytorch/issues/56264
 if "%BUILD_ENVIRONMENT%" == "win-vs2019-cpu-py3" (

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -1632,7 +1632,12 @@ class TestLinalg(TestCase):
         a = torch.eye(3, dtype=dtype, device=device)
         a[-1, -1] = 0  # make 'a' singular
         for p in norm_types:
-            run_test_case(a, p)
+            try:
+                run_test_case(a, p)
+            except np.linalg.LinAlgError:
+                # Numpy may fail to converge for some BLAS backends (although this is very rare)
+                # See the discussion in https://github.com/pytorch/pytorch/issues/67675
+                pass
 
         # test for 0x0 matrices. NumPy doesn't work for such input, we return 0
         input_sizes = [(0, 0), (2, 5, 0, 0)]

--- a/test/test_spectral_ops.py
+++ b/test/test_spectral_ops.py
@@ -819,9 +819,16 @@ class TestFFT(TestCase):
             input_1d = x.dim() == 1
             if input_1d:
                 x = x.view(1, -1)
+
+            # NOTE: librosa 0.9 changed default pad_mode to 'constant' (zero padding)
+            # however, we use the pre-0.9 default ('reflect')
+            pad_mode = 'reflect'
+
             result = []
             for xi in x:
-                ri = librosa.stft(xi.cpu().numpy(), n_fft, hop_length, win_length, window, center=center)
+                ri = librosa.stft(xi.cpu().numpy(), n_fft=n_fft, hop_length=hop_length,
+                                  win_length=win_length, window=window, center=center,
+                                  pad_mode=pad_mode)
                 result.append(torch.from_numpy(np.stack([ri.real, ri.imag], -1)))
             result = torch.stack(result, 0)
             if input_1d:

--- a/test/test_tensorboard.py
+++ b/test/test_tensorboard.py
@@ -22,6 +22,7 @@ skipIfNoTorchVision = unittest.skipIf(not HAS_TORCHVISION, "no torchvision")
 
 TEST_CAFFE2 = True
 try:
+    import caffe2.python.caffe2_pybind11_state as _caffe2_pybind11_state  # noqa: F401
     from caffe2.python import brew, cnn, core, workspace
     from caffe2.python.model_helper import ModelHelper
 except ImportError:
@@ -71,10 +72,11 @@ if TEST_TENSORBOARD:
     from torch.utils.tensorboard import summary, SummaryWriter
     from torch.utils.tensorboard._utils import _prepare_video, convert_to_HWC
     from torch.utils.tensorboard._convert_np import make_np
-    from torch.utils.tensorboard import _caffe2_graph as c2_graph
     from torch.utils.tensorboard._pytorch_graph import graph
     from google.protobuf import text_format
     from PIL import Image
+if TEST_TENSORBOARD and TEST_CAFFE2:
+    from torch.utils.tensorboard import _caffe2_graph as c2_graph
 
 class TestTensorBoardPyTorchNumpy(BaseTestCase):
     def test_pytorch_np(self):

--- a/torch/utils/tensorboard/__init__.py
+++ b/torch/utils/tensorboard/__init__.py
@@ -1,12 +1,9 @@
 import tensorboard
-from setuptools import distutils
-
-LooseVersion = distutils.version.LooseVersion
+from distutils.version import LooseVersion
 
 if not hasattr(tensorboard, '__version__') or LooseVersion(tensorboard.__version__) < LooseVersion('1.15'):
     raise ImportError('TensorBoard logging requires TensorBoard version 1.15 or above')
 
-del distutils
 del LooseVersion
 del tensorboard
 


### PR DESCRIPTION
Fixes a number of UT issues in release/1.10

@pruthvistony 
@jithunnair-amd 
Is the change to pin scipy in [.circleci/docker/common/install_conda.sh](https://github.com/ROCmSoftwarePlatform/pytorch/compare/release/1.10...jataylo:pytorch:release/1.10-fixes?expand=1#diff-0ddbdb4f5ddba44d9e863e08c31c15f32cf2868e9e0341529cd2697c2ccb25c5) suitable?

**Failing logs:**
--------------------------------------------------------
**test_tensorboard**
PYTORCH_TEST_WITH_ROCM=1 python3 test/test_tensorboard.py -v
Traceback (most recent call last):
  File "test/test_tensorboard.py", line 71, in <module>
    from torch.utils.tensorboard import summary, SummaryWriter
  File "/opt/conda/lib/python3.7/site-packages/torch/utils/tensorboard/__init__.py", line 4, in <module>
    LooseVersion = distutils.version.LooseVersion
AttributeError: module 'distutils' has no attribute 'version'

**test_nn**
PYTORCH_TEST_WITH_ROCM=1 python3 test/test_nn.py -v
test_nn – require cherry-pick PR to limit scipy package 1.6.3v
test_BCELoss_no_reduce (__main__.TestNN) ... Memory access fault by GPU node-3 (Agent handle: 0x562ac2695fe0) on address 0x7f87cc400000. Reason: Unknown.
Aborted (core dumped)

**test_linalg**
PYTORCH_TEST_WITH_ROCM=1 python3 test/test_linalg.py -v
ERROR: test_cond_cuda_complex128 (__main__.TestLinalgCUDA)
ERROR: test_cond_cuda_complex64 (__main__.TestLinalgCUDA)
ERROR: test_cond_cuda_float32 (__main__.TestLinalgCUDA)
ERROR: test_cond_cuda_float64 (__main__.TestLinalgCUDA)

**test_spectral_ops**
PYTORCH_TEST_WITH_ROCM=1 python3 test/test_spectral_ops.py -v
FAIL: test_stft_cuda_float64 (__main__.TestFFTCUDA)

**distributions/test_distributions**
PYTORCH_TEST_WITH_ROCM=1 python3 test/distributions/test_distributions.py -v
ERROR [0.003s]: test_binomial_sample (__main__.TestDistributions)
ERROR [0.003s]: test_geometric_sample (__main__.TestDistributions)
ERROR [0.066s]: test_poisson_gpu_sample (__main__.TestDistributions)
ERROR [0.003s]: test_poisson_sample (__main__.TestDistributions)


**Passing logs:**
--------------------------------------------------------
**test_tensorboard**
PYTORCH_TEST_WITH_ROCM=1 python3 test/test_tensorboard.py -v
Ran 52 tests in 0.799s
OK (skipped=7)

**test_nn**
PYTORCH_TEST_WITH_ROCM=1 python3 test/test_nn.py -v
Ran 2588 tests in 530.846s
OK (skipped=78, expected failures=4)

**test_linalg**
PYTORCH_TEST_WITH_ROCM=1 python3 test/test_linalg.py -v
Ran 2511 tests in 503.590s
OK (skipped=72)

**test_spectral_ops**
PYTORCH_TEST_WITH_ROCM=1 python3 test/test_spectral_ops.py -v
Ran 146 tests in 17.119s
OK (skipped=95)

**distributions/test_distributions**
PYTORCH_TEST_WITH_ROCM=1 python3 test/distributions/test_distributions.py -v
Ran 207 tests in 30.879s
OK