### PR TITLE
[SOW MS3] Skipping few tests temporarily

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -12723,7 +12723,12 @@ op_db: List[OpInfo] = [
            supports_forward_ad=True,
            supports_fwgrad_bwgrad=True,
            sample_inputs_func=sample_inputs_masked_select,
-           error_inputs_func=error_inputs_masked_select),
+           error_inputs_func=error_inputs_masked_select,
+           skips=(
+               DecorateInfo(unittest.skip("Skipped for ROCm"), 'TestCommon', 'test_non_standard_bool_values',
+                            active_if=TEST_WITH_ROCM, device_type='cuda'),
+           )
+           ),
     OpInfo('matrix_exp',
            dtypes=floating_and_complex_types_and(torch.bfloat16),
            dtypesIfCUDA=floating_and_complex_types_and(torch.float16,
@@ -17542,6 +17547,8 @@ op_db: List[OpInfo] = [
                # TODO: implement csr.to_sparse(sample_dim) where sampled_dim is 1.
                DecorateInfo(unittest.skip("csr.to_sparse(1) not implemented. Skipped!"),
                             'TestSparseCSR', 'test_sparse_csr_consistency'),
+               DecorateInfo(unittest.skip("Skipped for ROCm"), 'TestCommon', 'test_non_standard_bool_values',
+                            active_if=TEST_WITH_ROCM, device_type='cuda'),
            )
            ),
     OpInfo('logcumsumexp',
@@ -17799,6 +17806,8 @@ op_db: List[OpInfo] = [
                DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out_warning'),
                # Can't find schemas for this operator for some reason
                DecorateInfo(unittest.expectedFailure, 'TestOperatorSignatures', 'test_get_torch_func_signature_exhaustive'),
+               DecorateInfo(unittest.skip("Skipped for ROCm"), 'TestCommon', 'test_non_standard_bool_values',
+                            active_if=TEST_WITH_ROCM, device_type='cuda'),
            )),
     # Following tests are for jiterator's python interface
     # Jiterator can be used to author elementwise CUDA kernel
@@ -18286,6 +18295,10 @@ op_db: List[OpInfo] = [
         supports_out=False,
         supports_autograd=False,
         sample_inputs_func=sample_inputs_argwhere,
+        skips=(
+            DecorateInfo(unittest.skip("Skipped for ROCm"), 'TestCommon', 'test_non_standard_bool_values',
+                         active_if=TEST_WITH_ROCM, device_type='cuda'),
+        ),
     ),
     ReductionOpInfo(
         'all',


### PR DESCRIPTION
test_non_standard_bool_values_to_sparse_cuda_bool
test_non_standard_bool_values_argwhere_cuda_bool
test_non_standard_bool_values_masked_select_cuda_bool
test_non_standard_bool_values_nonzero_cuda_bool
They are tracked in SWDEV-344137 and this should be reverted after fix.

Fixes #ISSUE_NUMBER
