### PR TITLE
[CI ONLY] Use release/1.10.1 branch for CI scripts

### DIFF
--- a/.jenkins/pytorch/common_utils.sh
+++ b/.jenkins/pytorch/common_utils.sh
@@ -65,7 +65,7 @@ function file_diff_from_base() {
   set +e
   git fetch origin release/1.10.1 --quiet
   set -e
-  git diff --name-only "$(git merge-base origin/release/1.10 HEAD)" > "$1"
+  git diff --name-only "$(git merge-base origin/release/1.10.1 HEAD)" > "$1"
 }
 
 function get_bazel() {

--- a/.jenkins/pytorch/common_utils.sh
+++ b/.jenkins/pytorch/common_utils.sh
@@ -63,7 +63,7 @@ function get_pr_change_files() {
 function file_diff_from_base() {
   # The fetch may fail on Docker hosts, this fetch is necessary for GHA
   set +e
-  git fetch origin release/1.10 --quiet
+  git fetch origin release/1.10.1 --quiet
   set -e
   git diff --name-only "$(git merge-base origin/release/1.10 HEAD)" > "$1"
 }


### PR DESCRIPTION
CI scripts currently pull `release/1.10` branch. But since we limit refspec to `release/1.10.1` in CI job, it results in errors such as:
http://rocmhead.amd.com:8080/job/pytorch/job/pytorch-test-1/389/console
```
17:42:52 Oct 03 22:42:52 + file_diff_from_base /tmp/tmp.6vpKW8MKN0
17:42:52 Oct 03 22:42:52 + set +e
17:42:52 Oct 03 22:42:52 + git fetch origin release/1.10 --quiet
17:42:53 Oct 03 22:42:53 + set -e
17:42:53 Oct 03 22:42:53 ++ git merge-base origin/release/1.10 HEAD
17:42:53 Oct 03 22:42:53 fatal: Not a valid object name origin/release/1.10
17:42:53 Oct 03 22:42:53 + git diff --name-only ''
17:42:53 Oct 03 22:42:53 fatal: ambiguous argument '': unknown revision or path not in the working tree.
17:42:53 Oct 03 22:42:53 Use '--' to separate paths from revisions, like this:
17:42:53 Oct 03 22:42:53 'git <command> [<revision>...] -- [<file>...]'
```

Also, the script should probably be using `release/1.10.1` to figure out diffs anyway.