### PR TITLE
Disable check_cuda on ROCm

### DIFF
--- a/tools/dynamo/verify_dynamo.py
+++ b/tools/dynamo/verify_dynamo.py
@@ -150,9 +150,10 @@ _SANITY_CHECK_ARGS = (
 
 
 def main():
+    import torch
     python_ver = check_python()
     torch_ver = check_torch()
-    cuda_ver = check_cuda()
+    cuda_ver = check_cuda() if torch.version.hip is None else "None"
     print(
         f"Python version: {python_ver.major}.{python_ver.minor}.{python_ver.micro}\n"
         f"`torch` version: {torch_ver}\n"


### PR DESCRIPTION
Skips check_cuda() on ROCm in tools/dynamo/verify_dynamo.py

Output:
```
Python version: 3.8.15
`torch` version: 2.0.0a0+gitc0e9a5f
CUDA version: None

/opt/conda/lib/python3.8/site-packages/torch/_dynamo/eval_frame.py:372: UserWarning: TensorFloat32 tensor cores for float32 matrix multiplication available but not enabled.Consider setting `torch.set_float32_matmul_precision('high')`
  warnings.warn(
/opt/conda/lib/python3.8/site-packages/torch/_dynamo/eval_frame.py:372: UserWarning: TensorFloat32 tensor cores for float32 matrix multiplication available but not enabled.Consider setting `torch.set_float32_matmul_precision('high')`
  warnings.warn(
/opt/conda/lib/python3.8/site-packages/torch/_dynamo/eval_frame.py:372: UserWarning: TensorFloat32 tensor cores for float32 matrix multiplication available but not enabled.Consider setting `torch.set_float32_matmul_precision('high')`
  warnings.warn(
All required checks passed
```