### PR TITLE
[release/2.4] Update related_commits

### DIFF
--- a/related_commits
+++ b/related_commits
@@ -1,5 +1,5 @@
-ubuntu|pytorch|apex|release/1.4.0|2ee91c07370bd6111927cad48d7c61da8ece0c51|https://github.com/ROCm/apex
-centos|pytorch|apex|release/1.4.0|2ee91c07370bd6111927cad48d7c61da8ece0c51|https://github.com/ROCm/apex
+ubuntu|pytorch|apex|release/1.4.0|faf49ee1bb858e764228083e67809a338dfd18da|https://github.com/ROCm/apex
+centos|pytorch|apex|release/1.4.0|faf49ee1bb858e764228083e67809a338dfd18da|https://github.com/ROCm/apex
 ubuntu|pytorch|torchvision|release/0.19|bbf1b41e2b24a46f69f3ceba7576d67d56459647|https://github.com/ROCm/vision
 centos|pytorch|torchvision|release/0.19|bbf1b41e2b24a46f69f3ceba7576d67d56459647|https://github.com/ROCm/vision
 ubuntu|pytorch|torchtext|release/0.18.0|9bed85d7a7ae13cf8c28598a88d8e461fe1afcb4|https://github.com/pytorch/text


### PR DESCRIPTION
Replacing c10_warp_size with platform based warp_size values - https://github.com/ROCm/apex/pull/246
[Replaced warpsize with C10_WARP_SIZE (](https://github.com/ROCm/apex/commit/2ee91c07370bd6111927cad48d7c61da8ece0c51) - https://github.com/ROCm/apex/pull/250

Fix all warp size in apex - https://github.com/ROCm/apex/pull/257

Fixes : https://ontrack-internal.amd.com/browse/SWDEV-541725