### PR TITLE
[SWDEV-363998] Fixed test_profiler_tree issue

### DIFF
--- a/test/profiler/test_profiler_tree.py
+++ b/test/profiler/test_profiler_tree.py
@@ -110,8 +110,6 @@ class ProfilerTree:
             for node in nodes:
                 cls.validate_node(node)
                 name = cls.fmt_name(node.name)
-                if name.startswith("hip"):
-                    continue
                 prune_level = PRUNE_FUNCTIONS.get(name.strip(), None)
                 if prune_level is None:
                     out.append((depth, name))
@@ -131,6 +129,9 @@ class ProfilerTree:
 
         # Profiler inserts a `cudaDeviceSynchronize` at the end of profiling.
         if flat_nodes and flat_nodes[-1][1] == "cudaDeviceSynchronize":
+            flat_nodes = flat_nodes[:-1]
+
+        if flat_nodes and flat_nodes[-1][1] == "hipDeviceSynchronize":
             flat_nodes = flat_nodes[:-1]
 
         min_depth = min([d + 1 for d, name in flat_nodes if "begin_unit_test_marker" in name] or [0])

--- a/test/profiler/test_profiler_tree.py
+++ b/test/profiler/test_profiler_tree.py
@@ -110,6 +110,8 @@ class ProfilerTree:
             for node in nodes:
                 cls.validate_node(node)
                 name = cls.fmt_name(node.name)
+                if name.startswith("hip"):
+                    continue
                 prune_level = PRUNE_FUNCTIONS.get(name.strip(), None)
                 if prune_level is None:
                     out.append((depth, name))


### PR DESCRIPTION
Fixed the issue: https://ontrack-internal.amd.com/browse/SWDEV-363998

Docker image: compute-artifactory.amd.com:5000/rocm-plus-docker/framework/compute-rocm-dkms-no-npi-hipclang:11597_ubuntu20.04_py3.8_pytorch_rocm5.5_internal_testing_fe7cc73

Fixed unit tests failures in test_profiler_tree.py:
test_profiler_experimental_tree
test_profiler_experimental_tree_with_memory
test_profiler_experimental_tree_with_record_function

[test_profiler_tree.log](https://github.com/ROCmSoftwarePlatform/pytorch/files/10798203/test_profiler_tree.log)