### PR TITLE
[rocm7.1_internal_testing] update related_commit

### DIFF
--- a/related_commits
+++ b/related_commits
@@ -1,5 +1,5 @@
-ubuntu|pytorch|apex|master|2190fbaeb88384ed792373adbb83c182af117ca0|https://github.com/ROCm/apex
-centos|pytorch|apex|master|2190fbaeb88384ed792373adbb83c182af117ca0|https://github.com/ROCm/apex
+ubuntu|pytorch|apex|master|267d3973d0774ada55eaf1092a82c0d2a9bba78d|https://github.com/ROCm/apex
+centos|pytorch|apex|master|267d3973d0774ada55eaf1092a82c0d2a9bba78d|https://github.com/ROCm/apex
 ubuntu|pytorch|torchvision|main|e3b5d3a8bf5e8636462fd8bce9897bccc690b2a0|https://github.com/pytorch/vision
 centos|pytorch|torchvision|main|e3b5d3a8bf5e8636462fd8bce9897bccc690b2a0|https://github.com/pytorch/vision
 ubuntu|pytorch|torchdata|main|92950795e0790eb74df995daf40b658e85fd2c9f|https://github.com/pytorch/data


### PR DESCRIPTION
Commit Messages:
- Update README.md 
- Update version to 1.10.0
- add code to read BUILD_VERSION env variable, so that it is used instead of version.txt when creating a wheel 

PRs:
- https://github.com/ROCm/apex/pull/289
- https://github.com/ROCm/apex/pull/282
- https://github.com/ROCm/apex/pull/278
