### PR TITLE
[release/2.5] disable BF16 batchnorm with MIOpen for ROCm less then 6.4

### DIFF
--- a/aten/src/ATen/native/Normalization.cpp
+++ b/aten/src/ATen/native/Normalization.cpp
@@ -515,6 +515,9 @@ BatchNormBackend _select_batch_norm_backend(
       input.is_cuda()
       && input.dim() <= MIOPEN_DIM_MAX
       && input.scalar_type() != at::kDouble
+#if (defined(USE_ROCM) && ROCM_VERSION < 60400)
+      && input.scalar_type() != at::kBFloat16
+#endif
       && (weight.scalar_type() != at::kHalf)
       && (weight.scalar_type() != at::kBFloat16)
       && weight.defined() && bias.defined()


### PR DESCRIPTION
PR to disable BF16 batchnorm on ROCm less then 6.4
Fixes "Solver Not Found" https://ontrack-internal.amd.com/browse/SWDEV-502652
