### PR TITLE
[NO CP][ROCm][inductor][release/2.9] Fix tanh for FP64

### DIFF
--- a/test/inductor/test_op_dtype_prop.py
+++ b/test/inductor/test_op_dtype_prop.py
@@ -205,6 +205,9 @@ class TestCase(InductorTestCase):
         triton_op_name_overrides = {
             "round": "nearbyint",
         }
+        # ROCm uses fast_tahnf for everything input types that are not float64
+        if torch.version.hip and input_dtype != torch.float64:
+            triton_op_name_overrides["tanh"] = "fast_tanhf"
         override = triton_op_name_overrides.get(op_name)
         triton_op_name = override if override is not None else torch_op_name
 

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1315,7 +1315,12 @@ class TritonOverrides(OpOverrides):
     @staticmethod
     @maybe_upcast_float32()
     def tanh(x):
-        if torch.version.hip and get_triton_version() > (3, 2):
+        dtype = V.kernel.cse.varname_map.get(x).dtype
+        if (
+            torch.version.hip
+            and get_triton_version() > (3, 4)
+            and dtype != torch.float64
+        ):
             # On ROCm, use fast_tanhf depending on Triton version
             # Requires ROCm fork of Triton 3.3, 3.4, 3.5 or upstream Triton 3.6+
             return f"libdevice.fast_tanhf({x})"

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1315,7 +1315,11 @@ class TritonOverrides(OpOverrides):
     @staticmethod
     @maybe_upcast_float32()
     def tanh(x):
-        dtype = V.kernel.cse.varname_map.get(x).dtype
+        cse_var = V.kernel.cse.varname_map.get(x)
+        if cse_var and hasattr(cse_var, "dtype"):
+            dtype = cse_var.dtype
+        else:
+            dtype = None
         if (
             torch.version.hip
             and get_triton_version() > (3, 4)

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1322,7 +1322,7 @@ class TritonOverrides(OpOverrides):
             dtype = None
         if (
             torch.version.hip
-            and get_triton_version() > (3, 4)
+            and get_triton_version() > (3, 2)
             and dtype != torch.float64
         ):
             # On ROCm, use fast_tanhf depending on Triton version


### PR DESCRIPTION
fast_tanhf does not support float64 and gives a compiler error. fallback to tanh for float64.

Will fix SWDEV-557937 once it is backported to release_2.8.

Related to:
https://github.com/pytorch/pytorch/pull/162052

