### PR TITLE
Added MIOpen header files to installation package for ROCm.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1055,6 +1055,7 @@ def main():
         'include/ATen/hip/detail/*.cuh',
         'include/ATen/hip/detail/*.h',
         'include/ATen/hip/impl/*.h',
+        'include/ATen/miopen/*.h',
         'include/ATen/detail/*.h',
         'include/ATen/native/*.h',
         'include/ATen/native/cpu/*.h',


### PR DESCRIPTION
Added MIOpen header files to installation package for building Pytorch Extensions that requires MIOpen as a dependency.
