### PR TITLE
[release/2.6] skip convolution tests on Navi

### DIFF
--- a/test/jit/test_freezing.py
+++ b/test/jit/test_freezing.py
@@ -14,8 +14,10 @@ from torch.testing._internal.common_cuda import TEST_CUDA, TEST_CUDNN
 from torch.testing._internal.common_quantization import skipIfNoFBGEMM
 from torch.testing._internal.common_quantized import override_quantized_engine
 from torch.testing._internal.common_utils import (
+    NAVI_ARCH,
     set_default_dtype,
     skipCUDAMemoryLeakCheckIf,
+    skipIfRocmArch,
     skipIfTorchDynamo,
     TEST_WITH_ROCM,
 )
@@ -2972,6 +2974,7 @@ class TestFrozenOptimizations(JitTestCase):
             self.assertEqual(frozen(inp), mod(inp))
 
     @unittest.skipIf(not (TEST_CUDNN or TEST_WITH_ROCM), "requires CUDNN")
+    @skipIfRocmArch(NAVI_ARCH)  # not supported by MIOPEN on NAVI
     def test_freeze_conv_relu_fusion(self):
         with set_default_dtype(torch.float):
             conv_bias = [True, False]
@@ -3034,6 +3037,7 @@ class TestFrozenOptimizations(JitTestCase):
                 self.assertEqual(mod_eager(inp), frozen_mod(inp))
 
     @unittest.skipIf(not (TEST_CUDNN or TEST_WITH_ROCM), "requires CUDNN")
+    @skipIfRocmArch(NAVI_ARCH)  # not supported by MIOPEN on NAVI
     def test_freeze_conv_relu_fusion_not_forward(self):
         with set_default_dtype(torch.float):
 

--- a/test/nn/test_convolution.py
+++ b/test/nn/test_convolution.py
@@ -54,10 +54,12 @@ from torch.testing._internal.common_utils import (
     gradgradcheck,
     instantiate_parametrized_tests,
     MACOS_VERSION,
+    NAVI_ARCH,
     parametrize as parametrize_test,
     run_tests,
     set_default_dtype,
     skipIfNotMiopenSuggestNHWC,
+    skipIfRocmArch,
     skipIfRocmVersionLessThan,
     subtest,
     TEST_SCIPY,
@@ -3910,6 +3912,7 @@ class TestConvolutionNNDeviceType(NNTestCase):
 
     @onlyCUDA
     @skipCUDAIfNoCudnn
+    @skipIfRocmArch(NAVI_ARCH) # not supported by MIOPEN on NAVI
     @dtypes(torch.float, torch.float16)
     @precisionOverride({torch.half: 0.002, torch.float: 1e-4})
     def test_cudnn_convolution_relu(self, device, dtype):

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -108,7 +108,8 @@ except ImportError:
 
 
 MI300_ARCH = ("gfx940", "gfx941", "gfx942")
-
+NAVI_ARCH = ("gfx1030", "gfx1100", "gfx1101", "gfx1200", "gfx1201")
+NAVI4_ARCH = ("gfx1200", "gfx1201")
 
 def freeze_rng_state(*args, **kwargs):
     return torch.testing._utils.freeze_rng_state(*args, **kwargs)
@@ -1847,6 +1848,19 @@ def skipIfRocm(func=None, *, msg="test doesn't currently work on the ROCm stack"
         return wrapper
     if func:
         return dec_fn(func)
+    return dec_fn
+
+def skipIfRocmArch(arch: Tuple[str, ...]):
+    def dec_fn(fn):
+        @wraps(fn)
+        def wrap_fn(self, *args, **kwargs):
+            if TEST_WITH_ROCM:  # noqa: F821
+                prop = torch.cuda.get_device_properties(0)
+                if prop.gcnArchName.split(":")[0] in arch:
+                    reason = f"skipIfRocm: test skipped on {arch}"
+                    raise unittest.SkipTest(reason)
+            return fn(self, *args, **kwargs)
+        return wrap_fn
     return dec_fn
 
 def runOnRocm(fn):


### PR DESCRIPTION
MIOpen doesn't support convolution on Navi

- add `NAVI_ARCH` and `skipIfRocmArch` to common_utils.py
- test_jit.py::TestFrozenOptimizations::test_freeze_conv_relu_fusion* - skipped on Navi4, not supported by MIOpen
- nn/test_convolution.py::TestConvolutionNNDeviceTypeCUDA::test_cudnn_convolution_relu_cuda_float32 - skipped on Navi4, not supported by MIOpen

Fixes: SWDEV-527625
(partially cherry picked from commit a07b6bf4f3e34be3e96578d4fde5191e9abfee62)



Cherry-picked to release/2.8 branch via https://github.com/ROCm/pytorch/pull/2675