### PR TITLE
Pinning numpy version for backwards compatibility of 1.10.1

### DIFF
--- a/related_commits
+++ b/related_commits
@@ -1,4 +1,4 @@
 ubuntu|pytorch|apex|none|
 centos|pytorch|apex|none|
-ubuntu|pytorch|torchvision|release/0.11.2|bbe05219216b59d8af247afe2e28d840f241a9cf|https://github.com/ROCmSoftwarePlatform/vision
-centos|pytorch|torchvision|release/0.11.2|bbe05219216b59d8af247afe2e28d840f241a9cf|https://github.com/ROCmSoftwarePlatform/vision
+ubuntu|pytorch|torchvision|release/0.11.2|cb18e83524eacaa674319a372e8dd853b9bf2f14|https://github.com/ROCmSoftwarePlatform/vision
+centos|pytorch|torchvision|release/0.11.2|cb18e83524eacaa674319a372e8dd853b9bf2f14|https://github.com/ROCmSoftwarePlatform/vision

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 astunparse
 expecttest
 future
-numpy
+numpy==1.19.2
 psutil
 pyyaml
 requests


### PR DESCRIPTION
Pinning numpy version in requirements.txt due to bug encountered on the 1.10.1 release branch with numpy>=1.24.0 (SWDEV-385058)

Companion PR to pin requirements in torchvision: https://github.com/ROCmSoftwarePlatform/vision/pull/1