### PR TITLE
[AUTOGENERATED] [release/2.8] skip convolution tests on Navi4x

### DIFF
--- a/test/jit/test_freezing.py
+++ b/test/jit/test_freezing.py
@@ -15,11 +15,8 @@ from torch.testing._internal.common_cuda import TEST_CUDA, TEST_CUDNN
 from torch.testing._internal.common_quantization import skipIfNoFBGEMM
 from torch.testing._internal.common_quantized import override_quantized_engine
 from torch.testing._internal.common_utils import (
-<<<<<<< HEAD
     raise_on_run_directly,
-=======
     NAVI_ARCH,
->>>>>>> 3b9e558b7c ([release/2.6] skip convolution tests on Navi (#2055))
     set_default_dtype,
     skipCUDAMemoryLeakCheckIf,
     skipIfRocmArch,

--- a/test/jit/test_freezing.py
+++ b/test/jit/test_freezing.py
@@ -3032,7 +3032,7 @@ class TestFrozenOptimizations(JitTestCase):
                 self.assertEqual(mod_eager(inp), frozen_mod(inp))
 
     @unittest.skipIf(not (TEST_CUDNN or TEST_WITH_ROCM), "requires CUDNN")
-    @skipIfRocmArch(NAVI_ARCH)  # not supported by MIOPEN on NAVI
+    @skipIfRocmArch(NAVI4_ARCH)  # not supported by MIOPEN on NAVI4x
     def test_freeze_conv_relu_fusion_not_forward(self):
         with set_default_dtype(torch.float):
 

--- a/test/jit/test_freezing.py
+++ b/test/jit/test_freezing.py
@@ -16,7 +16,7 @@ from torch.testing._internal.common_quantization import skipIfNoFBGEMM
 from torch.testing._internal.common_quantized import override_quantized_engine
 from torch.testing._internal.common_utils import (
     raise_on_run_directly,
-    NAVI_ARCH,
+    NAVI4_ARCH,
     set_default_dtype,
     skipCUDAMemoryLeakCheckIf,
     skipIfRocmArch,
@@ -2969,7 +2969,7 @@ class TestFrozenOptimizations(JitTestCase):
             self.assertEqual(frozen(inp), mod(inp))
 
     @unittest.skipIf(not (TEST_CUDNN or TEST_WITH_ROCM), "requires CUDNN")
-    @skipIfRocmArch(NAVI_ARCH)  # not supported by MIOPEN on NAVI
+    @skipIfRocmArch(NAVI4_ARCH)  # not supported by MIOPEN on NAVI4x
     def test_freeze_conv_relu_fusion(self):
         with set_default_dtype(torch.float):
             conv_bias = [True, False]

--- a/test/jit/test_freezing.py
+++ b/test/jit/test_freezing.py
@@ -15,9 +15,14 @@ from torch.testing._internal.common_cuda import TEST_CUDA, TEST_CUDNN
 from torch.testing._internal.common_quantization import skipIfNoFBGEMM
 from torch.testing._internal.common_quantized import override_quantized_engine
 from torch.testing._internal.common_utils import (
+<<<<<<< HEAD
     raise_on_run_directly,
+=======
+    NAVI_ARCH,
+>>>>>>> 3b9e558b7c ([release/2.6] skip convolution tests on Navi (#2055))
     set_default_dtype,
     skipCUDAMemoryLeakCheckIf,
+    skipIfRocmArch,
     skipIfTorchDynamo,
     TEST_WITH_ROCM,
 )
@@ -2967,6 +2972,7 @@ class TestFrozenOptimizations(JitTestCase):
             self.assertEqual(frozen(inp), mod(inp))
 
     @unittest.skipIf(not (TEST_CUDNN or TEST_WITH_ROCM), "requires CUDNN")
+    @skipIfRocmArch(NAVI_ARCH)  # not supported by MIOPEN on NAVI
     def test_freeze_conv_relu_fusion(self):
         with set_default_dtype(torch.float):
             conv_bias = [True, False]
@@ -3029,6 +3035,7 @@ class TestFrozenOptimizations(JitTestCase):
                 self.assertEqual(mod_eager(inp), frozen_mod(inp))
 
     @unittest.skipIf(not (TEST_CUDNN or TEST_WITH_ROCM), "requires CUDNN")
+    @skipIfRocmArch(NAVI_ARCH)  # not supported by MIOPEN on NAVI
     def test_freeze_conv_relu_fusion_not_forward(self):
         with set_default_dtype(torch.float):
 

--- a/test/nn/test_convolution.py
+++ b/test/nn/test_convolution.py
@@ -48,10 +48,12 @@ from torch.testing._internal.common_utils import (
     gradgradcheck,
     instantiate_parametrized_tests,
     MACOS_VERSION,
+    NAVI_ARCH,
     parametrize as parametrize_test,
     run_tests,
     set_default_dtype,
     skipIfNotMiopenSuggestNHWC,
+    skipIfRocmArch,
     skipIfRocmVersionLessThan,
     subtest,
     TEST_SCIPY,
@@ -3883,6 +3885,7 @@ class TestConvolutionNNDeviceType(NNTestCase):
 
     @onlyCUDA
     @skipCUDAIfNoCudnn
+    @skipIfRocmArch(NAVI_ARCH) # not supported by MIOPEN on NAVI
     @dtypes(torch.float, torch.float16)
     @precisionOverride({torch.half: 0.002, torch.float: 1e-4})
     def test_cudnn_convolution_relu(self, device, dtype):

--- a/test/nn/test_convolution.py
+++ b/test/nn/test_convolution.py
@@ -48,7 +48,7 @@ from torch.testing._internal.common_utils import (
     gradgradcheck,
     instantiate_parametrized_tests,
     MACOS_VERSION,
-    NAVI_ARCH,
+    NAVI4_ARCH,
     parametrize as parametrize_test,
     run_tests,
     set_default_dtype,
@@ -3885,7 +3885,7 @@ class TestConvolutionNNDeviceType(NNTestCase):
 
     @onlyCUDA
     @skipCUDAIfNoCudnn
-    @skipIfRocmArch(NAVI_ARCH) # not supported by MIOPEN on NAVI
+    @skipIfRocmArch(NAVI4_ARCH) # not supported by MIOPEN on NAVI4x
     @dtypes(torch.float, torch.float16)
     @precisionOverride({torch.half: 0.002, torch.float: 1e-4})
     def test_cudnn_convolution_relu(self, device, dtype):

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -105,7 +105,6 @@ except ImportError:
 
 MI300_ARCH = ("gfx940", "gfx941", "gfx942")
 NAVI_ARCH = ("gfx1030", "gfx1100", "gfx1101", "gfx1200", "gfx1201")
-<<<<<<< HEAD
 NAVI3_ARCH = ("gfx1100", "gfx1101")
 NAVI4_ARCH = ("gfx1200", "gfx1201")
 
@@ -116,9 +115,6 @@ def is_navi3_arch():
         if gfx_arch in NAVI3_ARCH:
             return True
     return False
-=======
-NAVI4_ARCH = ("gfx1200", "gfx1201")
->>>>>>> 3b9e558b7c ([release/2.6] skip convolution tests on Navi (#2055))
 
 def freeze_rng_state(*args, **kwargs):
     return torch.testing._utils.freeze_rng_state(*args, **kwargs)
@@ -1930,19 +1926,11 @@ def skipIfRocm(func=None, *, msg="test doesn't currently work on the ROCm stack"
         return dec_fn(func)
     return dec_fn
 
-<<<<<<< HEAD
 def skipIfRocmArch(arch: tuple[str, ...]):
     def dec_fn(fn):
         @wraps(fn)
         def wrap_fn(self, *args, **kwargs):
             if TEST_WITH_ROCM:
-=======
-def skipIfRocmArch(arch: Tuple[str, ...]):
-    def dec_fn(fn):
-        @wraps(fn)
-        def wrap_fn(self, *args, **kwargs):
-            if TEST_WITH_ROCM:  # noqa: F821
->>>>>>> 3b9e558b7c ([release/2.6] skip convolution tests on Navi (#2055))
                 prop = torch.cuda.get_device_properties(0)
                 if prop.gcnArchName.split(":")[0] in arch:
                     reason = f"skipIfRocm: test skipped on {arch}"

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -105,6 +105,7 @@ except ImportError:
 
 MI300_ARCH = ("gfx940", "gfx941", "gfx942")
 NAVI_ARCH = ("gfx1030", "gfx1100", "gfx1101", "gfx1200", "gfx1201")
+<<<<<<< HEAD
 NAVI3_ARCH = ("gfx1100", "gfx1101")
 NAVI4_ARCH = ("gfx1200", "gfx1201")
 
@@ -115,6 +116,9 @@ def is_navi3_arch():
         if gfx_arch in NAVI3_ARCH:
             return True
     return False
+=======
+NAVI4_ARCH = ("gfx1200", "gfx1201")
+>>>>>>> 3b9e558b7c ([release/2.6] skip convolution tests on Navi (#2055))
 
 def freeze_rng_state(*args, **kwargs):
     return torch.testing._utils.freeze_rng_state(*args, **kwargs)
@@ -1926,11 +1930,19 @@ def skipIfRocm(func=None, *, msg="test doesn't currently work on the ROCm stack"
         return dec_fn(func)
     return dec_fn
 
+<<<<<<< HEAD
 def skipIfRocmArch(arch: tuple[str, ...]):
     def dec_fn(fn):
         @wraps(fn)
         def wrap_fn(self, *args, **kwargs):
             if TEST_WITH_ROCM:
+=======
+def skipIfRocmArch(arch: Tuple[str, ...]):
+    def dec_fn(fn):
+        @wraps(fn)
+        def wrap_fn(self, *args, **kwargs):
+            if TEST_WITH_ROCM:  # noqa: F821
+>>>>>>> 3b9e558b7c ([release/2.6] skip convolution tests on Navi (#2055))
                 prop = torch.cuda.get_device_properties(0)
                 if prop.gcnArchName.split(":")[0] in arch:
                     reason = f"skipIfRocm: test skipped on {arch}"


### PR DESCRIPTION
Cherry-pick of https://github.com/ROCm/pytorch/pull/2055, but changed due to these testcases work on Navi3x as expected, for Navi4x these testcases skipped until support of next kernels will be added:
* for test_freeze_conv_relu_fusion_not_forward and test_freeze_conv_relu_fusion: `ConvBinWinogradRxSf2x3g1Fused`
* for test_cudnn_convolution_relu: `ConvBinWinogradRxSf2x3g1`, `ConvBinWinogradRxSf2x3g1Fused` and `ConvWinoFuryRxS<2-3>`

#SWDEV-555401

Cherry-picked to release/2.9 branch via https://github.com/ROCm/pytorch/pull/2775