### PR TITLE
Move distributed case before single-GPU cases

### DIFF
--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -517,6 +517,9 @@ elif [[ "${BUILD_ENVIRONMENT}" == *jit_legacy-test || "${JOB_BASE_NAME}" == *jit
 elif [[ "${BUILD_ENVIRONMENT}" == *libtorch* ]]; then
   # TODO: run some C++ tests
   echo "no-op at the moment"
+elif [[ "${BUILD_ENVIRONMENT}" == *distributed* ]]; then
+  test_distributed
+  test_rpc
 elif [[ "${BUILD_ENVIRONMENT}" == *-test1 || "${JOB_BASE_NAME}" == *-test1 || "${SHARD_NUMBER}" == 1 ]]; then
   if [[ "${BUILD_ENVIRONMENT}" == *linux-xenial-cuda11.1*-test1* ]]; then
     test_torch_deploy
@@ -536,9 +539,6 @@ elif [[ "${BUILD_ENVIRONMENT}" == *vulkan-linux* ]]; then
   test_vulkan
 elif [[ "${BUILD_ENVIRONMENT}" == *-bazel-* ]]; then
   test_bazel
-elif [[ "${BUILD_ENVIRONMENT}" == *distributed* ]]; then
-  test_distributed
-  test_rpc
 elif [[ "${TEST_CONFIG}" = docs_test ]]; then
   test_docs_test
 else


### PR DESCRIPTION
so that distributed CI actually runs distributed UTs. This is needed because otherwise the `SHARD_NUMBER` being defined [here](https://github.com/ROCmSoftwarePlatform/rocAutomation/blob/jenkins-pipelines/pytorch/pytorch_ci/test_pytorch_test_distributed_1.sh#L73) ends up triggering single-GPU unit tests
