### PR TITLE
[SWDEV-396381] FSDP UT failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,5 @@
 
 ## PyTorch for ROCm5.5 (upstream commit: 36ba2ce)
 
-# TO BE FILLED
+### Fixed
+- [SWDEV-396381] Fixed FSDP UTs by limiting to 8 GPUs

--- a/torch/testing/_internal/common_fsdp.py
+++ b/torch/testing/_internal/common_fsdp.py
@@ -823,7 +823,12 @@ class FSDPTest(MultiProcessTestCase):
 
     @property
     def world_size(self):
-        return torch.cuda.device_count() if torch.cuda.is_available() else 4
+        nranks = 4
+        if torch.cuda.is_available:
+            nranks = torch.cuda.device_count()
+        if torch.version.hip and nranks > 8:
+            nranks = 8 ## use only 8 GPUs.
+        return nranks
 
     @property
     def process_group(self):

--- a/torch/testing/_internal/common_fsdp.py
+++ b/torch/testing/_internal/common_fsdp.py
@@ -823,12 +823,7 @@ class FSDPTest(MultiProcessTestCase):
 
     @property
     def world_size(self):
-        nranks = 4
-        if torch.cuda.is_available:
-            nranks = torch.cuda.device_count()
-        if torch.version.hip and nranks > 8:
-            nranks = 8 ## use only 8 GPUs.
-        return nranks
+        return min(torch.cuda.device_count(), 8) if torch.cuda.is_available() else 4
 
     @property
     def process_group(self):


### PR DESCRIPTION
This PR fixes UTs:  test_fsdp_uneven and test_fsdp_tp_integration in SWDEV-396381. 
This PR limits the nranks to 8GPUs if there are more than 8GPUs in a node. This avoids any key error trying to access for nodes greater than 8 as the test seems to be very small. 