### PR TITLE
Integrate batched versions of getrs, geqrf, getrf, getri, and gels

### DIFF
--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -9,6 +9,7 @@
 #include <c10/macros/Export.h>
 #include <c10/util/irange.h>
 
+
 // cublasLT was introduced in CUDA 10.1 but we enable only for 11.1 that also
 // added bf16 support
 #if defined(CUDA_VERSION) && CUDA_VERSION >= 11000 && !defined(_MSC_VER)
@@ -1162,8 +1163,76 @@ void vdot<c10::complex<double>>(CUDABLAS_DOT_ARGTYPES(c10::complex<double>)) {
                                    reinterpret_cast<cuDoubleComplex*>(result)));
 }
 
-// This guards blocks use of getrsBatched, geqrfBatched, getrfBatched on platforms other than cuda
-#ifdef CUDART_VERSION
+
+#ifdef USE_ROCM
+
+
+template <>
+void getrsBatched<float>(HIPBLAS_GETRS_ARGTYPES(float)) {
+  TORCH_HIPBLAS_CHECK(cublasSgetrsBatched(
+      handle,
+      trans,
+      n,
+      nrhs,
+      dA_array,
+      lda,
+      ipiv_array,
+      dB_array,
+      ldb,
+      info_array,
+      batchsize));
+}
+
+template <>
+void getrsBatched<double>(HIPBLAS_GETRS_ARGTYPES(double)) {
+  TORCH_HIPBLAS_CHECK(cublasDgetrsBatched(
+      handle,
+      trans,
+      n,
+      nrhs,
+      dA_array,
+      lda,
+      ipiv_array,
+      dB_array,
+      ldb,
+      info_array,
+      batchsize));
+}
+
+
+template <>
+void getrsBatched<c10::complex<float>>(HIPBLAS_GETRS_ARGTYPES(c10::complex<float>)) {
+  TORCH_HIPBLAS_CHECK(cublasCgetrsBatched(
+      handle,
+      trans,
+      n,
+      nrhs,
+      reinterpret_cast<hipblasComplex**>(dA_array),
+      lda,
+      ipiv_array,
+      reinterpret_cast<hipblasComplex**>(dB_array),
+      ldb,
+      info_array,
+      batchsize));
+}
+
+template <>
+void getrsBatched<c10::complex<double>>(HIPBLAS_GETRS_ARGTYPES(c10::complex<double>)) {
+  TORCH_HIPBLAS_CHECK(cublasZgetrsBatched(
+      handle,
+      trans,
+      n,
+      nrhs,
+      reinterpret_cast<hipblasDoubleComplex**>(dA_array),
+      lda,
+      ipiv_array,
+      reinterpret_cast<hipblasDoubleComplex**>(dB_array),
+      ldb,
+      info_array,
+      batchsize));
+}
+
+#else
 
 template <>
 void getrsBatched<float>(CUDABLAS_GETRS_ARGTYPES(float)) {
@@ -1228,7 +1297,52 @@ void getrsBatched<c10::complex<double>>(CUDABLAS_GETRS_ARGTYPES(c10::complex<dou
       info_array,
       batchsize));
 }
+#endif
 
