### PR TITLE
Use skipIfRocm instead of skipCUDAIfRocm and unskip tests

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -39,7 +39,7 @@ from torch.testing._internal.common_utils import (
 from torch.utils._python_dispatch import TorchDispatchMode
 from torch.utils._pytree import tree_flatten, tree_unflatten
 
-from torch.testing._internal.common_device_type import skipCUDAIfRocm 
+from torch.testing._internal.common_device_type import skipIfRocm 
 if IS_WINDOWS and IS_CI:
     sys.stderr.write(
         "Windows CI does not have necessary dependencies for test_torchinductor yet\n"
@@ -2770,8 +2770,6 @@ class CommonTemplate:
         if self.device != "cpu":
             self.assertEqual(torch._inductor.metrics.generated_kernel_count, 1)
 
-    # FIXME: https://github.com/ROCmSoftwarePlatform/frameworks-internal/issues/3378
-    @skipCUDAIfRocm
     def test_gather_scatter(self):
         def fn(node_feat, edge_index):
             src_node_feat = node_feat[edge_index[0]]
@@ -4023,8 +4021,6 @@ class CommonTemplate:
             fn, [torch.randn(1024, 4, 2), torch.arange(4), torch.randn(4, 1, 1)]
         )
 
-    # FIXME: https://github.com/ROCmSoftwarePlatform/frameworks-internal/issues/3378
-    @skipCUDAIfRocm
     def test_index_put2(self):
         def fn(a, b, c):
             return torch.index_put(a, [b], c, True)
@@ -4274,7 +4270,7 @@ class CommonTemplate:
         )
 
     # FIXME: https://github.com/ROCmSoftwarePlatform/frameworks-internal/issues/3378
-    @skipCUDAIfRocm
+    @skipIfRocm
     def test_scatter3(self):
         def fn(a, dim, index, b):
             return aten.scatter(a, dim, index, b, reduce="add")
@@ -4319,7 +4315,7 @@ class CommonTemplate:
         )
 
     # FIXME: https://github.com/ROCmSoftwarePlatform/frameworks-internal/issues/3378
-    @skipCUDAIfRocm
+    @skipIfRocm
     def test_scatter_add2(self):
         def fn(a, dim, index, b):
             return aten.scatter_add(a, dim, index, b)
@@ -4335,7 +4331,7 @@ class CommonTemplate:
         )
 
     # FIXME: https://github.com/ROCmSoftwarePlatform/frameworks-internal/issues/3378
-    @skipCUDAIfRocm
+    @skipIfRocm
     def test_scatter_add3(self):
         def fn(a, dim, index, b):
             return aten.scatter_add(a, dim, index, b)
@@ -4351,7 +4347,7 @@ class CommonTemplate:
         )
 
     # FIXME: https://github.com/ROCmSoftwarePlatform/frameworks-internal/issues/3378
-    @skipCUDAIfRocm
+    @skipIfRocm
     def test_scatter_reduce1(self):
         def fn(a, dim, index, b):
             return aten.scatter_reduce(a, dim, index, b, "sum")
@@ -4367,7 +4363,7 @@ class CommonTemplate:
         )
 
     # FIXME: https://github.com/ROCmSoftwarePlatform/frameworks-internal/issues/3378
-    @skipCUDAIfRocm
+    @skipIfRocm
     def test_scatter_reduce2(self):
         def fn(a, dim, index, b):
             return aten.scatter_reduce(a, dim, index, b, "sum", include_self=False)
@@ -4863,8 +4859,6 @@ class CommonTemplate:
             ],
         )
 
-    # FIXME: https://github.com/ROCmSoftwarePlatform/frameworks-internal/issues/3411
-    @skipCUDAIfRocm
     def test_argmax_argmin1(self):
         def fn(x):
             return (aten.argmax(x), aten.argmin(x))
@@ -4876,8 +4870,6 @@ class CommonTemplate:
             ],
         )
 
-    # FIXME: https://github.com/ROCmSoftwarePlatform/frameworks-internal/issues/3411
-    @skipCUDAIfRocm
     def test_argmax_argmin2(self):
         def fn(x):
             return (
@@ -6129,7 +6121,7 @@ if HAS_CUDA and not TEST_WITH_ASAN:
         common = check_model_cuda
 
         # FIXME: https://github.com/ROCmSoftwarePlatform/frameworks-internal/issues/3387
-        @skipCUDAIfRocm
+        @skipIfRocm
         def test_index_put_issue(self):
             def forward(
                 self,


### PR DESCRIPTION
skipCUDAIfRocm resulted in AttributeError's as device_type does not exist for the inductor UTs. Replaced these with skipIfRocm.

Since latest triton we are able to remove some skips:
```
test_gather_scatter (cpu, cuda) - PASSED
test_index_put2 (cpu, cuda) - PASSED
test_scatter3 (cpu, cuda) FAILED - LLVM error on cuda - AtomicLoadFAdd
test_scatter_add2 (cpu, cuda) FAILED - f16 LLVM error on Atomicloadfadd
test_scatter_add3 (cpu, cuda) FAILED - f16 LLVM error on AtomicLoadFAdd
test_scatter_reduce1 FAILED -  f16 LLVM error on AtomicLoadFAdd
test_scatter_reduce2 FAILED - f16 LLVM error on AtomicLoadFAdd
test_argmax_argmin1 - PASSED
test_argmax_argmin2 - PASSED
test_index_put_issue - FAILED - LLVM ERROR: Cannot select: 0xbd744d0: f16,ch = AtomicLoadFAdd<(load store monotonic (s16) on %ir.666, addrspace 1)>

```
