### PR TITLE
[release/2.7] update related_commit

### DIFF
--- a/related_commits
+++ b/related_commits
@@ -1,5 +1,5 @@
-ubuntu|pytorch|apex|release/1.7.0|20a62dc5a91c85fdc9bfd1b389919316f6476951|https://github.com/ROCm/apex
-centos|pytorch|apex|release/1.7.0|20a62dc5a91c85fdc9bfd1b389919316f6476951|https://github.com/ROCm/apex
+ubuntu|pytorch|apex|release/1.7.0|7a57becffa31a4394369152e978fa6f8a0f005c2|https://github.com/ROCm/apex
+centos|pytorch|apex|release/1.7.0|7a57becffa31a4394369152e978fa6f8a0f005c2|https://github.com/ROCm/apex
 ubuntu|pytorch|torchvision|release/0.22|59a3e1f9f78cfe44cb989877cc6f4ea77c8a75ca|https://github.com/pytorch/vision
 centos|pytorch|torchvision|release/0.22|59a3e1f9f78cfe44cb989877cc6f4ea77c8a75ca|https://github.com/pytorch/vision
 ubuntu|pytorch|torchtext|release/0.18.0|9bed85d7a7ae13cf8c28598a88d8e461fe1afcb4|https://github.com/pytorch/text


### PR DESCRIPTION
Commit Messages:
- Update README.md - Added Release Notes 
- Update version to 1.7.0 
- add code to read BUILD_VERSION env variable, so that it is used instead of version.txt when creating a wheel 

PRs:
- https://github.com/ROCm/apex/pull/286
- https://github.com/ROCm/apex/pull/285
- https://github.com/ROCm/apex/pull/281
