### PR TITLE
Set magma backend for test_out/warning

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -30,6 +30,7 @@ from torch.testing._internal.common_utils import (
     IS_FBCODE,
     first_sample,
     parametrize,
+    setLinalgBackendsToDefaultFinally,
 )
 from torch.testing._internal.common_methods_invocations import (
     op_db,
@@ -622,7 +623,9 @@ class TestCommon(TestCase):
     # Cases test here:
     #   - out= with the correct dtype and device, but the wrong shape
     @ops(_ops_and_refs, dtypes=OpDTypes.none)
+    @setLinalgBackendsToDefaultFinally
     def test_out_warning(self, device, op):
+        torch.backends.cuda.preferred_linalg_library('magma')
         # Prefers running in float32 but has a fallback for the first listed supported dtype
         supported_dtypes = op.supported_dtypes(self.device_type)
         if len(supported_dtypes) == 0:
@@ -746,7 +749,9 @@ class TestCommon(TestCase):
     #   - Case 4: out has the with correct shape and device, but a dtype that cannot
     #       "safely" cast to
     @ops(_ops_and_refs, dtypes=OpDTypes.any_one)
+    @setLinalgBackendsToDefaultFinally
     def test_out(self, device, dtype, op):
+        torch.backends.cuda.preferred_linalg_library('magma')
         # Prefers running in float32 but has a fallback for the first listed supported dtype
         samples = op.sample_inputs(device, dtype)
         for sample in samples:


### PR DESCRIPTION
Tests passing with change to magma
```
PYTORCH_TEST_WITH_ROCM=1 python test/test_ops.py TestCommonCUDA.test_out_linalg_svdvals_cuda_float32
[W Context.cpp:199] Warning: torch.backends.cuda.preferred_linalg_library is an experimental feature. If you see any error or unexpected behavior when this flag is set please file an issue on GitHub. (function operator())
.
----------------------------------------------------------------------
Ran 1 test in 20.643s

OK
```

```
PYTORCH_TEST_WITH_ROCM=1 python test/test_ops.py TestCommonCUDA.test_out_warning_linalg_svdvals_cuda
[W Context.cpp:199] Warning: torch.backends.cuda.preferred_linalg_library is an experimental feature. If you see any error or unexpected behavior when this flag is set please file an issue on GitHub. (function operator())
.
----------------------------------------------------------------------
Ran 1 test in 13.145s

OK

```