### PR TITLE
[release/2.7][ROCm] Bug fix TunableOp validator UT.

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -5162,7 +5162,7 @@ class TestLinalg(TestCase):
             # Check for rocBLAS and hipBLASLt
             self.assertTrue("ROCBLAS_VERSION" in validators)
             # format: [major].[minor].[patch].[tweak].[commit id]
-            self.assertTrue(re.match(r'^\d+.\d+.\d+.\d+.[a-z0-9]+$', validators["ROCBLAS_VERSION"]))
+            self.assertTrue(re.match(r'^\d+[a-z0-9.]+$', validators["ROCBLAS_VERSION"]))
             self.assertTrue("HIPBLASLT_VERSION" in validators)
             self.assertTrue(re.match(r'^\d+-[a-z0-9]+$', validators["HIPBLASLT_VERSION"]))
 


### PR DESCRIPTION
This is a partial cherry-pick from upstream: https://github.com/pytorch/pytorch/pull/158887

The TunableOp UT appears to fail with different versions of ROCm, but the real issue is the that regex in the UT is incorrect. @jeffdaily discovered this when we upgraded the nightly wheels to ROCm 6.4.2 in upstream PyTorch.

Will resolve SWDEV-548689.

Cherry-picked to rocm7.0_internal_testing branch via https://github.com/ROCm/pytorch/pull/2588