### PR TITLE
[release/1.12] Fix conda error during docker build

### DIFF
--- a/.circleci/docker/common/install_conda.sh
+++ b/.circleci/docker/common/install_conda.sh
@@ -55,6 +55,9 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
   # Ensure we run conda in a directory that jenkins has write access to
   pushd /opt/conda
 
+  # Update conda from defaults
+  as_jenkins conda update -n base -c defaults conda
+
   # Prevent conda from updating to 4.14.0, which causes docker build failures
   # See https://hud.pytorch.org/pytorch/pytorch/commit/754d7f05b6841e555cea5a4b2c505dd9e0baec1d
   # Uncomment the below when resolved to track the latest conda update,


### PR DESCRIPTION
Failure observed during docker build in http://rocm-ci.amd.com/view/Release-5.6/job/framework-pytorch-1.12-ci_rel-5.6/28
```
[2023-06-11T08:49:13.999Z] [91m++ conda install -q -y cmake
[2023-06-11T08:49:18.719Z] [0mCollecting package metadata (current_repodata.json): ...working... done
[2023-06-11T08:49:20.082Z] Solving environment: ...working... unsuccessful initial attempt using frozen solve. Retrying with flexible solve.
[2023-06-11T08:49:21.050Z] Solving environment: ...working... unsuccessful attempt using repodata from current_repodata.json, retrying with next repodata source.
[2023-06-11T08:49:21.050Z] [91m
[2023-06-11T08:49:21.050Z] ResolvePackageNotFound: 
[2023-06-11T08:49:21.050Z]   - conda==23.3.1
```

Tested successfully via: http://rocm-ci.amd.com/view/Release-5.6/job/framework-pytorch-1.12-ci_rel-5.6/33/
