### PR TITLE
Fixed test_memory_timeline

### DIFF
--- a/test/profiler/test_memory_profiler.py
+++ b/test/profiler/test_memory_profiler.py
@@ -1482,7 +1482,7 @@ class TestMemoryProfilerE2E(TestCase):
 
             # We generally don't care about tiny allocations during memory
             # profiling and they add a lot of noise to the unit test.
-            if size >= 256
+            if size >= 512
         ]
 
         self.assertExpectedInline(


### PR DESCRIPTION
Fixes https://github.com/ROCmSoftwarePlatform/frameworks-internal/issues/3748

It is an output comparison mismatching issue. Two extra operations: create and destroy introduces the mismatching.

Initial failures are on MI100/MI200. The test runs well on MI50 and CUDA node. Operations sequence are identical through comparisons between failed and successful cases. CUDA uses 96 bytes (MI50 with 64 bytes) for each but ROCm uses 384 bytes on MI100 and 256 bytes on MI200. And logging condition is if size >= 256.

After the fix, verified entire test_memory_profiler.py tests pass on CUDA node, MI50, MI100 and MI200.