### PR TITLE
[release/2.9] Make grouped GEMM CK opt‑in via env variable ROCM_ALLOW_GROUP_GEMM_CK and default to fallback path

### DIFF
--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -270,6 +270,9 @@ bool Context::userEnabledOverrideableSDP() const {
 
 static constexpr const auto cublas_config_var_name = "CUBLAS_WORKSPACE_CONFIG";
 static constexpr const std::array<const char*, 2> cublas_deterministic_configs = {":4096:8", ":16:8"};
+#ifdef USE_ROCM
+static constexpr const auto rocm_allow_group_gemm_ck = "ROCM_ALLOW_GROUP_GEMM_CK";
+#endif
 
 bool Context::checkCuBLASConfigDeterministic() {
   // If using CUDA 10.2 or greater, need to make sure CuBLAS workspace config
@@ -344,6 +347,13 @@ void Context::setAllowTF32CuBLAS(bool b) {
   float32_matmul_precision = b ? at::Float32MatmulPrecision::HIGH : at::Float32MatmulPrecision::HIGHEST;
   setFloat32Precision("cuda", "matmul", b ? "tf32" : "ieee");
 }
+
+#ifdef USE_ROCM
+bool Context::rocmAllowGroupGemmCk() const {
+    const auto allow_group_gemm_ck = c10::utils::check_env(rocm_allow_group_gemm_ck) == true;
+    return allow_group_gemm_ck;
+}
+#endif
 
 Float32MatmulPrecision Context::float32MatmulPrecision() const {
   bool invalid = float32Precision("cuda", "matmul") == "tf32" &&

--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -373,6 +373,7 @@ class TORCH_API Context {
   void setAllowBF16ReductionCuBLAS(bool);
   bool allowFP16AccumulationCuBLAS() const;
   void setAllowFP16AccumulationCuBLAS(bool);
+  bool rocmAllowGroupGemmCk() const;
 
   // Matmuls can use a so-called "persistent" kernel which launches one CUDA
   // block for each SM on the GPU, and each block then iterates over multiple

--- a/aten/src/ATen/native/cuda/Blas.cpp
+++ b/aten/src/ATen/native/cuda/Blas.cpp
@@ -1791,36 +1791,33 @@ std::optional<c10::ScalarType> out_dtype) {
   );
 #ifndef USE_ROCM
   bool use_fast_path = _scaled_mm_allowed_device(/*sm90_only*/true, /*sm100_only*/true) && a_b_and_out_are_bf16;
-#else
-  // _scaled_mm_allowed_device is used here within _grouped_mm_cuda which seems incorrect since scale is not used.
-  // the _grouped_mm_fallback should be safe for any ROCm GPU since it's just calling typical mm/bmm
-  // On ROCm fast path routes to _grouped_mm_fallback and slow path to group_gemm_ck.
-  // ROCM_ALLOW_GROUP_GEMM_CK env variable enables group_gemm_ck path.
-  bool use_fast_path = true;
-#if defined(USE_ROCM_CK_GEMM)
-  if (at::globalContext().rocmAllowGroupGemmCk() && at::detail::getCUDAHooks().isGPUArch({"gfx942", "gfx950"})) {
-    use_fast_path = false;
-  }
-#endif //USE_ROCM_CK_GEMM
-#endif
   const auto out_dtype_ = _resolve_grouped_mm_out_dtype(mat_a, mat_b, out_dtype);
   Tensor out = create_grouped_gemm_output_tensor(mat_a, mat_b, offs, out_dtype_);
   if (use_fast_path) {
     // fast path, no d2h sync needed
-#ifndef USE_ROCM
     at::cuda::detail::bf16bf16_grouped_mm(mat_a, mat_b, offs, bias, out);
-#else
-    _grouped_mm_fallback(mat_a, mat_b, offs, bias, out_dtype, out);
-#endif
   } else {
-#ifndef USE_ROCM
     _grouped_mm_fallback(mat_a, mat_b, offs, bias, out_dtype, out);
-#else
-#if defined(USE_ROCM_CK_GEMM)
-    at::hip::detail::group_gemm_ck(mat_a, mat_b, offs, bias, out);
-#endif
-#endif
   }
+#else
+  // On ROCm fast path routes to group_gemm_ck and slow path to _grouped_mm_fallback.
+  // Keep use_fast_path as false till ck kernel perf is optimal.
+  // To enable CK path, use env variable ROCM_ALLOW_GROUP_GEMM_CK=1.
+  bool use_fast_path = false;
+  // ifdef USE_ROCM_CK_GEMM is required since ROCm systems w/o CK should not call ck path.
+#if defined(USE_ROCM_CK_GEMM)
+  if (at::globalContext().rocmAllowGroupGemmCk() && at::detail::getCUDAHooks().isGPUArch({"gfx942", "gfx950"})) {
+    use_fast_path = true;
+  }
+#endif //USE_ROCM_CK_GEMM
+  const auto out_dtype_ = _resolve_grouped_mm_out_dtype(mat_a, mat_b, out_dtype);
+  Tensor out = create_grouped_gemm_output_tensor(mat_a, mat_b, offs, out_dtype_);
+  if (use_fast_path) {
+    at::hip::detail::group_gemm_ck(mat_a, mat_b, offs, bias, out);
+  } else {
+    _grouped_mm_fallback(mat_a, mat_b, offs, bias, out_dtype, out);
+  }
+#endif //ifndef USE_ROCM
   return out;
 }
 


### PR DESCRIPTION
On ROCm fast path routes to group_gemm_ck and slow path to _grouped_mm_fallback.
By default, fast path = False route is activated since CK path is not performant yet. 
To activate CK path, use ROCM_ALLOW_GROUP_GEMM_CK=1 env variable.
