### PR TITLE
Update test.sh

### DIFF
--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -74,6 +74,9 @@ echo "Testing pytorch"
 
 export LANG=C.UTF-8
 
+#Set python to required version
+alias python=`which python`
+
 PR_NUMBER=${PR_NUMBER:-${CIRCLE_PR_NUMBER:-}}
 
 if [[ "$TEST_CONFIG" == 'default' ]]; then


### PR DESCRIPTION
Fixes #SWDEV-381185

Below output after running inside pytorch docker

1# python --version
Python 3.8.16

2# /opt/conda/bin/python --version
Python 3.10.8

3# which python
/opt/conda/envs/py_3.8/bin/python

4# ls -lrt /opt/conda/envs/py_3.8/bin/python
lrwxrwxrwx 1 jenkins jenkins 9 Feb  2 22:46 /opt/conda/envs/py_3.8/bin/python -> python3.8

test.sh has below way to run the test which points to python 3.10 as default conda has python 3.10
time python test/run_test.py

Docker is build with python as per like BUILD_ENVIRONMENT=pytorch-devtoolset7-centos7.5.1804-rocm5.5-py3.8 is built with python3.8

Due to mismatch in BUILD and conda install version, test is not able to find torch

To overcome this, this PR will find the right python version for the test and set the same and run the test





