### PR TITLE
Set CONDA_CMAKE=yes for any 'rocm' configs

### DIFF
--- a/.ci/docker/build.sh
+++ b/.ci/docker/build.sh
@@ -260,6 +260,8 @@ case "$image" in
     if [[ "$image" == *rocm* ]]; then
       extract_version_from_image_name rocm ROCM_VERSION
       NINJA_VERSION=1.9.0
+      # Need conda cmake to detect conda mkl and build with mkl support
+      CONDA_CMAKE=yes
     fi
     if [[ "$image" == *centos7* ]]; then
       NINJA_VERSION=1.10.2


### PR DESCRIPTION
Fixes issues similar to https://ontrack-internal.amd.com/browse/SWDEV-382771 and https://ontrack-internal.amd.com/browse/SWDEV-387153

The conda cmake package can detect conda MKL during PyTorch build (but the regular cmake package cannot), thereby building PyTorch with MKL support. We need this change because ROCm-internal CI uses a config/BUILD_ENVIRONMENT that falls in the catchall clause of the switch-case statement in .ci/docker/build.sh, whereas upstream uses `pytorch-linux-focal-rocm-n-py3` and `pytorch-linux-focal-rocm-n-1-py3`, which have `CONDA_CMAKE=yes`.