### PR TITLE
[release/2.7][ROCm] update state check for test_trace_while_active* (…

### DIFF
--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -4638,7 +4638,7 @@ class NCCLTraceTest(NCCLTraceTestBase):
                     #ROCm runtime used to call uSleep(20 µs)inside the default‑signal busy-wait loop.
                     #Now, this sleep is removed which lets the host thread spin continuously
                     #Therefore, the state can either be scheduled or started before test dumps the trace.
-                    if TEST_WITH_ROCM and _get_torch_rocm_version() >= (6,4) and timing_enabled:
+                    if torch.version.hip and _get_torch_rocm_version() >= (6,4) and timing_enabled:
                         assert(
                             t[-1]["state"] in ("scheduled", "started"))
                     else:


### PR DESCRIPTION
…#2110)

When timing in enabled, ROCR runtime used to sleep for a small amount which ensured that the application saw the correct state. However, for perf reasons this sleep was removed and now the state is not guaranteed to be "started". That's why, I updated the test state check to be either "started" or "scheduled"

Fixes https://ontrack-internal.amd.com/browse/SWDEV-525883

Upstream PR: https://github.com/pytorch/pytorch/pull/153545

(cherry picked from commit 8a1ad2c45e2851466c7e14e35e2bfad8459a4bd8)

Fixes #ISSUE_NUMBER
