### PR TITLE
[rocm7.0_internal_testing] Fix profiler test_dynamic_toggle

### DIFF
--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -2012,7 +2012,7 @@ assert KinetoStepTracker.current_step() == initial_step + 2 * niters
 
         self.assertTrue(any("aten" in e.name for e in p.events()))
 
-        self.assertTrue(any("cuda" in e.name for e in p.events()))
+        self.assertTrue(any("cuda" in e.name for e in p.events()) or any("hip" in e.name for e in p.events()))
 
         self.assertTrue(any("kernel" in e.name for e in p.events()))
 


### PR DESCRIPTION
For profiling cuda code on rocm device, we need to check for presence of “hip” (hipified code) instead of “cuda”in the profiler event names.

Fixes #[480147](https://ontrack-internal.amd.com/browse/SWDEV-480147)
