### PR TITLE
[ROCM][release/2.6][SWDEV-526906]Added skip for test_sac_ilp_case1 test for MI300 Arch

### DIFF
--- a/test/distributed/_tools/test_sac_ilp.py
+++ b/test/distributed/_tools/test_sac_ilp.py
@@ -25,6 +25,7 @@ from torch.testing._internal.common_utils import (
     TestCase,
     skipIfRocmArch,
     NAVI_ARCH,
+    MI300_ARCH,
 )
 
 from torch.testing._internal.distributed._tensor.common_dtensor import (
@@ -138,7 +139,7 @@ class TestSACILP(TestCase):
 
     @skipIfTorchDynamo("https://github.com/pytorch/pytorch/issues/115653")
     @unittest.skipIf(not TEST_CUDA, "CUDA not available")
-    @skipIfRocmArch(NAVI_ARCH)
+    @skipIfRocmArch(NAVI_ARCH + MI300_ARCH)
     def test_sac_ilp_case1(self):
         """
         This is a case where the memory budget is either binding or too tight,


### PR DESCRIPTION
In this PR, I have added a skip for test_sac_ilp_case1 test for MI300 Arch in release/2.6 branch. Currently it only skips for Navi arch. There is a skip for this test for MI300 arch in release/2.8 branch. There are upstream issues for this test too https://github.com/search?q=repo%3Apytorch%2Fpytorch+test_sac_ilp_case1&type=issues.
This PR is for failing test reported in Jira https://ontrack-internal.amd.com/browse/SWDEV-526906.  