### PR TITLE
Rocm5.7 fix test profiler tree

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -132,7 +132,8 @@
 	url = https://github.com/NVIDIA/cudnn-frontend.git
 [submodule "third_party/kineto"]
     path = third_party/kineto
-    url = https://github.com/pytorch/kineto
+    url = https://github.com/ROCmSoftwarePlatform/kineto
+    branch = rocm5.7_internal_testing
 [submodule "third_party/pocketfft"]
 	path = third_party/pocketfft
 	url = https://github.com/mreineck/pocketfft


### PR DESCRIPTION
Fixed below unit tests:
test_profiler_tree.py TestProfilerTree.test_profiler_experimental_tree
test_profiler_tree.py TestProfilerTree.test_profiler_experimental_tree_with_memory -v
test_profiler_tree.py TestProfilerTree.test_profiler_experimental_tree_with_record_function -v

Reference JIRA ticket: https://ontrack-internal.amd.com/browse/SWDEV-371430

Excluding this API to match Kineto profiling behavior, since the unit test mentioned looks for an exact match of profiling output.
