### PR TITLE
Revert "Revert "Release the GIL when munmap'ing tensors - fixes #77139 (#83623)

### DIFF
--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -667,7 +667,12 @@ static int THPVariable_clear(THPVariable* self) {
     }
   }
   TORCH_INTERNAL_ASSERT(!isResurrectable((THPVariable*)self));
-  self->cdata = MaybeOwned<Variable>();
+  {
+    // MapAllocator can take significant time to release large tensors;
+    // release the GIL here to avoid impacting main thread perf.
+    pybind11::gil_scoped_release no_gil;
+    self->cdata = MaybeOwned<Variable>();
+  }
   return 0;
 }
 


### PR DESCRIPTION
- This reverts commit 8f737087497d79b3d46bb2c3b32b4c59281d5223.
- SWDEV-386723 - superbench perf regression.
- This makes the rocm5.5_internal_testing state in sync with release/1.13 branch and upstream also regarding this change.

