### PR TITLE
[rocm7.0_internal_testing] upgrade tensorboard compatible with numpy 2

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -314,8 +314,7 @@ z3-solver==4.12.6.0
 #Pinned versions:
 #test that import:
 
-tensorboard==2.18.0 ; python_version < "3.13"
-tensorboard==2.18.0 ; python_version >= "3.13"
+tensorboard==2.18.0
 #Description: Also included in .ci/docker/requirements-docs.txt
 #Pinned versions:
 #test that import: test_tensorboard


### PR DESCRIPTION
Fixes https://ontrack-internal.amd.com/browse/SWDEV-541809

Upgrading tensorboard after numpy upgrade
Ran in **registry-sc-harbor.amd.com/framework/compute-rocm-dkms-no-npi-hipclang:16381_ubuntu24.04_py3.12_pytorch_lw_rocm7.0_internal_testing_afe8b782**

```
    7  git checkout rocm7.0_IT_upgrade_tensorboard
    8  pip install .ci/docker/requirements-ci.txt
    9  pip install -r .ci/docker/requirements-ci.txt
   10  PYTORCH_TEST_WITH_ROCM=1 python test/test_monitor.py TestMonitorTensorboard.test_event_handler

root@ubb4-rack-22:/var/lib/jenkins/pytorch# PYTORCH_TEST_WITH_ROCM=1 python test/test_monitor.py TestMonitorTensorboard.test_event_handler
/opt/venv/lib/python3.12/site-packages/google/protobuf/internal/well_known_types.py:91: DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
  _EPOCH_DATETIME_NAIVE = datetime.datetime.utcfromtimestamp(0)
.
----------------------------------------------------------------------
Ran 1 test in 0.327s

OK
root@ubb4-rack-22:/var/lib/jenkins/pytorch#

```

Cherry-picked to release/2.6 branch via https://github.com/ROCm/pytorch/pull/2336

Cherry-picked to release/2.7 branch via https://github.com/ROCm/pytorch/pull/2337

Cherry-picked to release/2.5 branch via https://github.com/ROCm/pytorch/pull/2338

Cherry-picked to release/2.4 branch via https://github.com/ROCm/pytorch/pull/2339