### PR TITLE
Skipping failing unit tests in  release/1.13

### DIFF
--- a/test/distributed/fsdp/test_fsdp_overlap.py
+++ b/test/distributed/fsdp/test_fsdp_overlap.py
@@ -18,8 +18,8 @@ from torch.testing._internal.common_utils import (
     TEST_WITH_DEV_DBG_ASAN,
     get_cycles_per_ms,
     run_tests,
+    TEST_WITH_ROCM,
 )
-
 
 if not dist.is_available():
     print("Distributed not available, skipping tests", file=sys.stderr)
@@ -238,6 +238,7 @@ class TestForwardOverlapWorldSizeOne(FSDPTest):
             both = e4["gpu_total"]
             self.assertTrue(compute_only + all_gather_only > 1.1 * both)
 
+    @unittest.skipIf(TEST_WITH_ROCM, "Skipping as we won't be fixing this test failure on old version of pytorch")
     @skip_if_lt_x_gpu(2)
     def test_forward_overlap(self):
         self._dist_train()

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -6371,6 +6371,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
 
     # For https://github.com/pytorch/pytorch/pull/1273
     # Almost identical to the above `test_Conv2d_naive_groups`
+    @unittest.skipIf(TEST_WITH_ROCM, "Skipping these tests as they are skipped in upstream")
     @torch.backends.cudnn.flags(enabled=True, benchmark=False)
     def test_Conv2d_groups_nobias(self):
         dev_dtypes = [("cpu", torch.float)]
@@ -6409,6 +6410,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
     # Covering special case when group > 1, input-channel / group < 16 and output-channel is multiple of 16
     # See also https://github.com/pytorch/pytorch/pull/18463#issuecomment-476563686
     # and https://github.com/pytorch/pytorch/pull/18463#issuecomment-477001024
+    @unittest.skipIf(TEST_WITH_ROCM, "Skipping these tests as they are skipped in upstream") 
     @torch.backends.cudnn.flags(enabled=True, benchmark=False)
     def test_Conv2d_groups_nobias_v2(self):
         torch.manual_seed(123)
@@ -12719,6 +12721,7 @@ class TestNNDeviceType(NNTestCase):
         actual = F.conv1d(x, y, padding='same', dilation=3)
         self.assertEqual(expect, actual)
 
+    @unittest.skipIf(TEST_WITH_ROCM, "Skipping as we won't be fixing test_conv2d_same_padding_cuda_complex64 and test_conv2d_same_padding_cuda_float32 on old version of pytorch")
     @dtypes(torch.float, torch.cfloat)
     def test_conv2d_same_padding(self, device, dtype):
         if dtype is torch.cfloat:
@@ -15763,6 +15766,7 @@ class TestNNDeviceType(NNTestCase):
                 self.assertEqual(q.size(), out[0].size())
                 self.assertEqual(dtype, out[0].dtype)
 
+    @unittest.skipIf(TEST_WITH_ROCM, "Skipping as we won't be fixing test_Conv2d_naive_groups_cuda_float16 on old version of pytorch")
     @dtypesIfCUDA(*floating_types_and(torch.half, *[torch.bfloat16] if AMPERE_OR_ROCM else []))
     @dtypes(torch.float)
     @torch.backends.cudnn.flags(enabled=True, benchmark=False)

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -76,6 +76,7 @@ from torch.testing._internal.common_utils import (
     parametrize,
     sandcastle_skip,
     sandcastle_skip_if,
+    TEST_WITH_ROCM,
 )
 
 import torch.distributed.optim.post_localSGD_optimizer as post_localSGD_optimizer
@@ -4245,6 +4246,7 @@ class DistributedTest:
                     all([param.requires_grad for param in ddp_model.parameters()])
                 )
 
+        @unittest.skipIf(TEST_WITH_ROCM, "Skipping as we won't be fixing this on old version of pytorch")
         @sandcastle_skip_if(
             BACKEND not in DistTestCases.backend_feature["ddp"],
             f"The {BACKEND} backend does not support DistributedDataParallel"
@@ -4485,6 +4487,7 @@ class DistributedTest:
             "Failing with gloo backend + torchvision due to ongoing issue https://github.com/pytorch/pytorch/issues/111834",
         )
         @skip_if_lt_x_gpu(2)
