### PR TITLE
Disable MIOpen for empty tensors for RNN

### DIFF
--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -71,6 +71,12 @@ bool use_miopen(const at::Tensor& input, const double dropout_state) {
                                 (detail::getCUDAHooks().compiledWithMIOpen()) &&
                                 (input.is_cuda()) &&
                                 (at::globalContext().userEnabledCuDNN());
+    // MIOpen functions returns miopenStatusBadParm on empty
+    // tensors. Maybe some functions actually support empty tensors, but
+    // native kernels shouldn't be much slower because the output is also
+    // likely empty.
+    if (input.sym_numel() == 0) return false;
+
     return is_miopen_acceptable;
 }
 


### PR DESCRIPTION
Some MIOpen RNN functions (lstm, rnn, gru) can't work with empty tensors and return error "MIOpen error handling for support zero input length"
This PR disables MIOpen tor empty tensors and force to use native methods
The solution is based on condition of using CUDNN  https://github.com/pytorch/pytorch/blob/3a52147cc59b240737602d3d046080bbf6f567f1/aten/src/ATen/native/TensorProperties.cpp#L91
It also fix [test_nn.py::TestNN::test_RNN_input_size_zero](https://github.com/ROCmSoftwarePlatform/frameworks-internal/issues/6732)
@pruthvistony @jeffdaily @jithunnair-amd 
