### PR TITLE
[rocm7.1_internal_testing_inductor][ROCm][inductor] Additional pointwise tunings

### DIFF
--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -2507,6 +2507,15 @@ def pointwise(
                 ),
                 *hinted_configs,
             ]
+            # Additional reduction configs appended for ROCm builds
+            if torch.version.hip:
+                configs.append(triton_config_with_settings(
+                    size_hints,
+                    2048,
+                    num_warps=8,
+                    num_stages=2,
+                    waves_per_eu=1
+                )) # 20% improvement
     if len(size_hints) == 2:
         if (
             disable_pointwise_autotuning(inductor_meta) # or tile_hint == TileHint.SQUARE


### PR DESCRIPTION
This config improves the performance of a 1D pointwise kernel by 20% as measured on MI350.

(cherry picked from commit a7bac0ac90970ac28175dc76ded5bd937a3a2606)

Duplicate of this https://github.com/ROCm/pytorch/pull/2642
