### PR TITLE
[rocm7.0_internal_testing] Change triton package name depending on rocm version

### DIFF
--- a/.github/scripts/build_triton_wheel.py
+++ b/.github/scripts/build_triton_wheel.py
@@ -101,8 +101,12 @@ def build_triton(
         triton_pythondir = triton_basedir / "python"
         triton_repo = "https://github.com/openai/triton"
         if device == "rocm":
-            triton_pkg_name = "pytorch-triton-rocm"
             triton_repo = "https://github.com/ROCm/triton"
+            rocm_version = get_rocm_version()  # e.g., "7.0.1"
+            if tuple(map(int, rocm_version.split("."))) > (7, 0, 0):
+                triton_pkg_name = "triton"
+            else:
+                triton_pkg_name = "pytorch-triton-rocm"
         elif device == "xpu":
             triton_pkg_name = "pytorch-triton-xpu"
             triton_repo = "https://github.com/intel/intel-xpu-backend-for-triton"


### PR DESCRIPTION
Cherry-pick of https://github.com/ROCm/pytorch/pull/2518

Fixes https://ontrack-internal.amd.com/browse/SWDEV-554527