### PR TITLE
update assertRaisesRegex msg in test_rnn_check_device

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4148,7 +4148,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
 
             # input and weights are not at the same device
             with self.assertRaisesRegex(RuntimeError,
-                                        "Input and parameter tensors are not at the same device"):
+                                        "Expected all tensors to be on the same device.*"):
                 model(input.to('cuda:0'))
             with self.assertRaisesRegex(RuntimeError,
                                         "Input and parameter tensors are not at the same device"):
@@ -4162,7 +4162,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
                 else:
                     model(input, (hidden.to('cuda:0')))
             with self.assertRaisesRegex(RuntimeError,
-                                        r"Input and hidden tensors are not at the same device"):
+                                        r"Expected all tensors to be on the same device.*"):
                 if mode == 'LSTM':
                     model_cuda(input.to('cuda:0'), (hidden, hidden))
                 else:
@@ -4171,7 +4171,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             # hidden tensors are not at the same CUDA device
             if mode == 'LSTM':
                 with self.assertRaisesRegex(RuntimeError,
-                                            "Input and hidden tensors are not at the same device"):
+                                            "Expected all tensors to be on the same device.*"):
                     model(input.to('cuda:0'), (hidden.to('cuda:0'), hidden.to('cuda:1')))
 
     @unittest.skipIf(not TEST_MULTIGPU, "multi-GPU not supported")


### PR DESCRIPTION
Fixes #/SWDEV-424308 

A change in the error string causes this comparison failure. 
Once the test case is updated to match the new string, the test works fine. 

AssertionError: "Input and parameter tensors are not at the same device" does not match "Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu! (when checking argument for argument weight in method wrapper_CUDA__miopen_rnn)"

CC: @pruthvistony @jeffdaily 
