### PR TITLE
[PyTorch] FSDP UT Parity 

### DIFF
--- a/test/distributed/fsdp/test_fsdp_comm_hooks.py
+++ b/test/distributed/fsdp/test_fsdp_comm_hooks.py
@@ -23,6 +23,7 @@ from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
+    TEST_WITH_ROCM,
 )
 
 if not dist.is_available():
@@ -34,7 +35,7 @@ BFLOAT16_AVAILABLE = (
     torch.cuda.is_available()
     and torch.version.cuda is not None
     and int(torch.version.cuda.split(".")[0]) >= 11
-)
+) or TEST_WITH_ROCM
 
 
 class Net(nn.Module):
@@ -439,7 +440,6 @@ class TestCommunicationHooks(FSDPTest):
         "BFloat16 is only supported by CUDA 11+",
     )
     @skip_if_lt_x_gpu(2)
-    @skip_if_rocm
     @parametrize("has_wrapping", [True, False])
     @parametrize(
         "sharding_strategy",


### PR DESCRIPTION
This PR unskips the following tests in FSDP feature.

```
test_bf16_hook_has_wrapping_False_sharding_strategy_ShardingStrategy_FULL_SHARD
test_bf16_hook_has_wrapping_False_sharding_strategy_ShardingStrategy_NO_SHARD
test_bf16_hook_has_wrapping_False_sharding_strategy_ShardingStrategy_SHARD_GRAD_OP
test_bf16_hook_has_wrapping_True_sharding_strategy_ShardingStrategy_FULL_SHARD
test_bf16_hook_has_wrapping_True_sharding_strategy_ShardingStrategy_NO_SHARD
test_bf16_hook_has_wrapping_True_sharding_strategy_ShardingStrategy_SHARD_GRAD_OP
```

