### PR TITLE
[ROCM] test_upsamplingNearest2d_launch_rocm_cuda workaround.

### DIFF
--- a/aten/src/ATen/native/cuda/UpSampleNearest2d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleNearest2d.cu
@@ -300,9 +300,11 @@ static void upsample_nearest2d_out_cuda_template(
     // This is unlikely to happen.
     // TODO: kernel implementation could stride on spatial dimension. We probably
     //       need to overhaul the kernel.
+#if !defined(USE_ROCM)
     TORCH_CHECK(
         grid_x <= maxGridSize[0] && grid_y <= maxGridSize[1],
         "input tensor has spatial dimension larger than the kernel capacity");
+#endif
 
     cudaStream_t stream = at::cuda::getCurrentCUDAStream();
     AT_DISPATCH_FLOATING_TYPES_AND3(ScalarType::Half, ScalarType::BFloat16, ScalarType::Byte, input.scalar_type(), "upsample_nearest2d_out_frame", [&] {


### PR DESCRIPTION
hipGetDeviceProperties reports incorrect maxGridSize in ROCM 5.7. This is a temporary solution that disables the dimension check on ROCM, which is effectively useless because the correct maxGridSize on ROCM is int32_max.

The proper fix is tracked at SWDEV-408684.

Fixes [frameworks-internal #4834
](https://github.com/ROCmSoftwarePlatform/frameworks-internal/issues/4834)