### PR TITLE
update endpointdev repo

### DIFF
--- a/.circleci/docker/centos-rocm/Dockerfile
+++ b/.circleci/docker/centos-rocm/Dockerfile
@@ -18,7 +18,7 @@ RUN bash ./install_base.sh && rm install_base.sh
 # Update CentOS git version
 RUN yum -y remove git
 RUN yum -y remove git-*
-RUN yum -y install https://packages.endpoint.com/rhel/7/os/x86_64/endpoint-repo-1.9-1.x86_64.rpm
+RUN yum -y install https://packages.endpointdev.com/rhel/7/os/x86_64/endpoint-repo-1.9-1.x86_64.rpm
 RUN yum install -y git
 
 # Install devtoolset


### PR DESCRIPTION
Fixes #ISSUE_NUMBER


CentOS7 jobs are failing currently due to below issue. 

http://rocm-ci.amd.com/job/mainline-framework-pytorch-ci/608/console

 
https://packages.endpoint.com/rhel/7/os/x86_64/endpoint-repo-1.9-1.x86_64.rpm file is not accessible.
Not sure temporary issue. Not able to open the page too in web browser.

 

10:51:02  Removing intermediate container 3c0b159e80cb
10:51:02   ---> a2efbf298963
10:51:02  Step 11/74 : RUN yum -y install https://packages.endpoint.com/rhel/7/os/x86_64/endpoint-repo-1.9-1.x86_64.rpm
10:51:02   ---> Running in 33d38ae51228
10:51:03  Loaded plugins: fastestmirror, ovl
10:51:03  [91mCannot open: https://packages.endpoint.com/rhel/7/os/x86_64/endpoint-repo-1.9-1.x86_64.rpm. Skipping.
10:51:03  Error: Nothing to do
10:51:03  [0mThe command '/bin/sh -c yum -y install https://packages.endpoint.com/rhel/7/os/x86_64/endpoint-repo-1.9-1.x86_64.rpm' returned a non-zero code: 1
10:51:03  [ pytorch base image build is NOT successful ]