### PR TITLE
call filelock function

### DIFF
--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -908,11 +908,13 @@ elif [[ "${TEST_CONFIG}" == *inductor* && "${SHARD_NUMBER}" == 1 ]]; then
 elif [[ "${SHARD_NUMBER}" == 1 && $NUM_TEST_SHARDS -gt 1 ]]; then
   test_without_numpy
   install_torchvision
+  install_filelock
   install_triton
   test_python_shard 1
   test_aten
 elif [[ "${SHARD_NUMBER}" == 2 && $NUM_TEST_SHARDS -gt 1 ]]; then
   install_torchvision
+  install_filelock
   install_triton
   test_python_shard 2
   test_libtorch
@@ -940,6 +942,7 @@ elif [[ "${TEST_CONFIG}" == *functorch* ]]; then
   test_functorch
 else
   install_torchvision
+  install_filelock
   install_triton
   install_monkeytype
   test_python


### PR DESCRIPTION
A workaround for  #SWDEV-384803, forcing filelock installation, needs to be reverted after pytorch 2.0 is enabled on 5.6.
Same change for 5.6 branch as in 5.5 branch, https://github.com/ROCmSoftwarePlatform/pytorch/pull/1191