### PR TITLE
Added apex TOT to related_commits

### DIFF
--- a/related_commits
+++ b/related_commits
@@ -1,5 +1,5 @@
-ubuntu|pytorch|apex|master|none|https://github.com/ROCmSoftwarePlatform/apex
-centos|pytorch|apex|master|none|https://github.com/ROCmSoftwarePlatform/apex
+ubuntu|pytorch|apex|master|719215bd0f62f4a8b7f1271ec093a5ed470338e7|https://github.com/ROCmSoftwarePlatform/apex
+centos|pytorch|apex|master|719215bd0f62f4a8b7f1271ec093a5ed470338e7|https://github.com/ROCmSoftwarePlatform/apex
 ubuntu|pytorch|torchvision|main|369317f45354248582884f6e2f500b7cebea2236|https://github.com/pytorch/vision
 centos|pytorch|torchvision|main|369317f45354248582884f6e2f500b7cebea2236|https://github.com/pytorch/vision
 ubuntu|pytorch|torchtext|main|99c2735662a3b3701853e2a76d4c0b1df5bafa70|https://github.com/ROCmSoftwarePlatform/text


### PR DESCRIPTION
To avoid future complications in triaging we have added the apex commit in related_commits to the rocm5.3_internal_testing and rocm5.4_internal_testing branches.

