### PR TITLE
[AUTOGENERATED] [release/2.7] skip test_DistributedDataParallel

### DIFF
--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -5410,6 +5410,7 @@ class DistributedTest:
             f"The {BACKEND} backend does not support DistributedDataParallel",
         )
         @skip_if_no_gpu
+        @skip_if_rocm
         def test_DistributedDataParallel(self):
             _group, _group_id, rank = self._init_global_test()
             rank_to_GPU = init_multigpu_helper(dist.get_world_size(), BACKEND)


### PR DESCRIPTION
Cherry-pick of https://github.com/ROCm/pytorch/pull/1552 

#SWDEV-520036

Jithun: on-hold to see if QA sees this test being skipped by using CI=1 env var