### PR TITLE
[Release2.6][SWDEV-479939] Added sleep statement for Navi archs for vectorized operation on CPU

### DIFF
--- a/aten/src/ATen/native/cpu/AmpGradScalerKernels.cpp
+++ b/aten/src/ATen/native/cpu/AmpGradScalerKernels.cpp
@@ -55,7 +55,10 @@ void _amp_foreach_non_finite_check_and_unscale_cpu_kernel(
   for (auto index: c10::irange(detail::getCUDAHooks().deviceCount()))
   {
     if (detail::getCUDAHooks().isGPUArch(index, archs))
+    {
       is_navi_arch = true;
+      break;
+    }
   }
 
   // Ensures client code (GradScaler) filtered scaled_grads by dtype.

--- a/aten/src/ATen/native/cpu/AmpGradScalerKernels.cpp
+++ b/aten/src/ATen/native/cpu/AmpGradScalerKernels.cpp
@@ -126,7 +126,7 @@ void _amp_foreach_non_finite_check_and_unscale_cpu_kernel(
               [found_inf_ptr, inv_scale_ptr, is_navi_arch](Vectorized<scalar_t> val_vec) -> Vectorized<scalar_t>{
                 if (val_vec.has_inf_nan()) {
                   *found_inf_ptr = 1.f;
-		  // For Navi arch, the vectorized operation was running unreliably, perhaps taking longer                                               // to execute and resulting in failure.
+		  // For Navi arch, the vectorized operation was running unreliably, perhaps taking longer                                             // to execute and resulting in failure.
                   if (is_navi_arch)
                     sleep(0.5);
                 }


### PR DESCRIPTION
Created this PR to fix test_sharded_grad_scaler_found_inf failing test in Jira ticket https://ontrack-internal.amd.com/browse/SWDEV-479939.

The test was failing for Navi arch, that too when the test runs with cpu_offload=true. The cpu_offload=true, results in running the grad scalar optimizer to run on CPU. The grad scalar optimizer uses vectorized & scalar operations to find inf values in tensors. It seems for Navi arch, the vectorized operation is running unreliably, perhaps taking longer time to execute and resulting in failure. Adding a sleep statement in the vectorized operation helps run it successfully.