+#ifdef USE_ROCM
+template <>
+void geqrfBatched<float>(HIPBLAS_GEQRF_BATCHED_ARGTYPES(float)) {
+  TORCH_HIPBLAS_CHECK(cublasSgeqrfBatched(
+      handle, m, n, A_array, lda, tau_array, info, batchsize));
+}
+
+template <>
+void geqrfBatched<double>(HIPBLAS_GEQRF_BATCHED_ARGTYPES(double)) {
+  TORCH_HIPBLAS_CHECK(cublasDgeqrfBatched(
+      handle, m, n, A_array, lda, tau_array, info, batchsize));
+}
+
+
+
+template <>
+void geqrfBatched<c10::complex<float>>(
+    HIPBLAS_GEQRF_BATCHED_ARGTYPES(c10::complex<float>)) {
+  TORCH_HIPBLAS_CHECK(cublasCgeqrfBatched(
+      handle,
+      m,
+      n,
+      reinterpret_cast<double*const*>(A_array),
+      lda,
+      reinterpret_cast<double*const*>(tau_array),
+      info,
+      batchsize));
+}
+
+template <>
+void geqrfBatched<c10::complex<double>>(
+    HIPBLAS_GEQRF_BATCHED_ARGTYPES(c10::complex<double>)) {
+  TORCH_HIPBLAS_CHECK(cublasZgeqrfBatched(
+      handle,
+      m,
+      n,
+      reinterpret_cast<hipblasDoubleComplex**>(A_array),
+      lda,
+      reinterpret_cast<hipblasDoubleComplex**>(tau_array),
+      info,
+      batchsize));
+}
+
+#else
 template <>
 void geqrfBatched<float>(CUDABLAS_GEQRF_BATCHED_ARGTYPES(float)) {
   TORCH_CUDABLAS_CHECK(cublasSgeqrfBatched(
@@ -1268,10 +1382,59 @@ void geqrfBatched<c10::complex<double>>(
       info,
       batchsize));
 }
+#endif
+
+#ifdef USE_ROCM
 
 template <>
 void getrfBatched<double>(
-    int n, double** dA_array, int ldda, int* ipiv_array, int* info_array, int batchsize) {
+    HIPBLAS_GETRF_BATCHED_ARGTYPES(double)) {
+  auto handle = at::cuda::getCurrentCUDABlasHandle();
+  TORCH_HIPBLAS_CHECK(cublasDgetrfBatched(
+      handle, n, dA_array, ldda, ipiv_array, info_array, batchsize));
+}
+
+template <>
+void getrfBatched<float>(
+    HIPBLAS_GETRF_BATCHED_ARGTYPES(float)) {
+  auto handle = at::cuda::getCurrentCUDABlasHandle();
+  TORCH_HIPBLAS_CHECK(cublasSgetrfBatched(
+      handle, n, dA_array, ldda, ipiv_array, info_array, batchsize));
+}
+
+template <>
+void getrfBatched<c10::complex<double>>(
+    HIPBLAS_GETRF_BATCHED_ARGTYPES(c10::complex<double>)) {
+  auto handle = at::cuda::getCurrentCUDABlasHandle();
+  TORCH_HIPBLAS_CHECK(cublasZgetrfBatched(
+      handle,
+      n,
+      reinterpret_cast<hipblasDoubleComplex**>(dA_array),
+      ldda,
+      ipiv_array,
+      info_array,
+      batchsize));
+}
+
+template <>
+void getrfBatched<c10::complex<float>>(
+    HIPBLAS_GETRF_BATCHED_ARGTYPES(c10::complex<float>)) {
+  auto handle = at::cuda::getCurrentCUDABlasHandle();
+  TORCH_HIPBLAS_CHECK(cublasCgetrfBatched(
+      handle,
+      n,
+      reinterpret_cast<hipblasComplex**>(dA_array),
+      ldda,
+      ipiv_array,
+      info_array,
+      batchsize));
+}
+
+
+#else
+template <>
+void getrfBatched<double>(
+    CUDABLAS_GETRF_BATCHED_ARGTYPES(double)) {
   auto handle = at::cuda::getCurrentCUDABlasHandle();
   TORCH_CUDABLAS_CHECK(cublasDgetrfBatched(
       handle, n, dA_array, ldda, ipiv_array, info_array, batchsize));
@@ -1279,7 +1442,7 @@ void getrfBatched<double>(
 
 template <>
 void getrfBatched<float>(
-    int n, float** dA_array, int ldda, int* ipiv_array, int* info_array, int batchsize) {
+    CUDABLAS_GETRF_BATCHED_ARGTYPES(float)) {
   auto handle = at::cuda::getCurrentCUDABlasHandle();
   TORCH_CUDABLAS_CHECK(cublasSgetrfBatched(
       handle, n, dA_array, ldda, ipiv_array, info_array, batchsize));
@@ -1287,12 +1450,7 @@ void getrfBatched<float>(
 
 template <>
 void getrfBatched<c10::complex<double>>(
-    int n,
-    c10::complex<double>** dA_array,
-    int ldda,
-    int* ipiv_array,
-    int* info_array,
-    int batchsize) {
+    CUDABLAS_GETRF_BATCHED_ARGTYPES(c10::complex<double>)) {
   auto handle = at::cuda::getCurrentCUDABlasHandle();
   TORCH_CUDABLAS_CHECK(cublasZgetrfBatched(
       handle,
@@ -1306,12 +1464,7 @@ void getrfBatched<c10::complex<double>>(
 
 template <>
 void getrfBatched<c10::complex<float>>(
-    int n,
-    c10::complex<float>** dA_array,
-    int ldda,
-    int* ipiv_array,
-    int* info_array,
-    int batchsize) {
+    CUDABLAS_GETRF_BATCHED_ARGTYPES(c10::complex<float>)) {
   auto handle = at::cuda::getCurrentCUDABlasHandle();
   TORCH_CUDABLAS_CHECK(cublasCgetrfBatched(
       handle,
@@ -1322,7 +1475,152 @@ void getrfBatched<c10::complex<float>>(
       info_array,
       batchsize));
 }
+#endif
 
+#ifdef USE_ROCM
+template <>
+void getriBatched<double>(
+    HIPBLAS_GETRI_BATCHED_ARGTYPES(double)) {
+  auto handle = at::cuda::getCurrentCUDABlasHandle();
+  TORCH_HIPBLAS_CHECK(cublasDgetriBatched(
+      handle, n, dA_array, ldda, ipiv_array, dC_array, lddc, info_array, batchsize));
+}
+
+template <>
+void getriBatched<float>(
+    HIPBLAS_GETRI_BATCHED_ARGTYPES(float)) {
+  auto handle = at::cuda::getCurrentCUDABlasHandle();
+  TORCH_HIPBLAS_CHECK(cublasSgetriBatched(
+      handle, n, dA_array, ldda, ipiv_array, dC_array, lddc, info_array, batchsize));
+}
+
+template <>
+void getriBatched<c10::complex<double>>(
+    HIPBLAS_GETRI_BATCHED_ARGTYPES(c10::complex<double>)) {
+  auto handle = at::cuda::getCurrentCUDABlasHandle();
+  TORCH_HIPBLAS_CHECK(cublasZgetriBatched(
+      handle,
+      n,
+      reinterpret_cast<hipblasDoubleComplex**>(dA_array),
+      ldda,
+      ipiv_array,
+      reinterpret_cast<hipblasDoubleComplex**>(dC_array),
+      lddc,
+      info_array,
+      batchsize));
+}
+
+template <>
+void getriBatched<c10::complex<float>>(
+    HIPBLAS_GETRI_BATCHED_ARGTYPES(c10::complex<float>)) {
+  auto handle = at::cuda::getCurrentCUDABlasHandle();
+  TORCH_HIPBLAS_CHECK(cublasCgetriBatched(
+      handle,
+      n,
+      reinterpret_cast<hipblasComplex**>(dA_array),
+      ldda,
+      ipiv_array,
+      reinterpret_cast<hipblasComplex**>(dC_array),
+      lddc,
+      info_array,
+      batchsize));
+}
+
+#else
+template <>
+void getriBatched<double>(
+    CUDABLAS_GETRI_BATCHED_ARGTYPES(double)) {
+  auto handle = at::cuda::getCurrentCUDABlasHandle();
+  TORCH_CUDABLAS_CHECK(cublasDgetriBatched(
+      handle, n, dA_array, ldda, ipiv_array, dC_array, lddc, info_array, batchsize));
+}
+
+template <>
+void getriBatched<float>(
+    CUDABLAS_GETRI_BATCHED_ARGTYPES(float)) {
+  auto handle = at::cuda::getCurrentCUDABlasHandle();
+  TORCH_CUDABLAS_CHECK(cublasSgetriBatched(
+      handle, n, dA_array, ldda, ipiv_array, dC_array, lddc, info_array, batchsize));
+}
+
+template <>
+void getriBatched<c10::complex<double>>(
+    CUDABLAS_GETRI_BATCHED_ARGTYPES(c10::complex<double>)) {
+  auto handle = at::cuda::getCurrentCUDABlasHandle();
+  TORCH_CUDABLAS_CHECK(cublasZgetriBatched(
+      handle,
+      n,
+      reinterpret_cast<cuDoubleComplex**>(dA_array),
+      ldda,
+      ipiv_array,
+      reinterpret_cast<cuDoubleComplex**>(dC_array),
+      lddc,
+      info_array,
+      batchsize));
+}
+
+template <>
+void getriBatched<c10::complex<float>>(
+    CUDABLAS_GETRI_BATCHED_ARGTYPES(c10::complex<float>)) {
+  auto handle = at::cuda::getCurrentCUDABlasHandle();
+  TORCH_CUDABLAS_CHECK(cublasCgetriBatched(
+      handle,
+      n,
+      reinterpret_cast<cuComplex**>(dA_array),
+      ldda,
+      ipiv_array,
+      reinterpret_cast<cuComplex**>(dC_array),
+      lddc,
+      info_array,
+      batchsize));
+}
+#endif
+
+#if defined(USE_ROCM) && (ROCM_VERSION >= 50400)
+
+template <>
+void gelsBatched<double>(HIPBLAS_GELS_BATCHED_ARGTYPES(double)) {
+  TORCH_HIPBLAS_CHECK(hipblasDgelsBatched(
+      handle, trans, m, n, nrhs, dA_array, ldda, dC_array, lddc, info, devInfoArray, batchSize));
+}
+
+template <>
+void gelsBatched<float>(HIPBLAS_GELS_BATCHED_ARGTYPES(float)) {
+  TORCH_HIPBLAS_CHECK(hipblasSgelsBatched(
+      handle, trans, m, n, nrhs, dA_array, ldda, dC_array, lddc, info, devInfoArray, batchSize));
+}
+
+template <>
+void gelsBatched<c10::complex<double>>(HIPBLAS_GELS_BATCHED_ARGTYPES(c10::complex<double>)) {
+  TORCH_HIPBLAS_CHECK(hipblasZgelsBatched(
+      handle, trans,
+      m, n, nrhs,
+      reinterpret_cast<hipblasDoubleComplex**>(dA_array),
+      ldda,
+      reinterpret_cast<hipblasDoubleComplex**>(dC_array),
+      lddc,
+      info,
+      devInfoArray,
+      batchSize));
+}
+
+template <>
+void gelsBatched<c10::complex<float>>(HIPBLAS_GELS_BATCHED_ARGTYPES(c10::complex<float>)) {
+  TORCH_HIPBLAS_CHECK(hipblasCgelsBatched(
+      handle, trans,
+      m, n, nrhs,
+      reinterpret_cast<hipblasComplex**>(dA_array),
+      ldda,
+      reinterpret_cast<hipblasComplex**>(dC_array),
+      lddc,
+      info,
+      devInfoArray,
+      batchSize));
+}
+
+#else
+
+#ifdef CUDART_VERSION
 
 template <>
 void gelsBatched<double>(CUDABLAS_GELS_BATCHED_ARGTYPES(double)) {
@@ -1364,7 +1662,9 @@ void gelsBatched<c10::complex<float>>(CUDABLAS_GELS_BATCHED_ARGTYPES(c10::comple
       batchSize));
 }
 
-#endif // CUDART_VERSION
+#endif //CUDART_VERSION
+#endif //USE_ROCM
+
 
 } // namespace blas
 } // namespace cuda

--- a/aten/src/ATen/cuda/CUDABlas.h
+++ b/aten/src/ATen/cuda/CUDABlas.h
@@ -16,6 +16,12 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/OpMathType.h>
 
+#ifdef USE_ROCM
+#include <hipblas.h>
+#include <hipsolver.h>
+#endif
+
+
 namespace at {
 namespace cuda {
 namespace blas {
@@ -227,8 +233,30 @@ void vdot<c10::complex<float>>(CUDABLAS_DOT_ARGTYPES(c10::complex<float>));
 template <>
 void vdot<c10::complex<double>>(CUDABLAS_DOT_ARGTYPES(c10::complex<double>));
 
-// This guards blocks use of getrsBatched, geqrfBatched, getrfBatched on platforms other than cuda
-#ifdef CUDART_VERSION
+#ifdef USE_ROCM
+
+
+#define HIPBLAS_GETRS_ARGTYPES(Dtype)  \
+  hipblasHandle_t handle, hipblasOperation_t trans, \
+  int n, int nrhs, Dtype** dA_array, int lda, int* ipiv_array, \
+  Dtype** dB_array, int ldb, int* info_array, int batchsize
+
+template<class Dtype>
+void getrsBatched(HIPBLAS_GETRS_ARGTYPES(Dtype)) {
+  TORCH_INTERNAL_ASSERT(false, "at::cuda::blas::getrsBatched: not implemented for ",
+    typeid(Dtype).name());
+}
+template<>
+TORCH_CUDA_CU_API void getrsBatched<float>(HIPBLAS_GETRS_ARGTYPES(float));
+template<>
+TORCH_CUDA_CU_API void getrsBatched<double>(HIPBLAS_GETRS_ARGTYPES(double));
+template<>
+TORCH_CUDA_CU_API void getrsBatched<c10::complex<float>>(HIPBLAS_GETRS_ARGTYPES(c10::complex<float>));
+template<>
+TORCH_CUDA_CU_API void getrsBatched<c10::complex<double>>(HIPBLAS_GETRS_ARGTYPES(c10::complex<double>));
+
+
+#else
 
 #define CUDABLAS_GETRS_ARGTYPES(Dtype)  \
   cublasHandle_t handle, cublasOperation_t trans, \
@@ -249,6 +277,31 @@ TORCH_CUDA_CU_API void getrsBatched<c10::complex<float>>(CUDABLAS_GETRS_ARGTYPES
 template<>
 TORCH_CUDA_CU_API void getrsBatched<c10::complex<double>>(CUDABLAS_GETRS_ARGTYPES(c10::complex<double>));
 
+#endif
+
+#ifdef USE_ROCM
+#define HIPBLAS_GEQRF_BATCHED_ARGTYPES(Dtype)                   \
+  hipblasHandle_t handle, int m, int n, Dtype **A_array, int lda, \
+      Dtype **tau_array, int *info, int batchsize
+
+template <class Dtype>
+void geqrfBatched(HIPBLAS_GEQRF_BATCHED_ARGTYPES(Dtype)) {
+  TORCH_INTERNAL_ASSERT(
+      false,
+      "at::cuda::blas::geqrfBatched: not implemented for ",
+      typeid(Dtype).name());
+}
+template <>
+TORCH_CUDA_CU_API void geqrfBatched<float>(HIPBLAS_GEQRF_BATCHED_ARGTYPES(float));
+template <>
+TORCH_CUDA_CU_API void geqrfBatched<double>(HIPBLAS_GEQRF_BATCHED_ARGTYPES(double));
+template <>
+TORCH_CUDA_CU_API void geqrfBatched<c10::complex<double>>(
+    HIPBLAS_GEQRF_BATCHED_ARGTYPES(c10::complex<double>));
+template <>
+TORCH_CUDA_CU_API void geqrfBatched<c10::complex<float>>(
+    HIPBLAS_GEQRF_BATCHED_ARGTYPES(c10::complex<float>));
+#else
 #define CUDABLAS_GEQRF_BATCHED_ARGTYPES(Dtype)                   \
   cublasHandle_t handle, int m, int n, Dtype **A_array, int lda, \
       Dtype **tau_array, int *info, int batchsize
@@ -270,22 +323,107 @@ TORCH_CUDA_CU_API void geqrfBatched<c10::complex<double>>(
 template <>
 TORCH_CUDA_CU_API void geqrfBatched<c10::complex<float>>(
     CUDABLAS_GEQRF_BATCHED_ARGTYPES(c10::complex<float>));
+#endif
 
-#define CUDABLAS_GETRF_ARGTYPES(Dtype)  \
+#ifdef USE_ROCM
+#define HIPBLAS_GETRF_BATCHED_ARGTYPES(Dtype)  \
   int n, Dtype** dA_array, int ldda, int* ipiv_array, int* info_array, int batchsize
-
 template<class Dtype>
-void getrfBatched(CUDABLAS_GETRF_ARGTYPES(Dtype)) {
+void getrfBatched(HIPBLAS_GETRF_BATCHED_ARGTYPES(Dtype)) {
   TORCH_CHECK(false, "at::cuda::blas::getrfBatched: not implemented for ", typeid(Dtype).name());
 }
 template<>
-TORCH_CUDA_CU_API void getrfBatched<float>(CUDABLAS_GETRF_ARGTYPES(float));
+TORCH_CUDA_CU_API void getrfBatched<float>(HIPBLAS_GETRF_BATCHED_ARGTYPES(float));
 template<>
-TORCH_CUDA_CU_API void getrfBatched<double>(CUDABLAS_GETRF_ARGTYPES(double));
+TORCH_CUDA_CU_API void getrfBatched<double>(HIPBLAS_GETRF_BATCHED_ARGTYPES(double));
 template<>
-TORCH_CUDA_CU_API void getrfBatched<c10::complex<double>>(CUDABLAS_GETRF_ARGTYPES(c10::complex<double>));
+TORCH_CUDA_CU_API void getrfBatched<c10::complex<double>>(HIPBLAS_GETRF_BATCHED_ARGTYPES(c10::complex<double>));
 template<>
-TORCH_CUDA_CU_API void getrfBatched<c10::complex<float>>(CUDABLAS_GETRF_ARGTYPES(c10::complex<float>));
+TORCH_CUDA_CU_API void getrfBatched<c10::complex<float>>(HIPBLAS_GETRF_BATCHED_ARGTYPES(c10::complex<float>));
+
+#else
+
+#define CUDABLAS_GETRF_BATCHED_ARGTYPES(Dtype)  \
+  int n, Dtype** dA_array, int ldda, int* ipiv_array, int* info_array, int batchsize
+
+template<class Dtype>
+void getrfBatched(CUDABLAS_GETRF_BATCHED_ARGTYPES(Dtype)) {
+  TORCH_CHECK(false, "at::cuda::blas::getrfBatched: not implemented for ", typeid(Dtype).name());
+}
+template<>
+TORCH_CUDA_CU_API void getrfBatched<float>(CUDABLAS_GETRF_BATCHED_ARGTYPES(float));
+template<>
+TORCH_CUDA_CU_API void getrfBatched<double>(CUDABLAS_GETRF_BATCHED_ARGTYPES(double));
+template<>
+TORCH_CUDA_CU_API void getrfBatched<c10::complex<double>>(CUDABLAS_GETRF_BATCHED_ARGTYPES(c10::complex<double>));
+template<>
+TORCH_CUDA_CU_API void getrfBatched<c10::complex<float>>(CUDABLAS_GETRF_BATCHED_ARGTYPES(c10::complex<float>));
+#endif
+
+
+#ifdef USE_ROCM
+#define HIPBLAS_GETRI_BATCHED_ARGTYPES(Dtype)  \
+  int n, Dtype** dA_array, int ldda, int* ipiv_array, Dtype** dC_array, int lddc, int* info_array, int batchsize
+
+template<class Dtype>
+void getriBatched(HIPBLAS_GETRI_BATCHED_ARGTYPES(Dtype)) {
+  TORCH_CHECK(false, "at::cuda::blas::getriBatched: not implemented for ", typeid(Dtype).name());
+}
+template<>
+TORCH_CUDA_CU_API void getriBatched<float>(HIPBLAS_GETRI_BATCHED_ARGTYPES(float));
+template<>
+TORCH_CUDA_CU_API void getriBatched<double>(HIPBLAS_GETRI_BATCHED_ARGTYPES(double));
+template<>
+TORCH_CUDA_CU_API void getriBatched<c10::complex<double>>(HIPBLAS_GETRI_BATCHED_ARGTYPES(c10::complex<double>));
+template<>
+TORCH_CUDA_CU_API void getriBatched<c10::complex<float>>(HIPBLAS_GETRI_BATCHED_ARGTYPES(c10::complex<float>));
+
+
+#else
+
+
+#define CUDABLAS_GETRI_BATCHED_ARGTYPES(Dtype)  \
+  int n, Dtype** dA_array, int ldda, int* ipiv_array, Dtype** dC_array, int lddc, int* info_array, int batchsize
+
+template<class Dtype>
+void getriBatched(CUDABLAS_GETRI_BATCHED_ARGTYPES(Dtype)) {
+  TORCH_CHECK(false, "at::cuda::blas::getriBatched: not implemented for ", typeid(Dtype).name());
+}
+template<>
+TORCH_CUDA_CU_API void getriBatched<float>(CUDABLAS_GETRI_BATCHED_ARGTYPES(float));
+template<>
+TORCH_CUDA_CU_API void getriBatched<double>(CUDABLAS_GETRI_BATCHED_ARGTYPES(double));
+template<>
+TORCH_CUDA_CU_API void getriBatched<c10::complex<double>>(CUDABLAS_GETRI_BATCHED_ARGTYPES(c10::complex<double>));
+template<>
+TORCH_CUDA_CU_API void getriBatched<c10::complex<float>>(CUDABLAS_GETRI_BATCHED_ARGTYPES(c10::complex<float>));
+
+#endif
+
+
+
+#if defined(USE_ROCM) && (ROCM_VERSION >= 50400)
+
+#define HIPBLAS_GELS_BATCHED_ARGTYPES(Dtype)  \
+  hipblasHandle_t handle, hipblasOperation_t trans, int m, int n, int nrhs, Dtype** dA_array, int ldda, Dtype** dC_array, int lddc, int* info, int *devInfoArray, int batchSize
+
+template <class Dtype>
+void gelsBatched(HIPBLAS_GELS_BATCHED_ARGTYPES(Dtype)) {
+  TORCH_INTERNAL_ASSERT(false, "at::cuda::blas::gelsBatched: not implemented for ", typeid(Dtype).name());
+}
+
+template<>
+TORCH_CUDA_CU_API void gelsBatched<double>(HIPBLAS_GELS_BATCHED_ARGTYPES(double));
+template<>
+TORCH_CUDA_CU_API void gelsBatched<float>(HIPBLAS_GELS_BATCHED_ARGTYPES(float));
+template<>
+TORCH_CUDA_CU_API void gelsBatched<c10::complex<double>>(HIPBLAS_GELS_BATCHED_ARGTYPES(c10::complex<double>));
+template<>
+TORCH_CUDA_CU_API void gelsBatched<c10::complex<float>>(HIPBLAS_GELS_BATCHED_ARGTYPES(c10::complex<float>));
+
+#else
+
+#ifdef CUDART_VERSION
 
 #define CUDABLAS_GELS_BATCHED_ARGTYPES(Dtype)  \
   cublasHandle_t handle, cublasOperation_t trans, int m, int n, int nrhs, Dtype** dA_array, int ldda, Dtype** dC_array, int lddc, int* info, int *devInfoArray, int batchSize
@@ -304,7 +442,9 @@ TORCH_CUDA_CU_API void gelsBatched<c10::complex<double>>(CUDABLAS_GELS_BATCHED_A
 template<>
 TORCH_CUDA_CU_API void gelsBatched<c10::complex<float>>(CUDABLAS_GELS_BATCHED_ARGTYPES(c10::complex<float>));
 
-#endif // CUDART_VERSION
+#endif //CUDART_VERSION
+#endif //USE_ROCM
+
 
 } // namespace blas
 } // namespace cuda

--- a/aten/src/ATen/cuda/Exceptions.h
+++ b/aten/src/ATen/cuda/Exceptions.h
@@ -12,6 +12,9 @@
 #include <c10/util/Exception.h>
 #include <c10/cuda/CUDAException.h>
 
+#ifdef USE_ROCM
+#include <hipblas.h>
+#endif
 
 namespace c10 {
 
@@ -40,9 +43,15 @@ class CuDNNError : public c10::Error {
     }                                                                                           \
   } while (0)
 
+
+
+
+
+
 namespace at { namespace cuda { namespace blas {
 C10_EXPORT const char* _cublasGetErrorEnum(cublasStatus_t error);
 }}} // namespace at::cuda::blas
+
 
 #define TORCH_CUDABLAS_CHECK(EXPR)                              \
   do {                                                          \
@@ -52,6 +61,17 @@ C10_EXPORT const char* _cublasGetErrorEnum(cublasStatus_t error);
                 at::cuda::blas::_cublasGetErrorEnum(__err),     \
                 " when calling `" #EXPR "`");                   \
   } while (0)
+
+#ifdef USE_ROCM
+#define TORCH_HIPBLAS_CHECK(EXPR)								\
+  do {															\
+	hipblasStatus_t __err = EXPR;								\
+	TORCH_CHECK(__err == HIPBLAS_STATUS_SUCCESS,				\
+				"CUDA error: ",									\
+				" when calling `" #EXPR "`");					\
+  } while (0)
+#endif
+
 
 const char *cusparseGetErrorString(cusparseStatus_t status);
 

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
@@ -41,6 +41,8 @@
 #include <magma_v2.h>
 #include <ATen/cuda/detail/CUDAHooks.h>
 
+
+
 const bool use_magma_ = true;
 
 namespace {
@@ -1615,14 +1617,19 @@ static void lu_factor(const Tensor& input, const Tensor& pivots, const Tensor& i
   };
 
   const auto preferred_backend = at::globalContext().linalgPreferredBackend();
-#ifdef USE_CUSOLVER
+#if defined(USE_CUSOLVER) || defined(USE_HIPSOLVER)
   const auto lu_factor_cusolver = [batch_size, m, n](const Tensor& input, const Tensor& pivots, const Tensor& infos, bool compute_pivots) {
     // In CUDA 10.2, lu_factor_looped_cusolver does not finish the computations when the input
     // matrix is exactly singular. The returned pivots contain garbage. This breaks linalg.det
     // Now, batched_cublas does not handle rectangular matrices, so we still dispatch to
     // looped_cusolver even if m != n.
+#ifdef USE_CUSOLVER
     constexpr bool looped_correct = CUSOLVER_VERSION >= 11100;
-    if (m != n || (looped_correct && (batch_size == 1 || m >= 512))) {
+#else
+	bool looped_correct = false;
+#endif
+
+	if (m != n || (looped_correct && (batch_size == 1 || m >= 512))) {
       lu_factor_looped_cusolver(input, pivots, infos, compute_pivots);
     } else {
       lu_factor_batched_cublas(input, pivots, infos, compute_pivots);
@@ -1631,12 +1638,13 @@ static void lu_factor(const Tensor& input, const Tensor& pivots, const Tensor& i
 
   if (preferred_backend == at::LinalgBackend::Cusolver) {
     lu_factor_cusolver(input, pivots, infos, compute_pivots);
-  } else
-#endif // ifdef USE_CUSOLVER
+  }
+  else
+#endif // if USE_CUSOLVER || USE_HIPSOLVER
   if (preferred_backend == at::LinalgBackend::Magma) {
     lu_factor_magma(input, pivots, infos, compute_pivots);
   } else {  // preferred backend == default
-#ifdef USE_CUSOLVER
+#if defined(USE_CUSOLVER) || defined(USE_HIPSOLVER)
 #if AT_MAGMA_ENABLED()
     // If magma batched is buggy, we use cusolver
     // otherwise, lu_factor just works for square matrices, for non-square matrices magma batched is the fastest
@@ -1646,12 +1654,12 @@ static void lu_factor(const Tensor& input, const Tensor& pivots, const Tensor& i
     } else {
       lu_factor_batched_magma(input, pivots, infos, compute_pivots);
     }
-#else // USE_CUSOLVER && !AT_MAGMA_ENABLED
+#else
     lu_factor_cusolver(input, pivots, infos, compute_pivots);
-#endif
-#else // !USE_CUSOLVER
+#endif // AT_MAGMA_ENABLED
+#else
     lu_factor_magma(input, pivots, infos, compute_pivots);
-#endif
+#endif // USE_CUSOLVER || USE_HIPSOLVER
   }
 
   // We return the trivial permutation of pivots starting with 1 (FORTRAN indexing)
@@ -1836,9 +1844,9 @@ void geqrf_magma(const Tensor& input, const Tensor& tau) {
 }
 
 void geqrf_kernel(const Tensor& input, const Tensor& tau) {
-#ifdef CUDART_VERSION
+#if defined(CUDART_VERSION) || defined(USE_ROCM)
   auto geqrf_cusolver_backend = [](const Tensor& input, const Tensor& tau) {
-    #if defined(USE_CUSOLVER)
+#if defined(USE_CUSOLVER) || defined(USE_HIPSOLVER)
       // For the benchmarks see
       // https://github.com/pytorch/pytorch/pull/56253#discussion_r622851107
       if (input.size(-2) <= 256 && batchCount(input) >= std::max<int64_t>(2, input.size(-2) / 16)) {
@@ -1846,7 +1854,7 @@ void geqrf_kernel(const Tensor& input, const Tensor& tau) {
       } else {
         return geqrf_cusolver(input, tau);
       }
-    #endif
+#endif
       return geqrf_batched_cublas(input, tau);
   };
 
@@ -2530,13 +2538,11 @@ static void lu_solve_kernel(const Tensor& LU, const Tensor& pivots, const Tensor
     }
   };
 
-#ifdef CUDART_VERSION
   auto lu_solve_batched_cublas_fn = [](const Tensor& LU, const Tensor& pivots, const Tensor& B, TransposeType trans) {
     auto LU_ = maybe_expand_lu(B, LU);
     auto pivots_ = maybe_expand_pivots(B, pivots);
     lu_solve_batched_cublas(*LU_, *pivots_, B, trans);
   };
-#endif
 
   auto lu_solve_batched_magma_fn = [](const Tensor& LU, const Tensor& pivots, const Tensor& B, TransposeType trans) {
     auto LU_ = maybe_expand_lu(B, LU);
@@ -2547,7 +2553,7 @@ static void lu_solve_kernel(const Tensor& LU, const Tensor& pivots, const Tensor
 
   // Preferred Backend
   auto preferred_backend = at::globalContext().linalgPreferredBackend();
-#ifdef USE_CUSOLVER
+#if defined(USE_CUSOLVER) || defined(USE_HIPSOLVER)
   if (preferred_backend == at::LinalgBackend::Cusolver) {
     if (b <= 2 && n >= 64) {
       lu_solve_looped_cusolver(LU, pivots, B, trans);
@@ -2555,8 +2561,8 @@ static void lu_solve_kernel(const Tensor& LU, const Tensor& pivots, const Tensor
       lu_solve_batched_cublas_fn(LU, pivots, B, trans);
     }
     return;
-  } else
-#endif // ifdef USE_CUSOLVER
+  } else 
+#endif // if USE_CUSOLVER || USE_HIPSOLVER
   if (preferred_backend == at::LinalgBackend::Magma) {
     // Looped magma is very slow, but batched magma is buggy in these two cases
     if (!over_batched_magma_dim_limit && trans == TransposeType::NoTranspose) {
@@ -2596,18 +2602,15 @@ static void lu_solve_kernel(const Tensor& LU, const Tensor& pivots, const Tensor
   // Particular case when multiplying A^{-1}B where B is square
   // In this case doing two triangular solves is almost always fastest
   if (n == k) {
-#ifdef CUDART_VERSION
     if (n <= 16) {
       lu_solve_batched_cublas_fn(LU, pivots, B, trans);
       return;
     }
-#endif
     lu_solve_triangular(LU, pivots, B, trans);
     return;
   }
 
-#ifdef CUDART_VERSION
-#ifdef USE_CUSOLVER
+#if defined(USE_CUSOLVER) || defined(USE_HIPSOLVER)
 if (n <= 8) {
   if (use_magma_ && !over_batched_magma_dim_limit && trans == TransposeType::NoTranspose && k >= 256) {
     lu_solve_batched_magma_fn(LU, pivots, B, trans);
@@ -2633,11 +2636,7 @@ if (n <= 8) {
 } else { // n > 128
   lu_solve_triangular(LU, pivots, B, trans);
 }
-#endif // ifdef USE_CUSOLVER
-#else  // No cublas or cusolver
-  // lu_solve_triangular is almost always best
-  lu_solve_triangular(LU, pivots, B, trans);
-#endif // ifdef CUDART_VERSION
+#endif // ifdef USE_CUSOLVER || USE_HIPSOLVER
 }
 
 REGISTER_CUDA_DISPATCH(lu_solve_stub, &lu_solve_kernel);
@@ -2734,7 +2733,6 @@ void linalg_lstsq_gels(const Tensor& A, const Tensor& B, const Tensor& /*infos*/
         /*unitriangular=*/false);
   } else { // underdetermined case
     Tensor Ah = cloneBatchedColumnMajor(A.mH());
-
     // Step 1: compute QR factorization of conjugate transpose of A using geqrf
     geqrf_kernel(Ah, tau);
 
@@ -2805,7 +2803,7 @@ void lstsq_kernel(const Tensor& a, Tensor& b, Tensor& /*rank*/, Tensor& /*singul
         "Please rebuild with cuSOLVER.");
 #endif
   } else { // m >= n
-#if !AT_ROCM_ENABLED()
+//#if !AT_ROCM_ENABLED()
     // On CUDA platform we use either cuBLAS or cuSOLVER here
     // the batched vs looped dispatch is implemented based on the following performance results
     // https://github.com/pytorch/pytorch/pull/54725#issuecomment-832234456
@@ -2814,11 +2812,13 @@ void lstsq_kernel(const Tensor& a, Tensor& b, Tensor& /*rank*/, Tensor& /*singul
     } else {
       gels_looped(a, b, infos);
     }
+/*
 #else
     // On ROCm platform we can only use MAGMA here
     // If MAGMA is not available, an error will be thrown
     gels_magma(a, b, infos);
 #endif // !AT_ROCM_ENABLED()
+*/
   }
 }
 

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
@@ -27,6 +27,8 @@
 #include <ATen/ops/zeros.h>
 #endif
 
+
+
 namespace at {
 namespace native {
 
@@ -60,12 +62,6 @@ static Tensor get_device_pointers(const Tensor& input) {
 
 template <typename scalar_t>
 void apply_geqrf_batched(const Tensor& input, const Tensor& tau) {
-// AMD ROCm backend is implemented via rewriting all CUDA calls to HIP
-// rocBLAS does not implement BLAS-like extensions of cuBLAS, they're in rocSOLVER
-// rocSOLVER is currently not used in ATen, therefore we raise an error in this case
-#ifndef CUDART_VERSION
-  TORCH_CHECK(false, "geqrf: Batched version is supported only with cuBLAS backend.")
-#else
   auto batch_size = cuda_int_cast(batchCount(input), "batch_size");
   auto m = cuda_int_cast(input.size(-2), "m");
   auto n = cuda_int_cast(input.size(-1), "n");
@@ -84,7 +80,6 @@ void apply_geqrf_batched(const Tensor& input, const Tensor& tau) {
   // info only indicates wrong arguments to geqrfBatched call
   // info is a host variable, we can check it without device synchronization
   TORCH_INTERNAL_ASSERT(info == 0);
-#endif
 }
 
 void geqrf_batched_cublas(const Tensor& input, const Tensor& tau) {
@@ -95,9 +90,6 @@ void geqrf_batched_cublas(const Tensor& input, const Tensor& tau) {
 
 template <typename scalar_t>
 static void apply_lu_factor_batched_cublas(const Tensor& A, const Tensor& pivots, const Tensor& infos, bool get_pivots) {
-#ifndef CUDART_VERSION
-  TORCH_CHECK(false, "linalg.lu_factor: cuBLAS backend for linalg.lu_factor is not available.")
-#else
   // This function just works with square matrices
   TORCH_INTERNAL_ASSERT(A.size(-2) == A.size(-1));
 
@@ -111,7 +103,6 @@ static void apply_lu_factor_batched_cublas(const Tensor& A, const Tensor& pivots
   auto a_ptr_array_data = reinterpret_cast<scalar_t**>(a_ptr_array.data_ptr());
 
   at::cuda::blas::getrfBatched(n, a_ptr_array_data, lda, pivots_data, infos_data, batch_size);
-#endif
 }
 
 void lu_factor_batched_cublas(const Tensor& A, const Tensor& pivots, const Tensor& infos, bool get_pivots) {
@@ -122,15 +113,16 @@ void lu_factor_batched_cublas(const Tensor& A, const Tensor& pivots, const Tenso
 
 template <typename scalar_t>
 static void apply_lu_solve_batched_cublas(const Tensor& LU, const Tensor& pivots, const Tensor& B, TransposeType transpose) {
-#ifndef CUDART_VERSION
-  TORCH_CHECK(false, "linalg.lu_solve: cuBLAS backend for linalg.lu_solve is not available.")
-#else
-  TORCH_INTERNAL_ASSERT(batchCount(LU) == batchCount(B), "batch_size of LU and B must be the same");
-  TORCH_INTERNAL_ASSERT(batchCount(LU) == batchCount(pivots.unsqueeze(-1)), "batch_size of LU and pivots must be the same");
-  const auto trans = to_cublas(transpose);
 
+  TORCH_INTERNAL_ASSERT(batchCount(B) == batchCount(LU), "batch_size of b and lu must be the same");
+  TORCH_INTERNAL_ASSERT(batchCount(LU) == batchCount(pivots.unsqueeze(-1)), "batch_size of lu and pivots must be the same");
+#ifdef USE_ROCM
+  const auto trans = (hipblasOperation_t)to_cublas(transpose);
+#else
+  const auto trans = to_cublas(transpose);
+#endif
   auto pivots_data = pivots.data_ptr<int>();
-  auto batch_size = cuda_int_cast(batchCount(LU), "batch_size");;
+  auto batch_size = cuda_int_cast(batchCount(LU), "batch_size");
   auto m = cuda_int_cast(LU.size(-2), "m");
   auto nrhs = cuda_int_cast(B.size(-1), "nrhs");
   auto lda = cuda_int_cast(std::max<int>(1, m), "lda");
@@ -145,7 +137,6 @@ static void apply_lu_solve_batched_cublas(const Tensor& LU, const Tensor& pivots
   at::cuda::blas::getrsBatched(handle, trans, m, nrhs, lu_ptr_array_data,
     lda, pivots_data, b_ptr_array_data, lda, &info, batch_size);
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(info == 0);
-#endif
 }
 
 void lu_solve_batched_cublas(const Tensor& LU, const Tensor& pivots, const Tensor& B, TransposeType trans) {
@@ -416,19 +407,15 @@ void triangular_solve_batched_cublas(const Tensor& A, const Tensor& B, bool left
 
 template <typename scalar_t>
 inline void apply_gels_batched(const Tensor& A, Tensor& B, Tensor& infos) {
-// AMD ROCm backend is implemented via rewriting all CUDA calls to HIP
-// rocBLAS does not implement BLAS-like extensions of cuBLAS, they're in rocSOLVER
-// rocSOLVER is currently not used in ATen, therefore we raise an error in this case
-#ifndef CUDART_VERSION
-  TORCH_CHECK(false, "torch.linalg.lstsq: Batched version is supported only with cuBLAS backend.")
-#else
-#ifdef ROCM_VERSION
+#if defined(ROCM_VERSION) && (ROCM_VERSION >= 50400)
   // Cannot auto-hipifiy this piece of code, because in other functions
   // CUBLAS_OP_N must be translated to HIPSOLVER_OP_N
-  auto trans = rocblas_operation_none;
+  auto trans = HIPBLAS_OP_N;
 #else
   auto trans = CUBLAS_OP_N;
 #endif
+
+#if defined(CUDART_VERSION) || (defined(ROCM_VERSION) && (ROCM_VERSION >= 50400))
   auto m = cuda_int_cast(A.size(-2), "m");
   auto n = cuda_int_cast(A.size(-1), "n");
 
@@ -521,12 +508,9 @@ static void apply_batched_inverse_lib(Tensor& self, Tensor& self_inv, Tensor& in
 
   auto& allocator = *::c10::cuda::CUDACachingAllocator::get();
 
-  // at::cuda::blas::getr.Batched functions are only available with cuSPARSE
-#ifdef CUDART_VERSION
   // Heuristic: For small batch size or large matrix size, we use for-loop to iterate over the batches instead of
-  //            calling the batched cublas routine.
+  // calling the batched cublas routine.
   if (batch_size <= 8 || /* batch_size > 8 && */ n >= 512) {
-#endif
     for (int64_t i = 0; i < batch_size; i++) {
       auto dataPtr = allocator.allocate(sizeof(int) * lda);
       int* pivot = reinterpret_cast<int*>(dataPtr.get());
@@ -537,7 +521,6 @@ static void apply_batched_inverse_lib(Tensor& self, Tensor& self_inv, Tensor& in
       _apply_single_inverse_helper<scalar_t>(
         &self_data[i * self_mat_stride], &self_inv_data[i * self_inv_mat_stride], pivot, infos_getrf_working_ptr, infos_getrs_working_ptr, n, lda);
     }
-#ifdef CUDART_VERSION
   } else {
     // cublas batched kernels require input be "device array of device pointers"
     Tensor self_array = at::arange(
@@ -552,13 +535,14 @@ static void apply_batched_inverse_lib(Tensor& self, Tensor& self_inv, Tensor& in
     auto dataPtr = allocator.allocate(sizeof(int)*batch_size*lda);
     int* ipiv_array = reinterpret_cast<int*>(dataPtr.get());
 
+
     at::cuda::blas::getrfBatched<scalar_t>(n, reinterpret_cast<scalar_t**>(self_array.data_ptr()), lda,
       ipiv_array, infos_getrf_data, batch_size);
+
 
     at::cuda::blas::getriBatched<scalar_t>(n, reinterpret_cast<scalar_t**>(self_array.data_ptr()), lda,
       ipiv_array, reinterpret_cast<scalar_t**>(self_inv_array.data_ptr()), lda, infos_getrs_data, batch_size);
   }
-#endif
 }
 
 template <typename scalar_t>

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.h
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.h
@@ -8,6 +8,12 @@
 #include <ATen/native/TransposeType.h>
 #include <ATen/native/cuda/MiscUtils.h>
 
+
+#ifdef USE_ROCM
+#include <hipblas.h>
+#endif
+
+
 #if defined(CUDART_VERSION) && defined(CUSOLVER_VERSION)
 #define USE_CUSOLVER
 #endif

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -1,5 +1,4 @@
 #pragma once
-
 #include <c10/core/Backend.h>
 #include <c10/core/CopyBytes.h>
 #include <c10/core/DispatchKeySet.h>

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -3607,10 +3607,10 @@ class TestLinalg(TestCase):
                                     "The QR decomposition is not differentiable when mode='complete' and nrows > ncols"):
             b.backward()
 
-    @skipCUDAIfNoCusolver
     @skipCPUIfNoLapack
     @dtypes(torch.float, torch.double, torch.cfloat, torch.cdouble)
     def test_qr_batched(self, device, dtype):
+        torch.backends.cuda.preferred_linalg_library("cusolver")
         """
         test torch.linalg.qr vs numpy.linalg.qr. We need some special logic
         because numpy does not support batched qr
@@ -6914,6 +6914,7 @@ scipy_lobpcg  | {:10.2e}  | {:10.2e}  | {:6} | N/A
     @precisionOverride({torch.float32: 1e-3, torch.complex64: 1e-3,
                         torch.float64: 1e-8, torch.complex128: 1e-8})
     def test_lu_solve_batched(self, device, dtype):
+        torch.backends.cuda.preferred_linalg_library('cusolver')
         def sub_test(pivot):
             def lu_solve_batch_test_helper(A_dims, b_dims, pivot):
                 b, A, LU_data, LU_pivots = self.lu_solve_test_helper(A_dims, b_dims, pivot, device, dtype)

--- a/torch/utils/hipify/cuda_to_hip_mappings.py
+++ b/torch/utils/hipify/cuda_to_hip_mappings.py
@@ -6489,35 +6489,51 @@ CUDA_IDENTIFIER_MAP = collections.OrderedDict(
         ("cublasZgeam", ("rocblas_zgeam", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED)),
         (
             "cublasSgetrfBatched",
-            ("rocblas_sgetrf_batched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
+            ("hipblasSgetrfBatched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
         ),
         (
             "cublasDgetrfBatched",
-            ("rocblas_dgetrf_batched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
+            ("hipblasDgetrfBatched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
         ),
         (
             "cublasCgetrfBatched",
-            ("rocblas_cgetrf_batched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
+            ("hipblasCgetrfBatched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
         ),
         (
             "cublasZgetrfBatched",
-            ("rocblas_zgetrf_batched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
+            ("hipblasZgetrfBatched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
+        ),
+        (
+            "cublasSgetriBatched",
+            ("hipblasSgetriBatched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
+        ),
+        (
+            "cublasDgetriBatched",
+            ("hipblasDgetriBatched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
+        ),
+        (
+            "cublasCgetriBatched",
+            ("hipblasCgetriBatched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
+        ),
+        (
+            "cublasZgetriBatched",
+            ("hipblasZgetriBatched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
         ),
         (
             "cublasSgetrsBatched",
-            ("rocblas_sgetrs_batched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
+            ("hipblasSgetrsBatched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
         ),
         (
             "cublasDgetrsBatched",
-            ("rocblas_dgetrs_batched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
+            ("hipblasDgetrsBatched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
         ),
         (
             "cublasCgetrsBatched",
-            ("rocblas_cgetrs_batched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
+            ("hipblasCgetrsBatched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
         ),
         (
             "cublasZgetrsBatched",
-            ("rocblas_zgetrs_batched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
+            ("hipblasZgetrsBatched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
         ),
         (
             "cublasStrsmBatched",
@@ -6553,19 +6569,19 @@ CUDA_IDENTIFIER_MAP = collections.OrderedDict(
         ),
         (
             "cublasSgeqrfBatched",
-            ("rocblas_sgeqrf_batched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
+            ("hipblasSgeqrfBatched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
         ),
         (
             "cublasDgeqrfBatched",
-            ("rocblas_dgeqrf_batched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
+            ("hipblasDgeqrfBatched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
         ),
         (
             "cublasCgeqrfBatched",
-            ("rocblas_cgeqrf_batched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
+            ("hipblasDgeqrfBatched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
         ),
         (
             "cublasZgeqrfBatched",
-            ("rocblas_zgeqrf_batched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
+            ("hipblasZgeqrfBatched", CONV_MATH_FUNC, API_BLAS, HIP_UNSUPPORTED),
         ),
         (
             "cublasSgelsBatched",


### PR DESCRIPTION
Switching to hipsolver backend from magma for these operators. Related JIRA: [SWDEV-344553](https://ontrack-internal.amd.com/browse/SWDEV-344553)

Affected unit tests:

= <float32|float64|complex64|complex128>
test_meta.py TestMetaCUDA.test_meta_linalg_lu_factor_cuda_*
test_linalg.py TestLinalgCUDA.test_lu_solve_batched_cuda_*
test_meta.py TestMetaCUDA.test_meta_geqrf_cuda_*
test_linalg.py TestLinalgCUDA.test_linalg_lstsq_cuda*