### PR TITLE
[release/2.8] pin requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ psutil==7.0.0
 pyyaml==6.0.2
 requests==2.32.4
 # setuptools develop deprecated on 80.0
+# issue on Windows after >= 75.8.2 - https://github.com/pytorch/pytorch/issues/148877
 setuptools==75.8.2
 sympy==1.13.3
 types-dataclasses==0.6.6


### PR DESCRIPTION
docker image used;
registry-sc-harbor.amd.com/framework/compute-rocm-dkms-no-npi-hipclang:16510_ubuntu24.04_py3.12_pytorch_release-2.8_b4af472d

Keeping cmake at 3.31.4 or greater