### PR TITLE
[release/1.13] Fix conda error during docker build

### DIFF
--- a/.circleci/docker/common/install_conda.sh
+++ b/.circleci/docker/common/install_conda.sh
@@ -55,6 +55,9 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
   # Ensure we run conda in a directory that jenkins has write access to
   pushd /opt/conda
 
+  # Update conda from defaults
+  as_jenkins conda update -n base -c defaults conda
+
   # Prevent conda from updating to 4.14.0, which causes docker build failures
   # See https://hud.pytorch.org/pytorch/pytorch/commit/754d7f05b6841e555cea5a4b2c505dd9e0baec1d
   # Uncomment the below when resolved to track the latest conda update


### PR DESCRIPTION
Failure observed during PyTorch build in: http://rocm-ci.amd.com/job/framework-pytorch-1.13-ci_rel-5.6/32
```
[2023-06-13T03:02:49.015Z] ++ conda install -q -y cmake
[2023-06-13T03:03:08.270Z] Collecting package metadata (current_repodata.json): ...working... done
[2023-06-13T03:03:08.270Z] Solving environment: ...working... unsuccessful initial attempt using frozen solve. Retrying with flexible solve.
[2023-06-13T03:03:08.270Z] Solving environment: ...working... unsuccessful attempt using repodata from current_repodata.json, retrying with next repodata source.
[2023-06-13T03:03:08.270Z] 
[2023-06-13T03:03:08.270Z] ResolvePackageNotFound: 
[2023-06-13T03:03:08.270Z]   - conda==23.3.1
```

Tested successfully via: http://rocm-ci.amd.com/view/Release-5.6/job/framework-pytorch-1.13-ci_rel-5.6/33/