### PR TITLE
[AUTOGENERATED] [SWDEV-520999] [release/2.5] Replaced ROCm specific skips to generalized conditions

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -2844,7 +2844,6 @@ class AOTInductorTestsTemplate:
         )
 
     @skipIfRocm  # USE_MEM_EFF_ATTENTION was not enabled for build.
-    @unittest.skipIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Some archs don't support SDPA")
     def test_scaled_dot_product_efficient_attention(self):
         if self.device != "cuda":
             raise unittest.SkipTest("requires CUDA")


### PR DESCRIPTION
Cherry-pick of https://github.com/ROCm/pytorch/pull/2100 