### PR TITLE
[ROCm][Windows] Fix clang cl build on Windows with Python 3.11

### DIFF
--- a/functorch/csrc/dim/arena.h
+++ b/functorch/csrc/dim/arena.h
@@ -8,7 +8,7 @@
 #include <ATen/ATen.h>
 #include "minpybind.h"
 
-#ifdef _WIN32
+#if defined(_MSC_VER) && !defined(__clang__)
 #include <intrin.h>
 // https://stackoverflow.com/questions/355967/how-to-use-msvc-intrinsics-to-get-the-equivalent-of-this-gcc-code
 inline unsigned int __builtin_clz(unsigned int x) {


### PR DESCRIPTION
Added fix for build Pytorch with ROCm on Windows with Python 3.11. [PR with these changes](https://github.com/pytorch/pytorch/pull/159273) is already mrged to upstream main, but it needs to be added to pytorch 2.8.
 