### PR TITLE
Modified logging threshold for memory profiling (#1227)

### DIFF
--- a/test/profiler/test_memory_profiler.py
+++ b/test/profiler/test_memory_profiler.py
@@ -1480,7 +1480,7 @@ class TestMemoryProfilerE2E(TestCase):
 
             # We generally don't care about tiny allocations during memory
             # profiling and they add a lot of noise to the unit test.
-            if size >= 256
+            if size > 512
         ]
 
         self.assertExpectedInline(


### PR DESCRIPTION
Cherry-picked the fix from rocm5.6_internal_testing branch. Fixes [JIRA ticket](https://ontrack-internal.amd.com/browse/SWDEV-395420) by modification of logging threshold of memory profiling.
