### PR TITLE
Implement check_rocm for verify_dynamo.py

### DIFF
--- a/tools/dynamo/verify_dynamo.py
+++ b/tools/dynamo/verify_dynamo.py
@@ -8,6 +8,7 @@ import warnings
 from pkg_resources import packaging
 
 MIN_CUDA_VERSION = packaging.version.parse("11.6")
+MIN_ROCM_VERSION = packaging.version.parse("5.4")
 MIN_PYTHON_VERSION = (3, 7)
 
 
@@ -51,6 +52,27 @@ def get_cuda_version():
     cuda_str_version = cuda_version.group(1)
     return packaging.version.parse(cuda_str_version)
 
+def get_rocm_version():
+    from torch.utils import cpp_extension
+
+    ROCM_HOME = cpp_extension._find_rocm_home()
+    if not ROCM_HOME:
+        raise VerifyDynamoError("ROCM was not found on the system, please set ROCM_HOME environment variable")
+
+    hipcc = os.path.join(ROCM_HOME, "bin", "hipcc")
+    hip_version_str = (
+        subprocess.check_output([hipcc, "--version"])
+        .strip()
+        .decode(*cpp_extension.SUBPROCESS_DECODE_ARGS)
+    )
+    hip_version = re.search(r"HIP version: (\d+[.]\d+)", hip_version_str)
+
+    if hip_version is None:
+        raise VerifyDynamoError("HIP version not found in `hipcc --version` output")
+
+    hip_str_version = hip_version.group(1)
+
+    return packaging.version.parse(hip_str_version)
 
 def check_cuda():
     import torch
@@ -83,6 +105,33 @@ def check_cuda():
 
     return cuda_ver
 
+def check_rocm():
+    import torch
+
+    if not torch.cuda.is_available():
+        return None
+
+    # Extracts main ROCm version from full string
+    torch_rocm_ver = packaging.version.parse('.'.join(list(torch.version.hip.split(".")[0:2])))
+
+    # check if torch rocm version matches system rocm version
+    rocm_ver = get_rocm_version()
+    if rocm_ver != torch_rocm_ver:
+        warnings.warn(
+            f"ROCm version mismatch, `torch` version: {torch_rocm_ver}, env version: {rocm_ver}"
+        )
+    if torch_rocm_ver < MIN_ROCM_VERSION:
+        warnings.warn(
+            f"(`torch`) ROCm version not supported: {torch_rocm_ver} "
+            f"- minimum requirement: {MIN_ROCM_VERSION}"
+        )
+    if rocm_ver < MIN_ROCM_VERSION:
+        warnings.warn(
+            f"(env) ROCm version not supported: {rocm_ver} "
+            f"- minimum requirement: {MIN_ROCM_VERSION}"
+        )
+
+    return rocm_ver
 
 def check_dynamo(backend, device, err_msg):
     import torch
@@ -154,10 +203,12 @@ def main():
     python_ver = check_python()
     torch_ver = check_torch()
     cuda_ver = check_cuda() if torch.version.hip is None else "None"
+    rocm_ver = check_rocm() if not torch.version.hip is None else "None"
     print(
         f"Python version: {python_ver.major}.{python_ver.minor}.{python_ver.micro}\n"
         f"`torch` version: {torch_ver}\n"
         f"CUDA version: {cuda_ver}\n"
+        f"ROCM version: {rocm_ver}\n"
     )
     for args in _SANITY_CHECK_ARGS:
         check_dynamo(*args)


### PR DESCRIPTION
Implements an equivalent `check_rocm` in `verify_dynamo.py` currently this mimics the behaviour on CUDA, throwing a warning if `MIN_ROCM_VERSION` (5.4) requirement is not met by torch or the system ROCm.

```
Python version: 3.8.13
`torch` version: 2.0.0a0+git10df28a
CUDA version: None
ROCM version: 5.4
```

cc: @zstreet87 @jithunnair-amd @dllehr-amd 