+        @unittest.skipIf(TEST_WITH_ROCM, "Skipping as we won't be fixing this on old version of pytorch")
         @parametrize("grad_as_bucket_view", [True, False])
         @parametrize("static_graph", [True, False])
         @parametrize("optimize_subset", [True, False])
@@ -4516,6 +4519,7 @@ class DistributedTest:
             "Failing with gloo backend + torchvision due to ongoing issue https://github.com/pytorch/pytorch/issues/111834",
         )
         @skip_if_lt_x_gpu(2)
+        @unittest.skipIf(TEST_WITH_ROCM, "Skipping as we won't be fixing this on old version of pytorch")
         @parametrize("optimize_subset", [True, False])
         def test_ddp_hook_with_optimizer_parity_adam(self, optimize_subset):
             adam_lr = 1e-2
@@ -4540,6 +4544,7 @@ class DistributedTest:
             "Failing with gloo backend + torchvision due to ongoing issue https://github.com/pytorch/pytorch/issues/111834",
         )
         @skip_if_lt_x_gpu(2)
+        @unittest.skipIf(TEST_WITH_ROCM, "Skipping as we won't be fixing this on old version of pytorch")
         @parametrize("optimize_subset", [True, False])
         def test_ddp_hook_with_optimizer_parity_sgd(self, optimize_subset):
             sgd_lr = 1e-2


### PR DESCRIPTION
This PR is to skip the following unit tests 

test_nn

```
test_Conv2d_groups_nobias (__main__.TestNN)
test_Conv2d_groups_nobias_v2 (__main__.TestNN)
test_Conv2d_naive_groups_cuda_float16 (__main__.TestNNDeviceTypeCUDA)
test_conv2d_same_padding_cuda_complex64 (__main__.TestNNDeviceTypeCUDA)
test_conv2d_same_padding_cuda_float32 (__main__.TestNNDeviceTypeCUDA)
```

distributed/fsdp/test_fsdp_overlap

```
test_forward_overlap (__main__.TestForwardOverlapWorldSizeOne)
test_forward_overlap (__main__.TestForwardOverlapWorldSizeTwo)

```
distributed/test_distributed_spawn

```
TestDistBackendWithSpawn.test_DistributedDataParallel_non_default_stream
TestDistBackendWithSpawn.test_ddp_hook_with_optimizer_parity_adam_optimize_subset_False
TestDistBackendWithSpawn.test_ddp_hook_with_optimizer_parity_adam_optimize_subset_True
TestDistBackendWithSpawn.test_ddp_hook_with_optimizer_parity_adamw_grad_as_bucket_view_False_static_graph_False_optimize_subset_False
TestDistBackendWithSpawn.test_ddp_hook_with_optimizer_parity_adamw_grad_as_bucket_view_False_static_graph_False_optimize_subset_True
TestDistBackendWithSpawn.test_ddp_hook_with_optimizer_parity_adamw_grad_as_bucket_view_False_static_graph_True_optimize_subset_False
TestDistBackendWithSpawn.test_ddp_hook_with_optimizer_parity_adamw_grad_as_bucket_view_False_static_graph_True_optimize_subset_True
TestDistBackendWithSpawn.test_ddp_hook_with_optimizer_parity_adamw_grad_as_bucket_view_True_static_graph_False_optimize_subset_False
TestDistBackendWithSpawn.test_ddp_hook_with_optimizer_parity_adamw_grad_as_bucket_view_True_static_graph_False_optimize_subset_True
TestDistBackendWithSpawn.test_ddp_hook_with_optimizer_parity_adamw_grad_as_bucket_view_True_static_graph_True_optimize_subset_False
TestDistBackendWithSpawn.test_ddp_hook_with_optimizer_parity_adamw_grad_as_bucket_view_True_static_graph_True_optimize_subset_True
TestDistBackendWithSpawn.test_ddp_hook_with_optimizer_parity_sgd_optimize_subset_False
TestDistBackendWithSpawn.test_ddp_hook_with_optimizer_parity_sgd_optimize_subset_True
```