### PR TITLE
[ROCm] add case for FP32MatMulPattern skip property

### DIFF
--- a/torch/profiler/_pattern_matcher.py
+++ b/torch/profiler/_pattern_matcher.py
@@ -301,9 +301,12 @@ class FP32MatMulPattern(Pattern):
 
     @property
     def skip(self):
-        # Anything less than sm_80 is not Ampere which doesn't support TF32
-        has_tf32 = all(
-            int(arch[3:]) >= 80 for arch in torch.cuda.get_arch_list())
+        if torch.version.hip:
+            has_tf32 = False
+        else:
+            # Anything less than sm_80 is not Ampere which doesn't support TF32
+            has_tf32 = all(
+                int(arch[3:]) >= 80 for arch in torch.cuda.get_arch_list())
         return has_tf32 is False or super().skip or not self.prof.record_shapes
 
     def match(self, event: _ProfilerEvent):


### PR DESCRIPTION
TF32 is not supported on ROCm and hence the torch/profiler/_pattern_matcher.py FP32MatMulPattern should return False for ROCm instead of checking the results of torch.cuda.get_arch_list(). Depending on the gfx arch running the test, test_profiler.py's test_profiler_fp32_matmul_pattern (main.TestExperimentalUtils) will fail otherwise.

Signed-off-by: Jagadish Krishnamoorthy <jagdish.krishna@gmail.com>

