### PR TITLE
[SWDEV-435696] test_pattern_matcher skips cherry picked from 6.0

### DIFF
--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -75,18 +75,20 @@ class TestPaternMatcher(TestCase):
                 torch.randn(8, 8, device="cuda"),
                 torch.randint(-128, 127, (8, 8), dtype=torch.int8, device="cuda"),
             ),
-            (
-                torch.randn(8, 2, device="cuda", dtype=torch.bfloat16),
-                torch.randint(-128, 127, (2, 8), dtype=torch.int8, device="cuda"),
-            ),
+            # https://github.com/ROCmSoftwarePlatform/frameworks-internal/issues/5880 - Failed to emit LLVM IR with bf16
+            #(
+            #    torch.randn(8, 2, device="cuda", dtype=torch.bfloat16),
+            #    torch.randint(-128, 127, (2, 8), dtype=torch.int8, device="cuda"),
+            #),
             (
                 torch.randn(8, 5, device="cuda", dtype=torch.float16),
                 torch.randint(0, 255, (5, 2), dtype=torch.uint8, device="cuda"),
             ),
-            (
-                torch.randn(8, 8, device="cuda", dtype=torch.float32),
-                torch.randn(8, 8, device="cuda", dtype=torch.bfloat16),
-            ),
+            # https://github.com/ROCmSoftwarePlatform/frameworks-internal/issues/5880 - Failed to emit LLVM IR with bf16
+            #(
+            #    torch.randn(8, 8, device="cuda", dtype=torch.float32),
+            #    torch.randn(8, 8, device="cuda", dtype=torch.bfloat16),
+            #),
         ]
 
         for args in args_list:
@@ -103,10 +105,11 @@ class TestPaternMatcher(TestCase):
                 torch.randn(8, 8, device="cuda", dtype=torch.float16),
                 torch.randint(-128, 127, (2, 8), dtype=torch.int8, device="cuda").t(),
             ),
-            (
-                torch.randn(8, 8, device="cuda", dtype=torch.bfloat16),
-                torch.randint(0, 255, (2, 8), dtype=torch.uint8, device="cuda").t(),
-            ),
+            # https://github.com/ROCmSoftwarePlatform/frameworks-internal/issues/5880 - Failed to emit LLVM IR with bf16
+            #(
+            #    torch.randn(8, 8, device="cuda", dtype=torch.bfloat16),
+            #    torch.randint(0, 255, (2, 8), dtype=torch.uint8, device="cuda").t(),
+            #),
         ]
 
         for args in args_list:

--- a/test/inductor/test_select_algorithm.py
+++ b/test/inductor/test_select_algorithm.py
@@ -114,6 +114,7 @@ class TestSelectAlgorithm(TestCase):
         )
         self.check_counter(counters["inductor"]["select_algorithm_autotune"], 1)
 
+    @skipIfRocm
     @patches
     def test__int_mm(self):
         @torch.compile


### PR DESCRIPTION
Same issue as https://github.com/ROCmSoftwarePlatform/pytorch/pull/1294

Requires same fix in 2.1 branch due to lack of bf16 tl.dot support in the triton pin.