### PR TITLE
[release/2.9/ Reverting prefered hipBLASLt backend for RDNA 3 and RDNA 3.5 (Strix Point/Halo)

### DIFF
--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -468,10 +468,7 @@ at::BlasBackend Context::blasPreferredBackend() {
       static const std::vector<std::string> archs = {
           "gfx90a", "gfx942",
 #if ROCM_VERSION >= 60300
-          "gfx1100", "gfx1101", "gfx1102", "gfx1200", "gfx1201",
-#endif
-#if ROCM_VERSION >= 60402
-          "gfx1150", "gfx1151",
+          "gfx1200", "gfx1201",
 #endif
 #if ROCM_VERSION >= 60500
           "gfx950"


### PR DESCRIPTION
Reverting prefered hipBLASLt backend for RDNA 3 and RDNA 3.5 (Strix Point/Halo) due to several internal tickets opened for perf regression compared to torch builds before merging https://github.com/ROCm/pytorch/pull/2742
