### PR TITLE
[Revert this] CI workaround - disable openai triton wheel install for ROCm

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1029,12 +1029,13 @@ def main():
     extras_require = {
         'opt-einsum': ['opt-einsum>=3.3']
     }
-    if platform.system() == 'Linux':
-        triton_pin_file = os.path.join(cwd, ".github", "ci_commit_pins", "triton.txt")
-        if os.path.exists(triton_pin_file):
-            with open(triton_pin_file) as f:
-                triton_pin = f.read().strip()
-                extras_require['dynamo'] = ['pytorch-triton==2.0.0+' + triton_pin[:10], 'jinja2']
+    # TEMPORARILY DISABLE FOR CI TESTING
+    #if platform.system() == 'Linux':
+    #    triton_pin_file = os.path.join(cwd, ".github", "ci_commit_pins", "triton.txt")
+    #    if os.path.exists(triton_pin_file):
+    #        with open(triton_pin_file) as f:
+    #            triton_pin = f.read().strip()
+    #            extras_require['dynamo'] = ['pytorch-triton==2.0.0+' + triton_pin[:10], 'jinja2']
 
     # Parse the command line and check the arguments before we proceed with
     # building deps and setup. We need to set values so `--help` works.


### PR DESCRIPTION
Temporary removal of triton wheel install until we find out how to conditionalise out for ROCm
