### PR TITLE
Removing test custom handler temporarily

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -893,15 +893,18 @@ CUSTOM_HANDLERS = {
     "distributed/rpc/test_share_memory": get_run_test_with_subprocess_fn(),
     "distributed/rpc/cuda/test_tensorpipe_agent": get_run_test_with_subprocess_fn(),
     "doctests": run_doctests,
-    "inductor/test_torchinductor_opinfo": run_test_ops,
-    "test_ops": run_test_ops,
-    "test_ops_gradients": run_test_ops,
-    "test_ops_fwd_gradients": run_test_ops,
-    "test_ops_jit": run_test_ops,
-    "functorch/test_ops": run_test_ops,
+
+    # TODO: Removing custom test handlers for all files below, failing locally
+    # https://ontrack-internal.amd.com/browse/SWDEV-383419
+    #"inductor/test_torchinductor_opinfo": run_test_ops,
+    #"test_ops": run_test_ops,
+    #"test_ops_gradients": run_test_ops,
+    #"test_ops_fwd_gradients": run_test_ops,
+    #"test_ops_jit": run_test_ops,
+    #"functorch/test_ops": run_test_ops,
     # not a test_ops file, but takes 2 hrs on some architectures and
     # run_test_ops is good at parallelizing things
-    "test_decomp": run_test_ops,
+    #"test_decomp": run_test_ops,
 }
 
 


### PR DESCRIPTION
Removing temporarily, since many UT execution is blocked for below files.

Direct test file execution is fine.
https://ontrack-internal.amd.com/browse/SWDEV-383419