### PR TITLE
Lock fast_tanh path behind USE_FAST_MATH control to resolve NaN issues

### DIFF
--- a/torch/utils/_triton.py
+++ b/torch/utils/_triton.py
@@ -61,6 +61,17 @@ def has_triton_tma_device():
     return False
 
 
+@functools.cache
+def get_triton_version(fallback: tuple[int, int] = (0, 0)) -> tuple[int, int]:
+    try:
+        import triton  # noqa: F401
+
+        major, minor = tuple(int(v) for v in triton.__version__.split(".")[:2])
+        return (major, minor)
+    except ImportError:
+        return fallback
+
+
 @functools.lru_cache(None)
 def has_triton() -> bool:
     if not has_triton_package():


### PR DESCRIPTION
NaN issues discovered after fast_tanh change https://ontrack-internal.amd.com/browse/SWDEV-560271 making this non-default path until further debugging
