### PR TITLE
[release/2.8] fix-test_preferred_blas_library_settings

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -636,7 +636,7 @@ print(t.is_pinned())
                 gcn_arch = str(
                     torch.cuda.get_device_properties(0).gcnArchName.split(":", 1)[0]
                 )
-                if gcn_arch in ["gfx90a", "gfx942", "gfx950"]:
+                if gcn_arch in ["gfx90a", "gfx942", "gfx950", "gfx1100", "gfx1101", "gfx1102", "gfx1150", "gfx1151", "gfx1200", "gfx1201"]:
                     self.assertTrue(default == torch._C._BlasBackend.Cublaslt)
                 else:
                     self.assertTrue(default == torch._C._BlasBackend.Cublas)


### PR DESCRIPTION
Starting from https://github.com/ROCm/pytorch/pull/2741 hipBLASLt is default BLAS backend for Navi3X, Navi4X, Strix Point and Strix Halo
