### PR TITLE
[ROCM] Fixes SWDEV-408938

### DIFF
--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -99,7 +99,10 @@ class TestMatmulCuda(TestCase):
         # Move to CPU for comparison
         res_cuda = res_cuda.to("cpu")
         # Compare
-        self.assertEqual(res_cpu, res_cuda)
+        if dtype == torch.float16:
+            self.assertEqual(res_cpu, res_cuda, atol=size*2.5e-5, rtol=0.0)
+        else:
+            self.assertEqual(res_cpu, res_cuda)
         torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = orig
 
     @onlyCUDA


### PR DESCRIPTION
After discussion with the rocBLAS team it turns out our common testing method of floating point errors is flawed. The conclusions are

1) Relative tolerance parameter (rtol) may cause false negatives and
   should be avoided;
2) Absolute tolerance parameter (atol) should take the number of FLOPs
   into consideration.

An example for 1): [1e-5, 100.0, -100.0]. For FP16 its sum is 7.6e-06 (numpy CPU), and the rtol is exaggerated to 23.71%.

2) is straightforward since FP errors are accumulating.

Fixes #SWDEV-408938
