### PR TITLE
[release/2.9] skip convolution tests on Navi4x

### DIFF
--- a/test/jit/test_freezing.py
+++ b/test/jit/test_freezing.py
@@ -16,8 +16,10 @@ from torch.testing._internal.common_quantization import skipIfNoFBGEMM
 from torch.testing._internal.common_quantized import override_quantized_engine
 from torch.testing._internal.common_utils import (
     raise_on_run_directly,
+    NAVI4_ARCH,
     set_default_dtype,
     skipCUDAMemoryLeakCheckIf,
+    skipIfRocmArch,
     skipIfTorchDynamo,
     TEST_WITH_ROCM,
 )
@@ -2967,6 +2969,7 @@ class TestFrozenOptimizations(JitTestCase):
             self.assertEqual(frozen(inp), mod(inp))
 
     @unittest.skipIf(not (TEST_CUDNN or TEST_WITH_ROCM), "requires CUDNN")
+    @skipIfRocmArch(NAVI4_ARCH)  # not supported by MIOPEN on NAVI4x
     def test_freeze_conv_relu_fusion(self):
         with set_default_dtype(torch.float):
             conv_bias = [True, False]
@@ -3029,6 +3032,7 @@ class TestFrozenOptimizations(JitTestCase):
                 self.assertEqual(mod_eager(inp), frozen_mod(inp))
 
     @unittest.skipIf(not (TEST_CUDNN or TEST_WITH_ROCM), "requires CUDNN")
+    @skipIfRocmArch(NAVI4_ARCH)  # not supported by MIOPEN on NAVI4x
     def test_freeze_conv_relu_fusion_not_forward(self):
         with set_default_dtype(torch.float):
 

--- a/test/nn/test_convolution.py
+++ b/test/nn/test_convolution.py
@@ -48,10 +48,12 @@ from torch.testing._internal.common_utils import (
     gradgradcheck,
     instantiate_parametrized_tests,
     MACOS_VERSION,
+    NAVI4_ARCH,
     parametrize as parametrize_test,
     run_tests,
     set_default_dtype,
     skipIfNotMiopenSuggestNHWC,
+    skipIfRocmArch,
     skipIfRocmVersionLessThan,
     subtest,
     TEST_SCIPY,
@@ -3874,6 +3876,7 @@ class TestConvolutionNNDeviceType(NNTestCase):
 
     @onlyCUDA
     @skipCUDAIfNoCudnn
+    @skipIfRocmArch(NAVI4_ARCH) # not supported by MIOPEN on NAVI4x
     @dtypes(torch.float, torch.float16)
     @precisionOverride({torch.half: 0.002, torch.float: 1e-4})
     def test_cudnn_convolution_relu(self, device, dtype):


### PR DESCRIPTION
Cherry-pick of  https://github.com/ROCm/pytorch/pull/2675 (original commit https://github.com/ROCm/pytorch/pull/2055), for Navi4x only these testcases skipped until support of next kernels will be added (progress can be tracked here https://github.com/ROCm/rocm-libraries/pull/2237):

for test_freeze_conv_relu_fusion_not_forward and test_freeze_conv_relu_fusion: ConvBinWinogradRxSf2x3g1Fused
for test_cudnn_convolution_relu: ConvBinWinogradRxSf2x3g1, ConvBinWinogradRxSf2x3g1Fused and ConvWinoFuryRxS<2-3>

Fixes #SWDEV-555401
