### PR TITLE
[do not cherry pick to 6.1] sparse_allreduce skip

### DIFF
--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -2955,6 +2955,7 @@ class DistributedTest:
             BACKEND != "gloo", "Only Gloo backend support sparse all reduce"
         )
         @skip_if_no_gpu
+        @skip_if_rocm # Disable upstream at cutoff https://github.com/pytorch/pytorch/issues/104526
         def test_sparse_all_reduce_sum_cuda(self):
             self._test_sparse_all_reduce_sum(lambda t: t.clone().cuda())
 


### PR DESCRIPTION
At branch cutoff this was flakey/failing upstream https://github.com/pytorch/pytorch/issues/104526, seeing failures as of nightlies 2 weeks ago on both CUDA/ROCm and the issue was closed last week. 