### PR TITLE
[rocm7.1_internal_testing]  Remove --no-use-pep517

### DIFF
--- a/.ci/pytorch/common_utils.sh
+++ b/.ci/pytorch/common_utils.sh
@@ -96,7 +96,6 @@ function pip_build_and_install() {
     python3 -m pip wheel \
       --no-build-isolation \
       --no-deps \
-      --no-use-pep517 \
       -w "${wheel_dir}" \
       "${build_target}"
   fi

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -9,4 +9,4 @@ pyyaml==6.0.2
 requests==2.32.4
 six==1.17.0  # dependency chain: NNPACK -> PeachPy -> six
 typing-extensions==4.14.1
-pip  # not technically needed, but this makes setup.py invocation work
+pip==25.2  # not technically needed, but this makes setup.py invocation work

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -9,4 +9,4 @@ pyyaml==6.0.2
 requests==2.32.4
 six==1.17.0  # dependency chain: NNPACK -> PeachPy -> six
 typing-extensions==4.14.1
-pip==25.2  # not technically needed, but this makes setup.py invocation work
+pip  # not technically needed, but this makes setup.py invocation work


### PR DESCRIPTION
We are removing the flag `--use-pep517` as it been deprecated in pip >=25.3. Fixes https://ontrack-internal.amd.com/browse/SWDEV-564417
Fails with:
```
+ python3 -m pip wheel --no-build-isolation --no-deps --no-use-pep517 -w dist/vision git+https://github.com/pytorch/vision.git@966da7e46f65d6d49df3e31214470a4fe5cc8e66

Usage:
  /opt/venv/bin/python3 -m pip wheel [options] <requirement specifier> ...
  /opt/venv/bin/python3 -m pip wheel [options] -r <requirements file> ...
  /opt/venv/bin/python3 -m pip wheel [options] [-e] <vcs project url> ...
  /opt/venv/bin/python3 -m pip wheel [options] [-e] <local project path> ...
  /opt/venv/bin/python3 -m pip wheel [options] <archive url/path> ...

no such option: --no-use-pep517

```
After removing the flag
```
python3 -m pip wheel --no-build-isolation --no-deps  -w dist/vision git+https://github.com/pytorch/vision.git@966da7e46f65d6d49df3e31214470a4fe5cc8e66
Collecting git+https://github.com/pytorch/vision.git@966da7e46f65d6d49df3e31214470a4fe5cc8e66
  Cloning https://github.com/pytorch/vision.git (to revision 966da7e46f65d6d49df3e31214470a4fe5cc8e66) to /tmp/pip-req-build-otbwsr_y
```

Cherry-picked to release/2.9 branch via https://github.com/ROCm/pytorch/pull/2805





