### PR TITLE
[NO Cherry-pick] increase tolerance for torch.float16 on rocm for test_cublas_baddbmm_large_input_*_cuda_float16

### DIFF
--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -156,7 +156,10 @@ class TestMatmulCuda(TestCase):
         if N == M and M == P:
             M2_eye = torch.eye(N, device=device, dtype=dtype)
             out1_eye_gpu = torch.nn.functional.linear(M1, M2_eye.t(), torch.zeros_like(A))
-            self.assertEqual(M1_cpu.to(dtype=dtype), out1_eye_gpu.cpu())
+            if TEST_WITH_ROCM and dtype == torch.float16:
+                self.assertEqual(M1_cpu.to(dtype=dtype), out1_eye_gpu.cpu(), atol=1e-4, rtol=0.001)
+            else:
+                self.assertEqual(M1_cpu.to(dtype=dtype), out1_eye_gpu.cpu())
 
         # baddbmm
         def _expand_to_batch(t: torch.Tensor):
@@ -171,7 +174,10 @@ class TestMatmulCuda(TestCase):
         if N == M and M == P:
             M2_eye = torch.eye(N, device=device, dtype=dtype).expand(batch_size, N, N)
             out2_eye_gpu = torch.baddbmm(torch.zeros_like(A), M1, M2_eye, beta=beta, alpha=alpha)
-            self.assertEqual(M1_cpu.to(dtype=dtype), out2_eye_gpu.cpu())
+            if TEST_WITH_ROCM and dtype == torch.float16:
+                self.assertEqual(M1_cpu.to(dtype=dtype), out2_eye_gpu.cpu(), atol=1e-4, rtol=0.001)
+            else:
+                self.assertEqual(M1_cpu.to(dtype=dtype), out2_eye_gpu.cpu())
 
         # cross comparison
         self.assertEqual(out1_gpu, out2_gpu[0])


### PR DESCRIPTION
After talking with @pruthvistony  - this is a tolerance issue for torch.float16 on rocm on gfx90a.
```text
python torch/test/test_matmul_cuda.py -v -k test_cublas_baddbmm_large_input_2_1000_1000_1000_cuda_float16 
Test results will be stored in test-reports/python-unittest/test.test_matmul_cuda

Running tests...
----------------------------------------------------------------------
  test_cublas_baddbmm_large_input_2_1000_1000_1000_cuda_float16 (__main__.TestMatmulCudaCUDA) ... FAIL (2.579s)

======================================================================
FAIL [2.579s]: test_cublas_baddbmm_large_input_2_1000_1000_1000_cuda_float16 (__main__.TestMatmulCudaCUDA)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/var/lib/jenkins/pytorch/torch/testing/_internal/common_utils.py", line 2412, in wrapper
    method(*args, **kwargs)
  File "/var/lib/jenkins/pytorch/torch/testing/_internal/common_device_type.py", line 415, in instantiated_test
    result = test(self, **param_kwargs)
  File "/var/lib/jenkins/pytorch/torch/testing/_internal/common_device_type.py", line 1084, in only_fn
    return fn(slf, *args, **kwargs)
  File "test/test_matmul_cuda.py", line 162, in test_cublas_baddbmm_large_input
    self.assertEqual(M1_cpu.to(dtype=dtype), out1_eye_gpu.cpu())
  File "/var/lib/jenkins/pytorch/torch/testing/_internal/common_utils.py", line 3315, in assertEqual
    raise error_metas.pop()[0].to_error(
AssertionError: Tensor-likes are not close!

Mismatched elements: 53 / 1000000 (0.0%)
Greatest absolute difference: 6.079673767089844e-05 at index (305, 177) (up to 1e-05 allowed)
Greatest relative difference: inf at index (2, 351) (up to 0.001 allowed)
----------------------------------------------------------------------
Ran 1 test in 2.581s

FAILED (failures=1)
```

torch.float16 smallest value is 6.10352e-05
atol is increased from default 1e-5 to 1e-4 if TEST_WITH_ROCM and dtype==torch.float16

@jithunnair-amd @pruthvistony 
