### PR TITLE
Fix the distribution of the Ubuntu repo for ROCm 5.3 installation

### DIFF
--- a/.circleci/docker/common/install_rocm.sh
+++ b/.circleci/docker/common/install_rocm.sh
@@ -71,6 +71,10 @@ install_ubuntu() {
         ROCM_REPO="xenial"
     fi
 
+    if [[ $(ver $ROCM_VERSION) -ge $(ver 5.3) ]]; then
+        ROCM_REPO="${UBUNTU_VERSION_NAME}"
+    fi
+
     # Add rocm repository
     wget -qO - http://repo.radeon.com/rocm/rocm.gpg.key | apt-key add -
     local rocm_baseurl="http://repo.radeon.com/rocm/apt/${ROCM_VERSION}"


### PR DESCRIPTION
Fixes #ISSUE_NUMBER

The ROCM_REPO will follow the distribution of Ubuntu after ROCm5.3.
e.g. "focal" is used for Ubuntu 20.04.