### PR TITLE
ANTIALIAS updated to Resampling.LANCZOS

### DIFF
--- a/torch/utils/tensorboard/summary.py
+++ b/torch/utils/tensorboard/summary.py
@@ -483,9 +483,12 @@ def make_image(tensor, rescale=1, rois=None, labels=None):
     image = Image.fromarray(tensor)
     if rois is not None:
         image = draw_boxes(image, rois, labels=labels)
-    image = image.resize((scaled_width, scaled_height), Image.ANTIALIAS)
+    try:
+        ANTIALIAS = Image.Resampling.LANCZOS
+    except AttributeError:
+        ANTIALIAS = Image.ANTIALIAS
+    image = image.resize((scaled_width, scaled_height), ANTIALIAS)
     import io
-
     output = io.BytesIO()
     image.save(output, format="PNG")
     image_string = output.getvalue()


### PR DESCRIPTION
Fixes SWDEV-411637.

ANTIALIAS is deprecated and has been removed in Pillow 10. Without downgrading Pillow version from 10.0.0, PIL.Image.Resampling.LANCZOS needs to be used instead.