### PR TITLE
Skipping test on branch with no MIOpen immediate mode support

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -18347,6 +18347,8 @@ class TestNNDeviceType(NNTestCase):
                 self.assertEqual(q.size(), out[0].size())
                 self.assertEqual(dtype, out[0].dtype)
 
+    # Skip the test for ROCm as per https://ontrack-internal.amd.com/browse/SWDEV-355273
+    @skipIfRocm
     @dtypesIfCUDA(*floating_types_and(torch.half, *[torch.bfloat16] if AMPERE_OR_ROCM else []))
     @dtypes(torch.float)
     def test_Conv2d_naive_groups(self, device, dtype):


### PR DESCRIPTION
Support for MIOpen immediate mode is not enabled in release/1.11 release/1.12 branches which is required
for the test_Conv2d_naive_groups test to pass - https://ontrack-internal.amd.com/browse/SWDEV-355273

Copy from https://github.com/ROCmSoftwarePlatform/pytorch/commit/ae2949bf77745b987cd9d80b4eaf58c972ed0537