### PR TITLE
Updated requirements-ci.txt with protobuf version

### DIFF
--- a/.circleci/docker/requirements-ci.txt
+++ b/.circleci/docker/requirements-ci.txt
@@ -129,6 +129,7 @@ numba==0.54.1 ; python_version == "3.9"
 #test that import:
 
 #protobuf
+protobuf==3.20.2
 #Description:  Google’s data interchange format
 #Pinned versions:
 #test that import: test_tensorboard.py


### PR DESCRIPTION
Specified protobuf version in requirements-ci.txt. Built docker image and verified this [issue](https://ontrack-internal.amd.com/browse/SWDEV-411637?focusedId=13807080&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-13807080) is resolved without manual downgrade.
