### PR TITLE
[SWDEV-407256] - Temporarily skip distributed_spawn failures

### DIFF
--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -4629,6 +4629,7 @@ class DistributedTest:
                         # case.
                         optim.zero_grad(set_to_none=True)
 
+        @skip_if_rocm
         @skip_if_lt_x_gpu(2)
         def test_ddp_apply_optim_in_backward(self):
             for optim_cls in [torch.optim.SGD, torch.optim.Adam]:
@@ -4638,6 +4639,7 @@ class DistributedTest:
                         optim_kwargs={"lr": 0.03}
                     )
 
+        @skip_if_rocm
         @skip_if_lt_x_gpu(2)
         def test_ddp_apply_optim_in_backward_grad_as_bucket_view_false(self):
             self._test_ddp_apply_optim_in_backward(


### PR DESCRIPTION
Related ticket https://ontrack-internal.amd.com/browse/SWDEV-407256
Tracking issue: https://github.com/ROCmSoftwarePlatform/frameworks-internal/issues/4816

Numeric issues observed in 5.6 release/2.0 images. This PR will skip the affected UTs until further investigation.

Example fail
```
BACKEND=nccl WORLD_SIZE=2 PYTORCH_TEST_WITH_ROCM=1 HIP_VISIBLE_DEVICES=4,5 python3 test/distributed/test_distributed_spawn.py TestDistBackendWithSpawn.test_ddp_apply_optim_in_backward_grad_as_bucket_view_false
AssertionError: Tensor-likes are not close!
Mismatched elements: 9405 / 9408 (100.0%)
Greatest absolute difference: 0.06988954544067383 at index (34, 2, 0, 4) (up to 1e-05 allowed)
Greatest relative difference: 154.58467937778929 at index (7, 1, 3, 6) (up to 1.3e-06 allowed
```

NOTE: gloo backend passes this test, only nccl fails.