### PR TITLE
[SOW MS3] Workaround MIOPEN output tensor memory format issues #2

### DIFF
--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -1367,17 +1367,20 @@ at::Tensor _convolution(
       output = at::miopen_convolution(
           input.contiguous(backend_memory_format), weight, bias, params.padding, params.stride,
           params.dilation, params.groups, params.benchmark, params.deterministic);
+      output.contiguous(backend_memory_format)
       break;
     case ConvBackend::MiopenDepthwise:
       output = at::miopen_depthwise_convolution(
           input.contiguous(backend_memory_format), weight, bias, params.padding, params.stride,
           params.dilation, params.groups, params.benchmark, params.deterministic);
+      output.contiguous(backend_memory_format)
       break;
     case ConvBackend::MiopenTranspose:
       check_input_same_type_as_parameters(input, weight, bias);
       output = at::miopen_convolution_transpose(
           input.contiguous(backend_memory_format), weight, bias, params.padding, params.output_padding,
           params.stride, params.dilation, params.groups, params.benchmark, params.deterministic);
+      output.contiguous(backend_memory_format)
       break;
     case ConvBackend::Mkldnn:
 #if AT_MKLDNN_ENABLED()
@@ -1482,11 +1485,7 @@ at::Tensor _convolution(
     output = view3d(output);
   }
 
-#ifdef USE_ROCM
-  return output.contiguous(backend_memory_format);
-#else 
   return output;
-#endif
 }
 
 at::Tensor _convolution(

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -1367,20 +1367,20 @@ at::Tensor _convolution(
       output = at::miopen_convolution(
           input.contiguous(backend_memory_format), weight, bias, params.padding, params.stride,
           params.dilation, params.groups, params.benchmark, params.deterministic);
-      output.contiguous(backend_memory_format)
+      output = output.contiguous(backend_memory_format);
       break;
     case ConvBackend::MiopenDepthwise:
       output = at::miopen_depthwise_convolution(
           input.contiguous(backend_memory_format), weight, bias, params.padding, params.stride,
           params.dilation, params.groups, params.benchmark, params.deterministic);
-      output.contiguous(backend_memory_format)
+      output = output.contiguous(backend_memory_format);
       break;
     case ConvBackend::MiopenTranspose:
       check_input_same_type_as_parameters(input, weight, bias);
       output = at::miopen_convolution_transpose(
           input.contiguous(backend_memory_format), weight, bias, params.padding, params.output_padding,
           params.stride, params.dilation, params.groups, params.benchmark, params.deterministic);
-      output.contiguous(backend_memory_format)
+      output = output.contiguous(backend_memory_format);
       break;
     case ConvBackend::Mkldnn:
 #if AT_MKLDNN_ENABLED()

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -11411,7 +11411,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         input = torch.randn((16, 8, 8, 8), dtype=torch.float16, device="cuda").to(memory_format=torch.channels_last)
         out_transpose = torch.convolution(input, weight, None, (1, 1), (1, 1), (1, 1), True, (0, 0), 4)
 
-    @unittest.expectedFailureCUDA
+    @unittest.expectedFailureCUDAOnly
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     @unittest.skipIf(not TEST_CUDNN, "needs cudnn")
     def test_conv_cudnn_memory_layout_dominance(self):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -19657,7 +19657,6 @@ torch.cuda.synchronize()
                 self.assertEqual(F.relu(conv2d_out + alpha * z), cudnn_out)
 
     @onlyCUDA
-    @skipCUDAIfRocm
     @skipCUDAIfCudnnVersionLessThan(7603)
     def test_convert_conv2d_weight_memory_format(self, device):
         input = torch.randint(1, 10, (2, 8, 4, 4), dtype=torch.float32, device=device)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -52,7 +52,7 @@ from torch.testing._internal.common_cuda import TEST_CUDA, TEST_MULTIGPU, TEST_C
 from torch.testing._internal.common_nn import NNTestCase, NewModuleTest, CriterionTest, \
     module_tests, criterion_tests, loss_reference_fns, \
     ctcloss_reference, new_module_tests, single_batch_reference_fn
-from torch.testing._internal.common_device_type import expectedFailureXLA, instantiate_device_type_tests, dtypes, \
+from torch.testing._internal.common_device_type import expectedFailureXLA, expectedFailureCUDAOnly, instantiate_device_type_tests, dtypes, \
     dtypesIfCUDA, precisionOverride, skipCUDAIfNoCudnn, skipCUDAIfCudnnVersionLessThan, onlyCUDA, onlyCPU, \
     skipCUDAIfRocm, skipCUDAIf, skipCUDAIfNotRocm, skipCUDAIfRocmVersionLessThan, skipCUDAIfNotMiopenSuggestNHWC, \
     onlyNativeDeviceTypes, deviceCountAtLeast, largeTensorTest, expectedFailureMeta, skipMeta, get_all_device_types, \
@@ -11411,7 +11411,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         input = torch.randn((16, 8, 8, 8), dtype=torch.float16, device="cuda").to(memory_format=torch.channels_last)
         out_transpose = torch.convolution(input, weight, None, (1, 1), (1, 1), (1, 1), True, (0, 0), 4)
 
-    @unittest.expectedFailureCUDAOnly
+    @expectedFailureCUDAOnly
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     @unittest.skipIf(not TEST_CUDNN, "needs cudnn")
     def test_conv_cudnn_memory_layout_dominance(self):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -11411,9 +11411,9 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         input = torch.randn((16, 8, 8, 8), dtype=torch.float16, device="cuda").to(memory_format=torch.channels_last)
         out_transpose = torch.convolution(input, weight, None, (1, 1), (1, 1), (1, 1), True, (0, 0), 4)
 
-    @expectedFailureCUDAOnly
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     @unittest.skipIf(not TEST_CUDNN, "needs cudnn")
+    @expectedFailureCUDAOnly
     def test_conv_cudnn_memory_layout_dominance(self):
         # desired behavior here is to have the memory_layout of conv.weight to
         # dominante the layout of output.

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -11411,7 +11411,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         input = torch.randn((16, 8, 8, 8), dtype=torch.float16, device="cuda").to(memory_format=torch.channels_last)
         out_transpose = torch.convolution(input, weight, None, (1, 1), (1, 1), (1, 1), True, (0, 0), 4)
 
-    @unittest.expectedFailure
+    @unittest.expectedFailureCUDA
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     @unittest.skipIf(not TEST_CUDNN, "needs cudnn")
     def test_conv_cudnn_memory_layout_dominance(self):

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -1121,10 +1121,10 @@ def disableMkldnn(fn):
 
 def expectedFailureCUDAOnly(fn):
     if torch.version.hip is not None:
-        return expectedFailure('cuda')(fn)
-    else:
-        # function is launched on rocm and expected to successed
+        # function is launched on rocm and expected to succeed
         return fn
+    else:
+        return expectedFailure('cuda')(fn)
 
 def expectedFailureCUDA(fn):
     return expectedFailure('cuda')(fn)

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -922,23 +922,6 @@ class expectedFailure(object):
             return fn(slf, *args, **kwargs)
         return efail_fn
 
-class expectedSuccess(object):
-    def __init__(self, device_type):
-        self.device_type = device_type
-
-    def __call__(self, fn):
-
-        @wraps(fn)
-        def esuccess_fn(slf, *args, **kwargs):
-            if self.device_type is None or self.device_type == slf.device_type:
-                try:
-                    fn(slf, *args, **kwargs)
-                except Exception:
-                    slf.fail('expected test to succeed, but it failed with {}'.format(Exception))
-
-            return fn(slf, *args, **kwargs)
-        return esuccess_fn
-
 class onlyOn(object):
 
     def __init__(self, device_type):
@@ -1141,7 +1124,7 @@ def expectedFailureCUDAOnly(fn):
         return expectedFailure('cuda')(fn)
     else:
         # function is launched on rocm and expected to successed
-        return expectedSuccess('cuda')
+        return fn
 
 def expectedFailureCUDA(fn):
     return expectedFailure('cuda')(fn)


### PR DESCRIPTION
Follow up to https://github.com/ROCmSoftwarePlatform/pytorch/pull/1072.
This PR works around the issue by enforcing the output tensor to be contigous and match ouput format of the weight tensor.

``` 
python test_nn.py --verbose  TestNNDeviceTypeCUDA.test_conv_cudnn_ndhwc_cuda_float16
python test_nn.py --verbose  TestNNDeviceTypeCUDA.test_conv_cudnn_ndhwc_cuda_float32
python test_nn.py --verbose  TestNNDeviceTypeCUDA.test_convert_conv2d_weight_memory_format_cuda
```
