### PR TITLE
[rocm7.0_internal_testing] Fix test_aot_inductor

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -30,7 +30,8 @@ from torch.testing._internal import common_utils
 from torch.testing._internal.common_cuda import (
     SM80OrLater,
     SM90OrLater,
-    PLATFORM_SUPPORTS_FLASH_ATTENTION
+    PLATFORM_SUPPORTS_FLASH_ATTENTION,
+    PLATFORM_SUPPORTS_FP8
 )
 from torch.testing._internal.common_device_type import (
     _has_sufficient_memory,


### PR DESCRIPTION
Fixes  SWDEV-541804
Added PLATFORM_SUPPORTS_FP8 import alongside existing platform flags.
Adjusted import formatting to include a trailing comma.
