### PR TITLE
Fix test_c10d_spawn_gloo.py hang in distributed tests

### DIFF
--- a/test/distributed/test_c10d_spawn_gloo.py
+++ b/test/distributed/test_c10d_spawn_gloo.py
@@ -30,8 +30,17 @@ if sys.version_info < (3, 9):
         @classmethod
         def _init_pg_gloo(cls, rank, filename, world_size):
             store = c10d.FileStore(filename, world_size)
-            return c10d.ProcessGroupGloo(
+            backend = c10d.ProcessGroupGloo(
                 store, rank, world_size, ProcessGroupShareTensorTest.opts())
+            # set process group backends manually
+            c10d.init_process_group(backend="gloo", store=store, rank=rank, world_size=world_size)
+            pg = c10d.distributed_c10d._get_default_group()
+            try:
+                pg._set_backend(torch.device("cpu"), c10d.Backend.GLOO, backend)
+                pg._set_backend(torch.device("cuda"), c10d.Backend.GLOO, backend)
+            except AttributeError:
+                print('Attribute _set_backend not found')
+            return pg
 
         @sandcastle_skip_if(not TEST_MULTIGPU, "At least 2 CUDA GPUS needed")
         def test_shared_broadcast_gloo(self):


### PR DESCRIPTION
Distributed tests fails due to  AttributeError: 'torch._C._distributed_c10d.ProcessGroup' object has no attribute '_set_backend' , when running distributed/test_c10d_spawn_gloo.py This leads to tests not progressing resulting in hang. Check if the attribute '_set_backend' exists before using it.

Signed-off-by: Jagadish Krishnamoorthy <jagdish.krishna@gmail.com>

Cherry-pick from PR https://github.com/pytorch/pytorch/pull/92932
