### PR TITLE
Fix torch.version.hip issue containing trailing hash code

### DIFF
--- a/cmake/public/LoadHIP.cmake
+++ b/cmake/public/LoadHIP.cmake
@@ -84,6 +84,17 @@ if(HIP_FOUND)
   set(PYTORCH_FOUND_HIP TRUE)
   find_package_and_print_version(hip REQUIRED CONFIG)
 
+  if(HIP_VERSION)
+    # Check if HIP_VERSION contains a dash (e.g., "7.1.25421-32f9fa6ca5")
+    # and strip everything after it to get clean numeric version
+    string(FIND "${HIP_VERSION}" "-" DASH_POS)
+    if(NOT DASH_POS EQUAL -1)
+      string(SUBSTRING "${HIP_VERSION}" 0 ${DASH_POS} HIP_VERSION_CLEAN)
+      set(HIP_VERSION "${HIP_VERSION_CLEAN}")
+    endif()
+    message("HIP version: ${HIP_VERSION}")
+  endif()
+
   # The rocm-core package was only introduced in ROCm 6.4, so we make it optional.
   find_package(rocm-core CONFIG)
 

--- a/tools/generate_torch_version.py
+++ b/tools/generate_torch_version.py
@@ -119,6 +119,7 @@ if __name__ == "__main__":
     )
     parser.add_argument("--cuda-version", "--cuda_version", type=str)
     parser.add_argument("--hip-version", "--hip_version", type=str)
+    parser.add_argument("--rocm-version", "--rocm_version", type=str)
     parser.add_argument("--xpu-version", "--xpu_version", type=str)
 
     args = parser.parse_args()
@@ -126,6 +127,7 @@ if __name__ == "__main__":
     assert args.is_debug is not None
     args.cuda_version = None if args.cuda_version == "" else args.cuda_version
     args.hip_version = None if args.hip_version == "" else args.hip_version
+    args.rocm_version = None if args.rocm_version == "" else args.rocm_version
     args.xpu_version = None if args.xpu_version == "" else args.xpu_version
 
     pytorch_root = Path(__file__).parent.parent
@@ -141,7 +143,7 @@ if __name__ == "__main__":
     with open(version_path, "w") as f:
         f.write("from typing import Optional\n\n")
         f.write(
-            "__all__ = ['__version__', 'debug', 'cuda', 'git_version', 'hip', 'xpu']\n"
+            "__all__ = ['__version__', 'debug', 'cuda', 'git_version', 'hip', 'rocm', 'xpu']\n"
         )
         f.write(f"__version__ = '{version}'\n")
         # NB: This is not 100% accurate, because you could have built the
@@ -151,4 +153,5 @@ if __name__ == "__main__":
         f.write(f"cuda: Optional[str] = {repr(args.cuda_version)}\n")
         f.write(f"git_version = {repr(sha)}\n")
         f.write(f"hip: Optional[str] = {repr(args.hip_version)}\n")
+        f.write(f"rocm: Optional[str] = {repr(args.rocm_version)}\n")
         f.write(f"xpu: Optional[str] = {repr(args.xpu_version)}\n")

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -490,7 +490,7 @@ add_custom_target(
   "${Python_EXECUTABLE}" "${TOOLS_PATH}/generate_torch_version.py"
     --is-debug=${TORCH_VERSION_DEBUG}
     --cuda-version=${CUDA_VERSION}
-    --hip-version=${ROCM_VERSION_DEV}
+    --hip-version=${HIP_VERSION}
     --xpu-version=${SYCL_COMPILER_VERSION}
   BYPRODUCTS ${TORCH_SRC_DIR}/version.py
   COMMENT "Regenerating version file..."

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -491,6 +491,7 @@ add_custom_target(
     --is-debug=${TORCH_VERSION_DEBUG}
     --cuda-version=${CUDA_VERSION}
     --hip-version=${HIP_VERSION}
+    --rocm-version=${ROCM_VERSION_DEV}
     --xpu-version=${SYCL_COMPILER_VERSION}
   BYPRODUCTS ${TORCH_SRC_DIR}/version.py
   COMMENT "Regenerating version file..."

--- a/torch/version.py.tpl
+++ b/torch/version.py.tpl
@@ -4,6 +4,7 @@ cuda = '{{CUDA_VERSION}}'
 # TODO: use workspace status to stamp the correct version
 git_version = ""
 hip = None
+rocm = None
 
 # This is a gross monkey-patch hack that depends on the order of imports
 # in torch/__init__.py


### PR DESCRIPTION
Fixes #[SWDEV-565427](https://ontrack-internal.amd.com/browse/SWDEV-565427), [github issue](https://github.com/pytorch/pytorch/issues/166068)

## Motivation
Apex is not building because the hip version from hipcc --version is not matching torch.version.hip.

torch.version.hip has been changed due to recent [commit](https://github.com/pytorch/pytorch/pull/166336/files) to fix [issue](https://github.com/pytorch/pytorch/issues/166068). This commit stores rocm version in torch.version.hip.

The solution is to fix the torch.version.hip so that it uses the hipcc header values and removes the trailing hash code. In addition, torch.version.rocm variable is created to store the rocm version.

## Technical Details

### Fix torch.version.hip

HIP_VERSION variable is computed in https://github.com/ROCm/hip/blob/develop/cmake/FindHIP.cmake. This runs hipcc –version and extracts the output of HIP version line. 

e.g. 
```
hipcc --version 
HIP version: 7.1.25421-32f9fa6ca5 
```

For recent dockers, HIP_VERSION variable contains the hash code at the end. 

For the torch.version.hip to be parsable with packaging code, it should not contain the hash code. 

```
import torch  
from packaging import version  
print(version.parse(torch.version.hip)) 
```

torch.version.hip is a variable mentioned in torch/version.py which is created by tools/generate_torch_version.py and called in the installation process - torch/CMakeLists.txt. 

Before the revert, the torch.version.hip was based on HIP_VERSION variable. For torch.version.hip to be parsable, HIP_VERSION should also be parsable. 

This extra code removes the trailing hashcode from the HIP_VERSION variable so that the torch.version.hip is parsable by packaging version parse method.  

### Add torch.version.rocm

Code changes:
- Add rocm variable to torch/version.py.tpl
- Add code to write rocm variable in tools/generate_torch_version.py
- Write rocm version in installation process - torch/CMakeLists.txt

### Create unit test to check both torch.version.hip and torch.version.rocm are parsable.

## Testing

Tested on docker registry-sc-harbor.amd.com/framework/compute-rocm-dkms-no-npi-hipclang:16831_ubuntu24.04_py3.12_pytorch_rocm7.1_internal_testing_5fc1aeaa

Successfully build pytorch and apex. Tested above parsing torch.version.hip code.

```
>>> import torch
>>> torch.version.hip
'7.1.25421'
>>> torch.version.rocm
'7.2.0'
```