### PR TITLE
Update c10 macros.h to avoid __has_trivial copy

### DIFF
--- a/c10/macros/Macros.h
+++ b/c10/macros/Macros.h
@@ -388,7 +388,7 @@ __host__ __device__
 // Warning: __has_trivial_copy for GCC may not always detect the non-POD
 // correctly. For example, T = std::unique_ptr may evaluate to true and be
 // treated as POD. This can cause unexpected behavior.
-#if defined(__GNUG__) && __GNUC__ < 5
+#if defined(__GNUG__) && __GNUC__ < 5 && !defined(__clang__)
 #define C10_IS_TRIVIALLY_COPYABLE(T) __has_trivial_copy(T)
 #else
 #define C10_IS_TRIVIALLY_COPYABLE(T) std::is_trivially_copyable<T>::value


### PR DESCRIPTION
This change is a cherry pick from part of an upstream commit
https://github.com/pytorch/pytorch/commit/37f7c00a8aae2ced9666a69d0d51a4d9d4b379af

This will need implementing in all the release branches but our the current IFU in internal testing branches brought in this commit.

For release/1.10.1 this will reduce the size of the build log file from ~150MB to ~15MB without this change this warning is repeatedly observed:
```
Mar 28 12:37:30 /var/lib/jenkins/pytorch/c10/util/SmallVector.h:392:41: warning: builtin __has_trivial_copy is deprecated; use __is_trivially_constructible instead [-Wdeprecated-builtins]
Mar 28 12:37:30     : public SmallVectorTemplateBase<T, C10_IS_TRIVIALLY_COPYABLE(T)> {
Mar 28 12:37:30                                         ^
Mar 28 12:37:30 /var/lib/jenkins/pytorch/c10/macros/Macros.h:392:38: note: expanded from macro 'C10_IS_TRIVIALLY_COPYABLE'
Mar 28 12:37:30 #define C10_IS_TRIVIALLY_COPYABLE(T) __has_trivial_copy(T)
```

A full log example on CI is seen here, for all architectures this grows to over 200MB 
http://rocmhead:8080/job/pytorch/job/pytorch-build/761/

Post IFU in ROCmSoftwarePlatform/pytorch:master the log is only 9MB 
http://rocmhead:8080/job/pytorch/job/pytorch-build/765/

Log file from release/1.10.1 build post-PR
https://confluence.amd.com/download/attachments/747607727/build_release101_cherrypick.log?version=1&modificationDate=1680796593708&api=v2
