### PR TITLE
Add test_jit_cuda_fuser to ROCM_BLOCKLIST

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -246,6 +246,7 @@ ROCM_BLOCKLIST = [
     "distributed/_shard/test_replicated_tensor",
     "test_determination",
     "test_jit_legacy",
+    "test_jit_cuda_fuser", # Skipped until NVFuser enabled - https://ontrack-internal.amd.com/browse/SWDEV-361875
     "test_openmp",
 ]
 


### PR DESCRIPTION
Skips test_jit_cuda_fuser UTs in rocm5.4_internal_testing.

These tests were enabled in the latest IFU but are causing issues one some architectures due to lack of full NVfuser support. For now skip testing this file until fix is available. 

For full context and information:
- Follows on from: https://github.com/ROCmSoftwarePlatform/pytorch/pull/1136
- Ticket addressing: https://ontrack-internal.amd.com/browse/SWDEV-361875