### PR TITLE
[rocm7.0_internal_testing] Updated related_commits to adapt upstream vision change

### DIFF
--- a/related_commits
+++ b/related_commits
@@ -1,7 +1,7 @@
 ubuntu|pytorch|apex|master|051cba7694213627008d93fbab8f995712ae0761|https://github.com/ROCm/apex
 centos|pytorch|apex|master|051cba7694213627008d93fbab8f995712ae0761|https://github.com/ROCm/apex
-ubuntu|pytorch|torchvision|main|d84aa8936db75d73a6b8085316f4e2a802fe0b99|https://github.com/pytorch/vision
-centos|pytorch|torchvision|main|d84aa8936db75d73a6b8085316f4e2a802fe0b99|https://github.com/pytorch/vision
+ubuntu|pytorch|torchvision|main|f52c4f1afd7dec25cbe7b98bcf1cbc840298e8da|https://github.com/pytorch/vision
+centos|pytorch|torchvision|main|f52c4f1afd7dec25cbe7b98bcf1cbc840298e8da|https://github.com/pytorch/vision
 ubuntu|pytorch|torchtext|main|bde7ecdb6ba9179ccd30cde60a6550478d0a359f|https://github.com/pytorch/text
 centos|pytorch|torchtext|main|bde7ecdb6ba9179ccd30cde60a6550478d0a359f|https://github.com/pytorch/text
 ubuntu|pytorch|torchdata|main|922ac065407546b9cb4f629ab99f1fbf04d8fc12|https://github.com/pytorch/data


### PR DESCRIPTION
Fixes [SWDEV-546013](https://ontrack-internal.amd.com/browse/SWDEV-546013).
Recent upstream vision commit https://github.com/pytorch/vision/commit/f52c4f1afd7dec25cbe7b98bcf1cbc840298e8da breaks vision tests. The straightforward fix is to update vision related commits to the tip-of-tree. 
Tested locally with:
Torchvision builds fine.
pytest test/test_functional_tensor.py -v -k cuda runs fine.
micro_benchmarking_pytorch.py runs fine.
