### PR TITLE
[release/2.5] Upgrading pywavelets to a more universally compatible version

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -315,8 +315,7 @@ tensorboard==2.13.0
 #Pinned versions:
 #test that import: test_tensorboard
 
-pywavelets==1.4.1 ; python_version < "3.12"
-pywavelets==1.5.0 ; python_version >= "3.12"
+pywavelets==1.6.0
 #Description: This is a requirement of scikit-image, we need to pin
 # it here because 1.5.0 conflicts with numpy 1.21.2 used in CI
 #Pinned versions: 1.4.1


### PR DESCRIPTION
Fixes https://ontrack-internal.amd.com/browse/SWDEV-538152 and https://ontrack-internal.amd.com/browse/SWDEV-540045

Confirmed with 
```
Installing collected packages: pywavelets
  Attempting uninstall: pywavelets
    Found existing installation: PyWavelets 1.4.1
    Uninstalling PyWavelets-1.4.1:
      Successfully uninstalled PyWavelets-1.4.1
Successfully installed pywavelets-1.6.0
```
pywavelets requirements:
```
PyWavelets==1.6.0
└── numpy [required: >=1.22.4,<3]
PyWavelets==1.5.0
└── numpy [required: >=1.22.4,<2.0]
PyWavelets==1.4.1
└── numpy [required: >=1.17.3]
```

