### PR TITLE
Add step in PyTorch build flow to harmonize QA testing with upstream CI

### DIFF
--- a/.ci/pytorch/build.sh
+++ b/.ci/pytorch/build.sh
@@ -315,4 +315,8 @@ if [[ "$BUILD_ENVIRONMENT" != *libtorch* && "$BUILD_ENVIRONMENT" != *bazel* ]]; 
   python tools/stats/export_test_times.py
 fi
 
+if [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
+  source .ci/pytorch/rocm_extras.sh 
+fi
+
 print_sccache_stats

--- a/.ci/pytorch/rocm_extras.sh
+++ b/.ci/pytorch/rocm_extras.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -ex
+
+# This file contains ROCm-specific logic that's needed for QA to run tests successfully on ROCm
+export CI=1
+export PYTORCH_TEST_WITH_ROCM=1
+export PYTORCH_TESTING_DEVICE_ONLY_FOR="cuda"
+
+# Manually extract the test times for ROCm since default steps may not find the BUILD_ENVIRONMENT key in the json that's hosted upstream
+wget https://raw.githubusercontent.com/pytorch/test-infra/generated-stats/stats/test-times.json
+ROCM_BUILD_ENVIRONMENT_IN_JSON=$(grep -m1 "rocm" test-times.json | cut -d \" -f 2)
+BUILD_ENVIRONMENT=$ROCM_BUILD_ENVIRONMENT_IN_JSON python tools/stats/export_test_times.py


### PR DESCRIPTION
...to set environment variables and download test times json file during pytorch build
