### PR TITLE
[release/2.8] update related_commit

### DIFF
--- a/related_commits
+++ b/related_commits
@@ -1,5 +1,5 @@
-ubuntu|pytorch|apex|release/1.8.0|3f26640cff501d67d35acf424ed2566d50949f5b|https://github.com/ROCm/apex
-centos|pytorch|apex|release/1.8.0|3f26640cff501d67d35acf424ed2566d50949f5b|https://github.com/ROCm/apex
+ubuntu|pytorch|apex|release/1.8.0|c999af72f64f706cc95be83dcc28e1c0312d01a7|https://github.com/ROCm/apex
+centos|pytorch|apex|release/1.8.0|c999af72f64f706cc95be83dcc28e1c0312d01a7|https://github.com/ROCm/apex
 ubuntu|pytorch|torchvision|release/0.23|824e8c8726b65fd9d5abdc9702f81c2b0c4c0dc8|https://github.com/pytorch/vision
 centos|pytorch|torchvision|release/0.23|824e8c8726b65fd9d5abdc9702f81c2b0c4c0dc8|https://github.com/pytorch/vision
 ubuntu|pytorch|torchdata|release/0.11|377e64c1be69a9be6649d14c9e3664070323e464|https://github.com/pytorch/data


### PR DESCRIPTION
Commit Messages:
- Update README.md - Added Release Notes
- Update version to 1.8.0
- add code to read BUILD_VERSION env variable, so that it is used instead of version.txt when creating a wheel

PRs:
- https://github.com/ROCm/apex/pull/287
- https://github.com/ROCm/apex/pull/284
- https://github.com/ROCm/apex/pull/280
