### PR TITLE
test/run_test.py: Pass --save-xml to individual tests

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -561,6 +561,9 @@ def run_test(
             )
         unittest_args = [arg for arg in unittest_args if "--reruns" not in arg]
 
+    if options.save_xml:
+        unittest_args += ['--save-xml', options.save_xml]
+
     # Extra arguments are not supported with pytest
     executable = get_executable_command(options, is_cpp_test=is_cpp_test)
     if not executable:


### PR DESCRIPTION
When running `python3 test/run_test.py --continue-through-error --exclude-jit-executor --exclude-distributed-tests --save-xml <target_xml_directory>`, the `--save-xml` option had no effects.

It turns out this argument was never passed to individual testing scripts.

I'm not planning to send this to upstream without internal testing because run_test.py also invokes C++ unit tests and the extra `--save-xml` may cause massive regressions.