### PR TITLE
[UP CP][release/2.8][ROCm][inductor] Codegen support for fast_tanhf (#162052)

### DIFF
--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1232,7 +1232,18 @@ class TritonOverrides(OpOverrides):
     @staticmethod
     @maybe_upcast_float32()
     def tanh(x):
-        if torch.version.hip and get_triton_version() > (3, 2):
+        cse_var = V.kernel.cse.varname_map.get(x)
+        if cse_var and hasattr(cse_var, "dtype"):
+            dtype = cse_var.dtype
+        else:
+            dtype = None
+        if (
+            config.use_fast_math
+            and torch.version.hip
+            and get_triton_version() > (3, 2)
+            and dtype != torch.float64
+            and dtype is not None
+        ):
             # On ROCm, use fast_tanhf depending on Triton version
             # Requires ROCm fork of Triton 3.3, 3.4, 3.5 or upstream Triton 3.6+
             return f"libdevice.fast_tanhf({x})"


### PR DESCRIPTION
Improve tanh performance on ROCm when the data type is float32 or lower precision. For float64, retain the current implementation.

Requires commits that will be present in Triton 3.6.

Pull Request resolved: https://github.com/pytorch/pytorch/pull/162052 Approved by: https://github.com/jeffdaily,
https://github.com/naromero77amd, https://github.com/eellison, https://github.com/mlazos, https://github.com/v0i0, https://github.com/shunting314

(cherry picked from commit 9b885b079bd27ae18bba7ceb94d08a9aff0ca9ec)

Other notes:
- Similar to upstream PyTorch except we backported fast_tanhf back to Triton 3.3.
- Resolves [SWDEV-569928](https://ontrack-internal.amd.com/browse/SWDEV-569928)
- Resolves inductor failures here [SWDEV-557937](https://ontrack-internal.amd.com/browse/SWDEV-557937)


(cherry picked from commit c82113e081facfcdea6e096a003cac4ece33ad4c)

