### PR TITLE
[release/2.9] add AMD routine to common_utils.py of test framework

### DIFF
--- a/functorch/experimental/__init__.py
+++ b/functorch/experimental/__init__.py
@@ -1,5 +1,5 @@
 # PyTorch forward-mode is not mature yet
-from functorch import functionalize
 from torch._functorch.apis import chunk_vmap
 from torch._functorch.batch_norm_replacement import replace_all_batch_norm_modules_
 from torch._functorch.eager_transforms import hessian, jacfwd, jvp
+from torch.func import functionalize


### PR DESCRIPTION
added missed test routine to release/2.9 which present in release/2.8 and main branch of upstream.

Fixes #SWDEV-555401
