### PR TITLE
Additional fixes for ROCm

### DIFF
--- a/test/dynamo/test_cudagraphs.py
+++ b/test/dynamo/test_cudagraphs.py
@@ -11,7 +11,7 @@ import torch._dynamo.config
 import torch._dynamo.test_case
 import torch._dynamo.testing
 from torch._dynamo.testing import same
-from torch.testing._internal.common_utils import TEST_WITH_ROCM
+from torch.testing._internal.common_utils import TEST_WITH_ROCM, skipIfRocm
 
 
 def composed(*decs):
@@ -106,6 +106,7 @@ class TestAotCudagraphs(torch._dynamo.test_case.TestCase):
         fn(x, y)
 
     @patch("torch._functorch.config.use_functionalize", True)
+    @patch_all()
     def test_mutate_input(self):
         def model(x, y):
             y.add_(3)

--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -2,7 +2,7 @@
 import torch
 from torch._dynamo.test_case import run_tests, TestCase
 from torch._dynamo.utils import counters
-from torch.testing._internal.common_utils import IS_LINUX
+from torch.testing._internal.common_utils import IS_LINUX, skipIfRocm
 from torch.testing._internal.inductor_utils import HAS_CUDA
 
 
@@ -83,6 +83,7 @@ class TestPaternMatcher(TestCase):
         self.assertEqual(counters["inductor"]["pattern_matcher_count"], 1)
         self.assertEqual(counters["inductor"]["pattern_matcher_nodes"], 4)
 
+    @skipIfRocm
     def test_cat_slice_cat(self):
         def fn(a, b):
             cat_1 = torch.ops.aten.cat.default([a, b], 1)

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -38,7 +38,6 @@ from torch.testing._internal.common_utils import (
     IS_WINDOWS,
     IS_X86,
     TEST_WITH_ASAN,
-    TEST_WITH_ROCM,
     TEST_WITH_SLOW,
     TestCase as TorchTestCase,
 )
@@ -4595,7 +4594,7 @@ class CommonTemplate:
         def fn(a):
             return torch.nn.functional.dropout(a, 0.55, True)
 
-        for cg in[False, True] if not torch.version.hip else [False]:
+        for cg in [False, True] if not torch.version.hip else [False]:
             with patch.object(config.triton, "cudagraphs", cg):
                 torch._dynamo.reset()
 

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -5022,6 +5022,7 @@ class CommonTemplate:
             ],
         )
 
+    @skipIfRocm
     def test_argmax_argmin2(self):
         def fn(x):
             return (

--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -29,8 +29,8 @@ from torch.testing._internal.common_utils import (
     skipIfCrossRef,
     skipIfTorchDynamo,
     suppress_warnings,
-    TestCase,
     TEST_WITH_ROCM,
+    TestCase,
 )
 from torch.testing._internal.inductor_utils import HAS_CPU, HAS_CUDA
 
@@ -491,7 +491,9 @@ class TestInductorOpInfo(TestCase):
             #     print(f"SKIPPING OP {op_name} on {device_type}", flush=True, file=f)
             #     print(f"SKIPPING OP {op_name} on {device_type}", flush=True)
             self.skipTest(f"{op_name} in {dtype} not supported")
-        elif TEST_WITH_ROCM and dtype in inductor_skips_rocm[device_type].get(op_name, set()):
+        elif TEST_WITH_ROCM and dtype in inductor_skips_rocm[device_type].get(
+            op_name, set()
+        ):
             test_expect = TestExpect.SKIP
             self.skipTest(f"{op_name} in {dtype} not supported on ROCM")
         elif dtype in inductor_expected_failures_single_sample[device_type].get(

--- a/tools/dynamo/verify_dynamo.py
+++ b/tools/dynamo/verify_dynamo.py
@@ -206,6 +206,8 @@ _SANITY_CHECK_ARGS = (
 
 
 def main():
+    import torch
+
     python_ver = check_python()
     torch_ver = check_torch()
     cuda_ver = check_cuda() if torch.version.hip is None else "None"

--- a/tools/dynamo/verify_dynamo.py
+++ b/tools/dynamo/verify_dynamo.py
@@ -57,7 +57,9 @@ def get_rocm_version():
 
     ROCM_HOME = cpp_extension._find_rocm_home()
     if not ROCM_HOME:
-        raise VerifyDynamoError("ROCM was not found on the system, please set ROCM_HOME environment variable")
+        raise VerifyDynamoError(
+            "ROCM was not found on the system, please set ROCM_HOME environment variable"
+        )
 
     hipcc = os.path.join(ROCM_HOME, "bin", "hipcc")
     hip_version_str = (
@@ -73,6 +75,7 @@ def get_rocm_version():
     hip_str_version = hip_version.group(1)
 
     return packaging.version.parse(hip_str_version)
+
 
 def check_cuda():
     import torch
@@ -105,6 +108,7 @@ def check_cuda():
 
     return cuda_ver
 
+
 def check_rocm():
     import torch
 
@@ -112,7 +116,9 @@ def check_rocm():
         return None
 
     # Extracts main ROCm version from full string
-    torch_rocm_ver = packaging.version.parse('.'.join(list(torch.version.hip.split(".")[0:2])))
+    torch_rocm_ver = packaging.version.parse(
+        '.'.join(list(torch.version.hip.split(".")[0:2]))
+    )
 
     # check if torch rocm version matches system rocm version
     rocm_ver = get_rocm_version()
@@ -132,6 +138,7 @@ def check_rocm():
         )
 
     return rocm_ver
+
 
 def check_dynamo(backend, device, err_msg):
     import torch
@@ -202,7 +209,7 @@ def main():
     python_ver = check_python()
     torch_ver = check_torch()
     cuda_ver = check_cuda() if torch.version.hip is None else "None"
-    rocm_ver = check_rocm() if not torch.version.hip is None else "None"
+    rocm_ver = check_rocm() if torch.version.hip is not None else "None"
     print(
         f"Python version: {python_ver.major}.{python_ver.minor}.{python_ver.micro}\n"
         f"`torch` version: {torch_ver}\n"

--- a/torch/_dynamo/test_case.py
+++ b/torch/_dynamo/test_case.py
@@ -7,7 +7,6 @@ import torch.testing
 from torch.testing._internal.common_utils import (
     IS_WINDOWS,
     TEST_WITH_CROSSREF,
-    TEST_WITH_ROCM,
     TEST_WITH_TORCHDYNAMO,
     TestCase as TorchTestCase,
 )

--- a/torch/testing/_internal/inductor_utils.py
+++ b/torch/testing/_internal/inductor_utils.py
@@ -4,7 +4,6 @@ from torch._inductor.codecache import CppCodeCache
 from torch._inductor.utils import has_triton
 from torch.testing._internal.common_utils import (
     IS_FBCODE,
-    TEST_WITH_ROCM,
 )
 import torch
 


### PR DESCRIPTION
Addresses issue occuring in upstream CI run https://github.com/pytorch/pytorch/pull/94660
- Fixes linting issues
- Imports torch in `verify_dynamo.py` for hip check
- Skips `test_cat_slice_cat` UT in `inductor/test_pattern_matcher` on ROCm
- Skips additional `Tensor-likes are not close!` errors in `test_torchinductor.py`
- Adds `patch_all()` to skip additional UT in `dynamo/test_cudagraphs`