### PR TITLE
Make sampled_addmm_out_sparse_csr and spmm compatible with hipSparse >= 2.4.0

### DIFF
--- a/aten/src/ATen/cuda/CUDASparseDescriptors.cpp
+++ b/aten/src/ATen/cuda/CUDASparseDescriptors.cpp
@@ -53,7 +53,7 @@ cusparseIndexType_t getCuSparseIndexType(const c10::ScalarType& scalar_type) {
   }
 }
 
-#if AT_USE_HIPSPARSE_GENERIC_52_API() || AT_USE_CUSPARSE_GENERIC_API()
+#if AT_USE_HIPSPARSE_CONST_DESCRIPTORS() || AT_USE_HIPSPARSE_GENERIC_52_API() || AT_USE_CUSPARSE_GENERIC_API()
 CuSparseDnMatDescriptor::CuSparseDnMatDescriptor(const Tensor& input, int64_t batch_offset) {
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(input.layout() == kStrided);
   IntArrayRef input_strides = input.strides();
@@ -106,7 +106,7 @@ CuSparseDnMatDescriptor::CuSparseDnMatDescriptor(const Tensor& input, int64_t ba
 
   descriptor_.reset(raw_descriptor);
 }
-#endif // AT_USE_HIPSPARSE_GENERIC_52_API() || AT_USE_CUSPARSE_GENERIC_API()
+#endif // AT_USE_HIPSPARSE_CONST_DESCRIPTORS() || AT_USE_HIPSPARSE_GENERIC_52_API() || AT_USE_CUSPARSE_GENERIC_API()
 
 CuSparseDnVecDescriptor::CuSparseDnVecDescriptor(const Tensor& input) {
   // cuSPARSE doesn't support batched vectors
@@ -177,7 +177,7 @@ CuSparseSpMatCsrDescriptor::CuSparseSpMatCsrDescriptor(const Tensor& input, int6
       value_type // data type of values
       ));
 
-#if AT_USE_HIPSPARSE_GENERIC_52_API() || !defined(USE_ROCM)
+#if AT_USE_HIPSPARSE_CONST_DESCRIPTORS() || AT_USE_HIPSPARSE_GENERIC_52_API() || !defined(USE_ROCM)
   if (ndim == 3 && batch_offset == -1) {
     int batch_count =
         at::native::cuda_int_cast(at::native::batchCount(input), "batch_count");

--- a/aten/src/ATen/native/sparse/cuda/SparseBlasImpl.cpp
+++ b/aten/src/ATen/native/sparse/cuda/SparseBlasImpl.cpp
@@ -579,7 +579,7 @@ void spmm(
     const Scalar& beta,
     const Scalar& alpha,
     const Tensor& result) {
-#if !(AT_USE_CUSPARSE_GENERIC_API() || AT_USE_HIPSPARSE_GENERIC_52_API())
+#if !(AT_USE_CUSPARSE_GENERIC_SDDMM() || AT_USE_HIPSPARSE_GENERIC_52_API() || AT_USE_HIPSPARSE_CONST_DESCRIPTORS())
   addmm_out_legacy(mat1, mat2, beta, alpha, result);
 #else
   c10::MaybeOwned<Tensor> result_ = prepare_dense_matrix_for_cusparse(result);
@@ -1406,7 +1406,7 @@ void sampled_addmm_out_sparse_csr(
     const Scalar& beta,
     const Scalar& alpha,
     const at::sparse_csr::SparseCsrTensor& C) {
-#if !(AT_USE_CUSPARSE_GENERIC_SDDMM() || AT_USE_HIPSPARSE_GENERIC_52_API())
+#if !(AT_USE_CUSPARSE_GENERIC_SDDMM() || AT_USE_HIPSPARSE_GENERIC_52_API() || AT_USE_HIPSPARSE_CONST_DESCRIPTORS())
   TORCH_CHECK(
       false,
       "Calling sampled_addmm with sparse GPU tensors requires compiling ",


### PR DESCRIPTION
Fixes #SWDEV-420269

Tested with `CI=1 PYTORCH_TEST_WITH_ROCM=1  python3 test/run_test.py --continue-through-error --verbose -i test_sparse test_sparse_csr --use-pytest`
All tests passed:
```
xmllint --xpath '//testsuites/testsuite/@*' test_sparse/test_sparse-807071f7b5dbf692.xml  test_sparse_csr/test_sparse_csr-bc83509a402772ff.xml 
 name="pytest"
 errors="0"
 failures="0"
 skipped="345"
 tests="2799"
 time="163.612"
 timestamp="2023-09-14T19:28:32.475896"
 hostname="eaeb070677c3"
 name="pytest"
 errors="0"
 failures="0"
 skipped="729"
 tests="4751"
 time="263.728"
 timestamp="2023-09-14T19:31:23.585087"
 hostname="eaeb070677c3"
 ```