### PR TITLE
Schedule remainder loop chunk in threadblock 0.

### DIFF
--- a/aten/src/ATen/native/cuda/Loops.cuh
+++ b/aten/src/ATen/native/cuda/Loops.cuh
@@ -68,6 +68,7 @@ __device__ inline void elementwise_kernel_helper(func_t f, policy_t policy) {
 
 #ifdef USE_ROCM
 template <
+    bool reverted_idx=false,
     int thread_work_size = thread_work_size(),
     typename func_t,
     typename policy_t>
@@ -79,6 +80,8 @@ __device__ inline void templated_elementwise_kernel_helper(
   using args_t = typename traits::ArgsTuple;
 
   int idx = blockIdx.x;
+  if constexpr (reverted_idx)
+    idx = gridDim.x - blockIdx.x - 1;
 
   return_t results[thread_work_size];
   args_t args[thread_work_size];


### PR DESCRIPTION
Remainder loop chunk is not execute using input vectorized elementwise kernel, but uses standard unrolling, and it is expected to run slower than the rest of the chunk, on average. To prevent long tail, schedule remainder loop chunk as threablock 0 so it will be scheduled first and hopefully complete execution before other faster chunks.

