### PR TITLE
ROCm changes for PyT2.0 support

### DIFF
--- a/.ci/pytorch/common_utils.sh
+++ b/.ci/pytorch/common_utils.sh
@@ -149,38 +149,6 @@ function clone_pytorch_xla() {
   fi
 }
 
-function install_filelock() {
-  pip_install filelock
-}
-
-function install_triton() {
-  local commit
-  commit=$(get_pinned_commit triton)
-  local short_hash
-  short_hash=$(echo "${commit}"|cut -c -10)
-  local index_url
-  index_url=https://download.pytorch.org/whl/nightly/cpu
-  if [[ "${TEST_CONFIG}" == *rocm* ]] || [[ "${BUILD_ENVIRONMENT}" == *rocm* ]]; then
-    echo "skipping triton due to rocm"
-  elif pip install "pytorch-triton==2.0.0+${short_hash}" --index-url "${index_url}"; then
-     echo "Using prebuilt version ${short_hash}"
-  else
-    if [[ "${BUILD_ENVIRONMENT}" == *gcc7* ]]; then
-      # Trition needs gcc-9 to build
-      sudo apt-get install -y g++-9
-      CXX=g++-9 pip_install --user "git+https://github.com/openai/triton@${commit}#subdirectory=python"
-    elif [[ "${BUILD_ENVIRONMENT}" == *clang* ]]; then
-      # Trition needs <filesystem> which surprisingly is not available with clang-9 toolchain
-      sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-      sudo apt-get install -y g++-9
-      CXX=g++-9 pip_install --user "git+https://github.com/openai/triton@${commit}#subdirectory=python"
-    else
-      pip_install --user "git+https://github.com/openai/triton@${commit}#subdirectory=python"
-    fi
-    pip_install --user jinja2
-  fi
-}
-
 function checkout_install_torchdeploy() {
   local commit
   commit=$(get_pinned_commit multipy)

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -3013,8 +3013,6 @@ class CommonTemplate:
             (torch.randn([10, 4]), torch.randint(10, [8]), torch.tensor([0, 2, 6])),
         )
 
