### PR TITLE
[release/2.7] Update related_commits

### DIFF
--- a/related_commits
+++ b/related_commits
@@ -1,5 +1,5 @@
-ubuntu|pytorch|apex|release/1.7.0|38d1eb2a5785e017a7e3efab20b93bdcca5cb65b|https://github.com/ROCm/apex
-centos|pytorch|apex|release/1.7.0|38d1eb2a5785e017a7e3efab20b93bdcca5cb65b|https://github.com/ROCm/apex
+ubuntu|pytorch|apex|release/1.7.0|1c50337d42df24bb3021d759e8ccb96b1c9f7fe5|https://github.com/ROCm/apex
+centos|pytorch|apex|release/1.7.0|1c50337d42df24bb3021d759e8ccb96b1c9f7fe5|https://github.com/ROCm/apex
 ubuntu|pytorch|torchvision|release/0.22|59a3e1f9f78cfe44cb989877cc6f4ea77c8a75ca|https://github.com/pytorch/vision
 centos|pytorch|torchvision|release/0.22|59a3e1f9f78cfe44cb989877cc6f4ea77c8a75ca|https://github.com/pytorch/vision
 ubuntu|pytorch|torchtext|release/0.18.0|9bed85d7a7ae13cf8c28598a88d8e461fe1afcb4|https://github.com/pytorch/text


### PR DESCRIPTION
Fixing the C10_warpsize issue. replacing the macros with at::cuda::warp_size() - https://github.com/ROCm/apex/pull/244

[[release/1.7.0] Added AITER as a submodule and use in fused_rope.py](https://github.com/ROCm/apex/commit/53f3c6427e07abad6cf48f9e80ef6ebab5ce8964) - https://github.com/ROCm/apex/pull/226

[Replaced warpsize with C10_WARP_SIZE](https://github.com/ROCm/apex/commit/f4170973eb0532b597be425e004ad88609fb5d24) - https://github.com/ROCm/apex/pull/253

[Disabling Aiter Installation in default build ](https://github.com/ROCm/apex/commit/1c50337d42df24bb3021d759e8ccb96b1c9f7fe5) - https://github.com/ROCm/apex/pull/255

Fixes https://ontrack-internal.amd.com/browse/SWDEV-496182
