### PR TITLE
Include test_vmap into rocm_blocklist

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -290,6 +290,7 @@ ROCM_BLOCKLIST = [
     "test_jit_legacy",
     "test_cuda_nvml_based_avail",
     "test_jit_cuda_fuser", # Skipped until NVFuser enabled - https://ontrack-internal.amd.com/browse/SWDEV-361875
+    "functorch/test_vmap",
 ]
 
 # The tests inside these files should never be run in parallel with each other


### PR DESCRIPTION
This test suite fails only on MI300.

Further debugging is tracked by this task: https://github.com/ROCmSoftwarePlatform/frameworks-internal/issues/6065