### PR TITLE
[DON'T REVIEW] Update Apex commit for ROCm5.3 to bypass Atomic.cuh not found error

### DIFF
--- a/related_commits
+++ b/related_commits
@@ -1,5 +1,5 @@
-ubuntu|pytorch|apex|master|none|https://github.com/ROCmSoftwarePlatform/apex
-centos|pytorch|apex|master|none|https://github.com/ROCmSoftwarePlatform/apex
+ubuntu|pytorch|apex|master|ae5ca6711a83ba48a1ac72e13c96dd210d57112f|https://github.com/ROCmSoftwarePlatform/apex
+centos|pytorch|apex|master|ae5ca6711a83ba48a1ac72e13c96dd210d57112f|https://github.com/ROCmSoftwarePlatform/apex
 ubuntu|pytorch|torchvision|main|369317f45354248582884f6e2f500b7cebea2236|https://github.com/pytorch/vision
 centos|pytorch|torchvision|main|369317f45354248582884f6e2f500b7cebea2236|https://github.com/pytorch/vision
 ubuntu|pytorch|torchtext|main|99c2735662a3b3701853e2a76d4c0b1df5bafa70|https://github.com/ROCmSoftwarePlatform/text


### PR DESCRIPTION
Since this error only occurs in 1.10 but not in 1.11 and 1.12, using the commit before [--index_mul_2d extension enablement](https://github.com/ROCmSoftwarePlatform/apex/commit/7a344314aff007dbd44b8e751560d779835cae2f) can bypass the error.

