### PR TITLE
Do not reinstall triton if BUILD_ENVIRONMENT OR TEST_CONFIG is rocm

### DIFF
--- a/.ci/pytorch/common_utils.sh
+++ b/.ci/pytorch/common_utils.sh
@@ -135,7 +135,7 @@ function install_filelock() {
 
 function install_triton() {
   local commit
-  if [[ "${TEST_CONFIG}" == *rocm* ]]; then
+  if [[ "${TEST_CONFIG}" == *rocm* ]] || [[ "${BUILD_ENVIRONMENT}" == *rocm* ]]; then
     echo "skipping triton due to rocm"
   else
     commit=$(get_pinned_commit triton)

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -846,7 +846,7 @@ elif [[ "${BUILD_ENVIRONMENT}" == *libtorch* ]]; then
   echo "no-op at the moment"
 elif [[ "$TEST_CONFIG" == distributed ]]; then
   install_filelock
-  #install_triton
+  install_triton
   test_distributed
   # Only run RPC C++ tests on the first shard
   if [[ "${SHARD_NUMBER}" == 1 ]]; then
@@ -857,19 +857,19 @@ elif [[ "$TEST_CONFIG" == deploy ]]; then
   test_torch_deploy
 elif [[ "${TEST_CONFIG}" == *inductor_distributed* ]]; then
   install_filelock
-  #install_triton
+  install_triton
   install_huggingface
   test_inductor_distributed
 elif [[ "${TEST_CONFIG}" == *dynamo* && "${SHARD_NUMBER}" == 1 && $NUM_TEST_SHARDS -gt 1 ]]; then
   test_without_numpy
   install_torchvision
-  #install_triton
+  install_triton
   test_dynamo_shard 1
   test_aten
 elif [[ "${TEST_CONFIG}" == *dynamo* && "${SHARD_NUMBER}" == 2 && $NUM_TEST_SHARDS -gt 1 ]]; then
   install_torchvision
   install_filelock
-  #install_triton
+  install_triton
   test_dynamo_shard 2
 elif [[ "${TEST_CONFIG}" == *aot_eager_all* ]]; then
   install_torchtext
@@ -917,7 +917,7 @@ elif [[ "${TEST_CONFIG}" == *aot_eager_torchbench* ]]; then
 elif [[ "${TEST_CONFIG}" == *inductor_huggingface* ]]; then
   install_torchvision
   install_filelock
-  #install_triton
+  install_triton
   install_huggingface
   if [[ "${TEST_CONFIG}" == *inductor_huggingface_perf* ]]; then
     test_inductor_huggingface_perf
@@ -927,7 +927,7 @@ elif [[ "${TEST_CONFIG}" == *inductor_huggingface* ]]; then
 elif [[ "${TEST_CONFIG}" == *inductor_timm* && $NUM_TEST_SHARDS -gt 1 ]]; then
   install_torchvision
   install_filelock
-  #install_triton
+  install_triton
   install_timm
   id=$((SHARD_NUMBER-1))
   if [[ "${TEST_CONFIG}" == *inductor_timm_perf* && $NUM_TEST_SHARDS -gt 1 ]]; then
@@ -939,7 +939,7 @@ elif [[ "${TEST_CONFIG}" == *inductor_torchbench* ]]; then
   install_torchtext
   install_torchvision
   install_filelock
-  #install_triton
+  install_triton
   if [[ "${TEST_CONFIG}" == *inductor_torchbench_perf* ]]; then
     checkout_install_torchbench
     test_inductor_torchbench_perf
@@ -953,18 +953,18 @@ elif [[ "${TEST_CONFIG}" == *inductor_torchbench* ]]; then
 elif [[ "${TEST_CONFIG}" == *inductor* && "${SHARD_NUMBER}" == 1 ]]; then
   install_torchvision
   install_filelock
-  #install_triton
+  install_triton
   test_inductor
   test_inductor_distributed
 elif [[ "${SHARD_NUMBER}" == 1 && $NUM_TEST_SHARDS -gt 1 ]]; then
   test_without_numpy
   install_torchvision
-  #install_triton
+  install_triton
   test_python_shard 1
   test_aten
 elif [[ "${SHARD_NUMBER}" == 2 && $NUM_TEST_SHARDS -gt 1 ]]; then
   install_torchvision
-  #install_triton
+  install_triton
   test_python_shard 2
   test_libtorch
   test_aot_compilation
@@ -974,7 +974,7 @@ elif [[ "${SHARD_NUMBER}" == 2 && $NUM_TEST_SHARDS -gt 1 ]]; then
 elif [[ "${SHARD_NUMBER}" -gt 2 ]]; then
   # Handle arbitrary number of shards
   install_torchvision
-  #install_triton
+  install_triton
   test_python_shard "$SHARD_NUMBER"
 elif [[ "${BUILD_ENVIRONMENT}" == *vulkan* ]]; then
   test_vulkan
@@ -992,7 +992,7 @@ elif [[ "${TEST_CONFIG}" == *functorch* ]]; then
   test_functorch
 else
   install_torchvision
-  #install_triton
+  install_triton
   install_monkeytype
   test_python
   test_aten

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -846,7 +846,7 @@ elif [[ "${BUILD_ENVIRONMENT}" == *libtorch* ]]; then
   echo "no-op at the moment"
 elif [[ "$TEST_CONFIG" == distributed ]]; then
   install_filelock
-  install_triton
+  #install_triton
   test_distributed
   # Only run RPC C++ tests on the first shard
   if [[ "${SHARD_NUMBER}" == 1 ]]; then
@@ -857,19 +857,19 @@ elif [[ "$TEST_CONFIG" == deploy ]]; then
   test_torch_deploy
 elif [[ "${TEST_CONFIG}" == *inductor_distributed* ]]; then
   install_filelock
-  install_triton
+  #install_triton
   install_huggingface
   test_inductor_distributed
 elif [[ "${TEST_CONFIG}" == *dynamo* && "${SHARD_NUMBER}" == 1 && $NUM_TEST_SHARDS -gt 1 ]]; then
   test_without_numpy
   install_torchvision
-  install_triton
+  #install_triton
   test_dynamo_shard 1
   test_aten
 elif [[ "${TEST_CONFIG}" == *dynamo* && "${SHARD_NUMBER}" == 2 && $NUM_TEST_SHARDS -gt 1 ]]; then
   install_torchvision
   install_filelock
-  install_triton
+  #install_triton
   test_dynamo_shard 2
 elif [[ "${TEST_CONFIG}" == *aot_eager_all* ]]; then
   install_torchtext
@@ -917,7 +917,7 @@ elif [[ "${TEST_CONFIG}" == *aot_eager_torchbench* ]]; then
 elif [[ "${TEST_CONFIG}" == *inductor_huggingface* ]]; then
   install_torchvision
   install_filelock
-  install_triton
+  #install_triton
   install_huggingface
   if [[ "${TEST_CONFIG}" == *inductor_huggingface_perf* ]]; then
     test_inductor_huggingface_perf
@@ -927,7 +927,7 @@ elif [[ "${TEST_CONFIG}" == *inductor_huggingface* ]]; then
 elif [[ "${TEST_CONFIG}" == *inductor_timm* && $NUM_TEST_SHARDS -gt 1 ]]; then
   install_torchvision
   install_filelock
-  install_triton
+  #install_triton
   install_timm
   id=$((SHARD_NUMBER-1))
   if [[ "${TEST_CONFIG}" == *inductor_timm_perf* && $NUM_TEST_SHARDS -gt 1 ]]; then
@@ -939,7 +939,7 @@ elif [[ "${TEST_CONFIG}" == *inductor_torchbench* ]]; then
   install_torchtext
   install_torchvision
   install_filelock
-  install_triton
+  #install_triton
   if [[ "${TEST_CONFIG}" == *inductor_torchbench_perf* ]]; then
     checkout_install_torchbench
     test_inductor_torchbench_perf
@@ -953,18 +953,18 @@ elif [[ "${TEST_CONFIG}" == *inductor_torchbench* ]]; then
 elif [[ "${TEST_CONFIG}" == *inductor* && "${SHARD_NUMBER}" == 1 ]]; then
   install_torchvision
   install_filelock
-  install_triton
+  #install_triton
   test_inductor
   test_inductor_distributed
 elif [[ "${SHARD_NUMBER}" == 1 && $NUM_TEST_SHARDS -gt 1 ]]; then
   test_without_numpy
   install_torchvision
-  install_triton
+  #install_triton
   test_python_shard 1
   test_aten
 elif [[ "${SHARD_NUMBER}" == 2 && $NUM_TEST_SHARDS -gt 1 ]]; then
   install_torchvision
-  install_triton
+  #install_triton
   test_python_shard 2
   test_libtorch
   test_aot_compilation
@@ -974,7 +974,7 @@ elif [[ "${SHARD_NUMBER}" == 2 && $NUM_TEST_SHARDS -gt 1 ]]; then
 elif [[ "${SHARD_NUMBER}" -gt 2 ]]; then
   # Handle arbitrary number of shards
   install_torchvision
-  install_triton
+  #install_triton
   test_python_shard "$SHARD_NUMBER"
 elif [[ "${BUILD_ENVIRONMENT}" == *vulkan* ]]; then
   test_vulkan
@@ -992,7 +992,7 @@ elif [[ "${TEST_CONFIG}" == *functorch* ]]; then
   test_functorch
 else
   install_torchvision
-  install_triton
+  #install_triton
   install_monkeytype
   test_python
   test_aten


### PR DESCRIPTION
By default when testing locally TEST_CONFIG is not set. This results in OpenAI's triton being installed in the install_triton path (as opposed to doing nothing at all)

This issue causes failures in inductor UTs on ROCm when run with test.sh
```
inductor/test_torchinductor_opinfo.py::TestInductorOpInfoCUDA::test_comprehensive___radd___cuda_float16 /usr/bin/ld: cannot find -lcuda
 raise BackendCompilerFailed(self.compiler_fn, e) from e
torch._dynamo.exc.BackendCompilerFailed: compile_fx_wrapper raised CalledProcessError: Command '['/usr/bin/gcc', '/tmp/tmptgpf59c5/main.c', '-O3', '-I/root/.local/lib/python3.8/site-packages/triton/third_party/cuda/include', '-I/opt/conda/envs/py_3.8/include/python3.8', '-I/tmp/tmptgpf59c5', '-shared', '-fPIC', '-lcuda', '-o', '/tmp/tmptgpf59c5/triton_.cpython-38-x86_64-linux-gnu.so']' returned non-zero exit status 1.
```


**Proposed solution**
Add `BUILD_ENVIRONMENT==*rocm*` to the conditional logic for bypassing install_triton, BUILD_ENVIRONMENT is set in the Docker image but TEST_CONFIG is only set on the CI, as long as one of these is set we will not install triton, this is a minimal change that is unlikely to cause any unintended consequences.

Related to:
https://ontrack-internal.amd.com/browse/SWDEV-408892
https://ontrack-internal.amd.com/browse/SWDEV-404977
https://ontrack-internal.amd.com/browse/SWDEV-398062
