### PR TITLE
Fix for inductor_skips_rocm

### DIFF
--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -121,6 +121,7 @@ if COLLECT_EXPECT:
     atexit.register(print_seen)
 
 inductor_skips = defaultdict(dict)
+inductor_skips_rocm = defaultdict(dict)
 
 inductor_skips["cpu"] = {
     "linalg.ldl_solve": {b8, f16, f32, f64, i32, i64},  # segfault


### PR DESCRIPTION
Ran into an issue with https://github.com/ROCmSoftwarePlatform/pytorch/pull/1159

'inductor_skips_rocm' dict must be defined before use or following error occurs

```
_________ ERROR collecting test/inductor/test_torchinductor_opinfo.py __________
Traceback (most recent call last):
  File "/var/lib/jenkins/pytorch/test/inductor/test_torchinductor_opinfo.py", line 185, in <module>
    inductor_skips_rocm["cuda"] = {
NameError: name 'inductor_skips_rocm' is not defined
```

