### PR TITLE
[release/2.7] pin numpy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,9 @@ jinja2
 lintrunner ; platform_machine != "s390x"
 networkx
 ninja
-numpy
+numpy==1.22.4; python_version == "3.9" or python_version == "3.10"
+numpy==1.26.2; python_version == "3.11" or python_version == "3.12"
+numpy==2.1.2; python_version >= "3.13"
 optree>=0.13.0
 packaging
 psutil


### PR DESCRIPTION
Validation:
* http://rocm-ci.amd.com/job/mainline-pytorch2.7-manylinux-wheels/43/
* py3.11 testing: `registry-sc-harbor.amd.com/framework/compute-rocm-dkms-no-npi-hipclang:16149_ubuntu22.04_py3.11_pytorch_lw_release2.7_pin_numpy_3bbb3836`
Ran microbenchmark without numpy issue 
* py3.12 testing: `registry-sc-harbor.amd.com/framework/compute-rocm-dkms-no-npi-hipclang:16149_ubuntu24.04_py3.12_pytorch_lw_release2.7_pin_numpy_3bbb3836`
Ran microbenchmark without numpy issue 

When running the microbenchmark in an image without this fix is an error message complaining about a numpy fault, but when running the microbenchmark in an image built from this branch, there was clean run.