### PR TITLE
[release/2.8/ Reverting prefered hipBLASLt backend for RDNA 3 and RDNA 3.5 (Strix Point/Halo)

### DIFF
--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -336,10 +336,7 @@ at::BlasBackend Context::blasPreferredBackend() {
       static const std::vector<std::string> archs = {
           "gfx90a", "gfx942",
 #if ROCM_VERSION >= 60400
-          "gfx1100", "gfx1101", "gfx1102", "gfx1200", "gfx1201",
-#endif
-#if ROCM_VERSION >= 60402
-          "gfx1150", "gfx1151",
+          "gfx1200", "gfx1201",
 #endif
 #if ROCM_VERSION >= 60500
           "gfx950"

--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -341,9 +341,6 @@ at::BlasBackend Context::blasPreferredBackend() {
 #if ROCM_VERSION >= 60402
           "gfx1150", "gfx1151",
 #endif
-#if ROCM_VERSION >= 60402
-          "gfx1150", "gfx1151",
-#endif
 #if ROCM_VERSION >= 60500
           "gfx950"
 #endif
@@ -369,9 +366,6 @@ at::BlasBackend Context::blasPreferredBackend() {
           "gfx90a", "gfx942",
 #if ROCM_VERSION >= 60300
           "gfx1100", "gfx1101", "gfx1102", "gfx1200", "gfx1201",
-#endif
-#if ROCM_VERSION >= 60402
-          "gfx1150", "gfx1151",
 #endif
 #if ROCM_VERSION >= 60402
           "gfx1150", "gfx1151",

--- a/aten/src/ATen/native/cuda/Blas.cpp
+++ b/aten/src/ATen/native/cuda/Blas.cpp
@@ -275,9 +275,6 @@ static bool isSupportedHipLtROCmArch(int index) {
 #if ROCM_VERSION >= 60402
         "gfx1150", "gfx1151",
 #endif
-#if ROCM_VERSION >= 60402
-        "gfx1150", "gfx1151",
-#endif
 #if ROCM_VERSION >= 60500
         "gfx950"
 #endif


### PR DESCRIPTION
Reverting prefered hipBLASLt backend for RDNA 3 and RDNA 3.5 (Strix Point/Halo) due to several internal tickets opened for perf regression compared to torch builds before merging https://github.com/ROCm/pytorch/pull/2741
