### PR TITLE
Fixed maximum recursion issue of test_linalg.py

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -109,12 +109,12 @@ def get_tunableop_untuned_filename():
 
 class TestLinalg(TestCase):
     def setUp(self):
-        super(self.__class__, self).setUp()
+        super().setUp()
         torch.backends.cuda.matmul.allow_tf32 = False
 
     def tearDown(self):
         torch.backends.cuda.matmul.allow_tf32 = True
-        super(self.__class__, self).tearDown()
+        super().tearDown()
 
     @contextlib.contextmanager
     def _tunableop_ctx(self):


### PR DESCRIPTION
test_linalg.py tests fail with the following due to missing IFU from commit https://github.com/pytorch/pytorch/commit/cd949d133e2ae5de47e860d2d2350cbfbd18fe20
Traceback (most recent call last):
  File "/var/lib/jenkins/pytorch/test/test_linalg.py", line 112, in setUp
    super(self.__class__, self).setUp()
  File "/var/lib/jenkins/pytorch/test/test_linalg.py", line 112, in setUp
    super(self.__class__, self).setUp()
  File "/var/lib/jenkins/pytorch/test/test_linalg.py", line 112, in setUp
    super(self.__class__, self).setUp()
  [Previous line repeated 982 more times]
RecursionError: maximum recursion depth exceeded