-    # FIXME: https://github.com/ROCmSoftwarePlatform/frameworks-internal/issues/3597
-    @skipIfRocm
     def test_batch_norm_2d(self):
         m = torch.nn.Sequential(
             torch.nn.BatchNorm2d(10),

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -48,10 +48,12 @@ test_skips = {
 }
 
 if TEST_WITH_ROCM:
-    # FIXME: https://github.com/ROCmSoftwarePlatform/frameworks-internal/issues/3849
+    # LLVM assertion error
     test_skips["test_argmax_argmin1_dynamic_shapes"] = ("cpu", "cuda")
-    # FIXME: https://github.com/ROCmSoftwarePlatform/frameworks-internal/issues/3462
+    # Tensor-likes are not close
     test_skips["test_convolution1_dynamic_shapes"] = ("cpu", "cuda")
+    # aten.miopen_batch_norm is not registered for lowering
+    test_skips["test_batch_norm_2d_dynamic_shapes"] = ("cuda")
 
 
 def make_dynamic_cls(cls):

--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -150,20 +150,12 @@ inductor_skips["cuda"] = {
     "_native_batch_norm_legit": {f16, f32, f64},
 }
 
-inductor_skips_rocm["cuda"] = {
-    # FIXME: https://github.com/ROCmSoftwarePlatform/frameworks-internal/issues/3817
-    "cumulative_trapezoid": {f16, f32, f64, b8, i32, i64},
-    "trapezoid": {f16, f32, f64, b8, i32, i64},
-    "trapz": {f16, f32, f64, b8, i32, i64},
-    # FIXME: LAPACK support - can skip like this https://github.com/ROCmSoftwarePlatform/pytorch/pull/1177 - https://github.com/ROCmSoftwarePlatform/frameworks-internal/issues/3598
-    ("linalg.pinv", "hermitian"): {f16, f32, f64, b8, i32, i64},
-    ("linalg.matrix_rank", "hermitian"): {f16, f32, f64, b8, i32, i64},
-    # FIXME: Tensors are not alike https://github.com/ROCmSoftwarePlatform/frameworks-internal/issues/3462
-    "logcumsumexp": {f32},
-    # FIXME: MIOpen batch norm failure
-    "nn.functional.batch_norm": {f32},
-    "nn.functional.instance_norm": {f32},
-}
+if TEST_WITH_ROCM:
+    # LAPACK support
+    inductor_skips["cuda"][("linalg.pinv", "hermitian")] = {f16, f32, f64, b8, i32, i64}
+    inductor_skips["cuda"][("linalg.matrix_rank", "hermitian")] = {f16, f32, f64, b8, i32, i64}
+    # Tensors are not alike
+    inductor_skips["cuda"]["logcumsumexp"] = {f32}
 
 inductor_expected_failures_single_sample = defaultdict(dict)
 
@@ -365,7 +357,7 @@ if not TEST_WITH_ROCM:
     # (including _linalg_svd), possibly we should have something similar here
     inductor_expected_failures_single_sample["cuda"]["linalg.cond"] = {f32, f64}
     inductor_expected_failures_single_sample["cuda"]["linalg.svdvals"] = {f32, f64}
-    inductor_expected_failures_single_sample["cuda"]["norm.nuc"] = {f32, f64}
+    inductor_expected_failures_single_sample["cuda"][("norm", "nuc")] = {f32, f64}
 
 inductor_gradient_expected_failures_single_sample = defaultdict(dict)
 
@@ -389,6 +381,10 @@ inductor_gradient_expected_failures_single_sample["cuda"] = {
 
 if not TEST_WITH_ROCM:
     inductor_gradient_expected_failures_single_sample["cuda"]["tanh"] = {f16}
+else:
+    # aten.miopen_batch_norm is unsupported for lowering
+    inductor_expected_failures_single_sample["cuda"]["nn.functional.batch_norm"] = {f16, f32}
+    inductor_expected_failures_single_sample["cuda"]["nn.functional.instance_norm"] = {f16, f32}  
 
 inductor_should_fail_with_exception = defaultdict(dict)
 
@@ -418,23 +414,13 @@ def get_skips_and_xfails(from_dict, xfails=True):
 # Note: if you get a "AssertionError: Couldn't find OpInfo for ..." error for an OpInfo you are sure
 # exists, you might be trying to use a test variant and you need to replace, for example,
 # "max.reduction_no_dim" with ("max", "reduction_no_dim") as the key of one of these dictionaries
-if not TEST_WITH_ROCM:
-    test_skips_or_fails = (
-        get_skips_and_xfails(inductor_skips, xfails=False)
-        | get_skips_and_xfails(inductor_expected_failures_single_sample, xfails=True)
-        | get_skips_and_xfails(
-            inductor_gradient_expected_failures_single_sample, xfails=True
-        )
+test_skips_or_fails = (
+    get_skips_and_xfails(inductor_skips, xfails=False)
+    | get_skips_and_xfails(inductor_expected_failures_single_sample, xfails=True)
+    | get_skips_and_xfails(
+        inductor_gradient_expected_failures_single_sample, xfails=True
     )
-else:
-    test_skips_or_fails = (
-        get_skips_and_xfails(inductor_skips, xfails=False)
-        | get_skips_and_xfails(inductor_skips_rocm, xfails=False)
-        | get_skips_and_xfails(inductor_expected_failures_single_sample, xfails=True)
-        | get_skips_and_xfails(
-            inductor_gradient_expected_failures_single_sample, xfails=True
-        )
-    )
+)
 
 def wrapper_set_seed(op, *args, **kwargs):
     """Wrapper to set seed manually for some functions like dropout

--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -529,10 +529,6 @@ class TestInductorOpInfo(TestCase):
             # with open("test_output.txt", "a") as f:
             #     print(f"SKIPPING OP {op_name} on {device_type}", flush=True, file=f)
             #     print(f"SKIPPING OP {op_name} on {device_type}", flush=True)
-        elif TEST_WITH_ROCM and dtype in inductor_skips_rocm[device_type].get(
-            op_name, set()
-        ):
-            test_expect = ExpectedTestResult.SKIP
         elif dtype in inductor_expected_failures_single_sample[device_type].get(
             op_name, set()
         ) or dtype in inductor_gradient_expected_failures_single_sample[

--- a/tools/dynamo/verify_dynamo.py
+++ b/tools/dynamo/verify_dynamo.py
@@ -81,7 +81,7 @@ def get_rocm_version():
 def check_cuda():
     import torch
 
-    if not torch.cuda.is_available():
+    if not torch.cuda.is_available() or torch.version.cuda is None:
         return None
 
     torch_cuda_ver = packaging.version.parse(torch.version.cuda)

--- a/tools/dynamo/verify_dynamo.py
+++ b/tools/dynamo/verify_dynamo.py
@@ -81,7 +81,7 @@ def get_rocm_version():
 def check_cuda():
     import torch
 
-    if not torch.cuda.is_available() or torch.version.cuda is None:
+    if not torch.cuda.is_available() or torch.version.hip is not None:
         return None
 
     torch_cuda_ver = packaging.version.parse(torch.version.cuda)

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -1403,6 +1403,9 @@ make_fallback(aten._linalg_eigh)
 make_fallback(aten.zeros.names)
 
 
+# ROCm specific
+make_fallback(aten.miopen_batch_norm, warn=False)
+
 add_layout_constraint(aten.convolution, constrain_to_fx_strides)
 
 


### PR DESCRIPTION
- Removed warnings on fallback to aten.miopen_batch_norm (due to perf diff)

- Refactored ROCm skips in opinfo

- sync with some upstream changes to remove install_triton, 
