### PR TITLE
Cherry-pick the fix to resolve missing deprecated distributed_c10d._get_global_rank

### DIFF
--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -350,6 +350,18 @@ def get_global_rank(group: ProcessGroup, group_rank: int) -> int:
             return rank
     raise RuntimeError(f"Group rank {group_rank} is not part of group {group}")
 
+# TODO: remove this once the ecosystem moves away from it.
+def _get_global_rank(group, rank):
+    """
+    This method is deprecated, please use get_global_rank.
+    """
+    warnings.warn(
+        "torch.distributed.distributed_c10d._get_global_rank is deprecated "
+        "please use torch.distributed.distributed_c10d.get_global_rank instead"
+    )
+    return get_global_rank(group, rank)
+
+
 def get_process_group_ranks(group: ProcessGroup):
     """
     Get all ranks associated with ``group``.


### PR DESCRIPTION
Cherry-picked the fix from https://github.com/pytorch/pytorch/pull/84363.

`torch.distributed.distributed_c10d._get_global_rank` is going to be deprecated in the future when the ecosystem moves away from it, but not now.
It will be replaced with `torch.distributed.distributed_c10d.get_global_rank` later.

