### PR TITLE
Pin numpy to match vision/0.11.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 astunparse
 expecttest
 future
-numpy==1.19.2
+numpy==1.23.1
 psutil
 pyyaml
 requests


### PR DESCRIPTION
Align numpy pinning in requirements.txt to the numpy version used in vision/0.11.2 branch https://github.com/ROCmSoftwarePlatform/vision/commit/cb18e83524eacaa674319a372e8dd853b9bf2f14
