### PR TITLE
[release/2.9] [Upstream cherry-pick] Add partitioned scatter approach with optimizations

### DIFF
--- a/test/inductor/test_metrics.py
+++ b/test/inductor/test_metrics.py
@@ -76,6 +76,7 @@ class TestMetrics(TestCase):
         )
 
     @config.patch("fx_graph_remote_cache", False)
+    @config.patch("partitioned_scatter_enabled", False)
     def test_atomic_add(self):
         @torch.compile
         def f(lhs, index, rhs):

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -820,6 +820,22 @@ _fuse_ddp_communication_passes: list[Union[Callable[..., None], str]] = [
 _micro_pipeline_tp: bool = False
 
 
+# Enable/disable partitioned scatter optimization for atomic add kernels
+# this will improve kernel performance at cost of memory usage.
+partitioned_scatter_enabled = (
+    os.environ.get("TORCHINDUCTOR_PARTITIONED_SCATTER_ENABLED", "0") == "1"
+)
+
+# Min partitions for scatter optimization
+partitioned_scatter_min_partitions: int = 2
+
+# Max partitions for scatter optimization
+partitioned_scatter_max_partitions: int = 128
+
+# Memory budget fraction for scatter buffers
+partitioned_scatter_memory_budget: float = 0.10
+
+
 class _collective:
     auto_select: bool = False
     one_shot_all_reduce_threshold_bytes: int = 128 * 1024

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -61,6 +61,7 @@ from .ddp_fusion import fuse_ddp_communication
 from .group_batch_fusion import group_batch_fusion_passes, POST_GRAD_FUSIONS
 from .micro_pipeline_tp import micro_pipeline_tp_pass
 from .pre_grad import is_same_dict, save_inductor_dict
+from .reduced_atomic_contention import partitioned_scatter_optimization_pass
 from .reinplace import reinplace_inplaceable_ops
 from .split_cat import POST_GRAD_PATTERNS
 
@@ -140,6 +141,10 @@ def post_grad_passes(gm: torch.fx.GraphModule, is_inference: bool):
             GraphTransformObserver(gm, f"pass_pattern_{i}").apply_graph_pass(
                 patterns.apply
             )
+        if config.partitioned_scatter_enabled:
+            GraphTransformObserver(
+                gm, "partitioned_scatter_optimization"
+            ).apply_graph_pass(partitioned_scatter_optimization_pass)
         for pass_name in config.post_grad_fusion_options:
             # skip all patterns for group batch fusions or quantization patterns
             if pass_name in POST_GRAD_FUSIONS or pass_name in OPTIMUS_EXCLUDE_POST_GRAD:

--- a/torch/_inductor/fx_passes/reduced_atomic_contention.py
+++ b/torch/_inductor/fx_passes/reduced_atomic_contention.py
@@ -1,0 +1,397 @@
+# mypy: allow-untyped-defs
+"""
+Partitioned Scatter Optimization for Reduced Atomic Contention.
+
+This pass transforms high-contention index_put operations by distributing
+writes across multiple partitions, reducing atomic contention.
+"""
+
+import logging
+import math
+from typing import Any, Optional
+
+import torch
+import torch.fx as fx
+from torch._dynamo.utils import counters
+from torch._inductor import config
+from torch._inductor.pattern_matcher import (
+    Arg,
+    CallFunction,
+    Match,
+    PatternMatcherPass,
+    register_graph_pattern,
+)
+
+
+log = logging.getLogger(__name__)
+aten = torch.ops.aten
+prims = torch.ops.prims
+
+
+def _get_min_partitions() -> int:
+    """Get minimum partitions from config."""
+    return getattr(config, "partitioned_scatter_min_partitions", 2)
+
+
+def _get_max_partitions() -> int:
+    """Get maximum partitions from config."""
+    return getattr(config, "partitioned_scatter_max_partitions", 128)
+
+
+def _get_memory_budget_fraction() -> float:
+    """Get memory budget fraction from config."""
+    return getattr(config, "partitioned_scatter_memory_budget", 0.10)
+
+
+partitioned_scatter_patterns = PatternMatcherPass(
+    pass_name="partitioned_scatter_optimization"
+)
+
+
+def partitioned_scatter_optimization_pass(graph: fx.Graph) -> fx.Graph:
+    """
+    Apply partitioned scatter optimization to high-contention index_put operations.
+
+    Reduces atomic contention by distributing writes across multiple buffers.
+    Controlled by: config.partitioned_scatter_enabled
+    """
+    if not getattr(config, "partitioned_scatter_enabled", False):
+        return graph
+
+    num_matches = partitioned_scatter_patterns.apply(graph)
+
+    if num_matches > 0:
+        log.info(
+            "partitioned_scatter_optimization: applied to %d operation(s)",
+            num_matches,
+        )
+        graph.lint()
+
+    return graph
+
+
+def validate_match(match: Match) -> bool:
+    """Check if pattern match should be optimized for scatter."""
+    output_node = match.output_node()
+    if not output_node or not hasattr(output_node, "args") or len(output_node.args) < 4:
+        return False
+
+    # Only apply when accumulating
+    if output_node.args[3] is not True:
+        log.debug("Skipping: accumulate=False")
+        return False
+
+    # Extract metadata
+    input_node = output_node.args[0]
+    indices_arg = output_node.args[1]
+
+    # Validate input_node is an FX Node
+    if not isinstance(input_node, fx.Node):
+        return False
+
+    scatter_dim, index_node = _extract_scatter_dim_and_index(indices_arg)
+    if scatter_dim is None or index_node is None:
+        return False
+
+    # Get tensor shapes and validate
+    input_meta = _get_tensor_meta(input_node)
+    index_meta = _get_tensor_meta(index_node)
+    if not input_meta or not index_meta:
+        return False
+
+    # Skip unsupported cases
+    if isinstance(input_meta["numel"], torch.SymInt) or isinstance(
+        index_meta["numel"], torch.SymInt
+    ):
+        log.debug("Skipping: dynamic shapes not supported")
+        return False
+
+    if input_meta["dtype"] == torch.bool or index_meta["dtype"] == torch.bool:
+        log.debug("Skipping: bool dtype not supported")
+        return False
+
+    if scatter_dim >= len(input_meta["shape"]):
+        log.debug("Skipping: scatter dim %d out of bounds", scatter_dim)
+        return False
+
+    # Calculate optimal partitions and check memory
+    output_size = input_meta["numel"]
+    index_size = index_meta["numel"]
+
+    # Safety check (also done in _estimate_optimal_partitions)
+    if output_size == 0 or index_size == 0:
+        return False
+
+    contention_ratio = index_size / output_size
+
+    # Check minimum index size threshold
+    min_index_size = getattr(config, "partitioned_scatter_min_index_size", 4096)
+    if index_size < min_index_size:
+        log.debug(
+            "Skipping: index size %d below threshold %d", index_size, min_index_size
+        )
+        return False
+
+    # Get optimal partitions and adjust for memory constraints
+    num_partitions = _estimate_optimal_partitions(output_size, index_size)
+    num_partitions = _fit_to_memory_budget(
+        output_size, num_partitions, input_meta["dtype"]
+    )
+
+    # If reduced to < min partitions, optimization not worthwhile
+    if num_partitions < _get_min_partitions():
+        log.debug("Skipping: insufficient memory for minimum partitions")
+        return False
+
+    # Store optimization parameters for replacement
+    match._num_partitions = num_partitions  # type: ignore[attr-defined]
+    match._scatter_dim = scatter_dim  # type: ignore[attr-defined]
+    match._index_node = index_node  # type: ignore[attr-defined]
+
+    log.debug(
+        "Applying optimization: %d partitions, dim=%d, contention=%.2f, "
+        "output_size=%d, index_size=%d",
+        num_partitions,
+        scatter_dim,
+        contention_ratio,
+        output_size,
+        index_size,
+    )
+
+    return True
+
+
+@register_graph_pattern(
+    CallFunction(aten.index_put.default, Arg(), Arg(), Arg(), True),
+    pass_dict=partitioned_scatter_patterns,  # type: ignore[arg-type]
+    extra_check=validate_match,
+)
+@register_graph_pattern(
+    CallFunction(aten.index_put_.default, Arg(), Arg(), Arg(), True),
+    pass_dict=partitioned_scatter_patterns,  # type: ignore[arg-type]
+    extra_check=validate_match,
+)
+def create_replacement(match: Match, input_tensor, indices, values) -> None:
+    """Replace high-contention index_put with partitioned scatter."""
+    # Get optimization parameters (set in validate_match)
+    num_partitions: int = match._num_partitions  # type: ignore[attr-defined]
+    scatter_dim: int = match._scatter_dim  # type: ignore[attr-defined]
+    index_node = match._index_node  # type: ignore[attr-defined]
+
+    def repl(input_tensor, index_node, values):
+        """Partitioned scatter implementation that will be traced."""
+        dim_size = input_tensor.shape[scatter_dim]
+        num_operations = index_node.numel()
+
+        # Flatten if needed
+        if len(index_node.shape) > 1:
+            flat_index = index_node.reshape(num_operations)
+            values_ndim = len(index_node.shape)
+            flat_values = values.reshape(
+                [num_operations] + list(values.shape[values_ndim:])
+            )
+        else:
+            flat_index = index_node
+            flat_values = values
+
+        # Generate operation IDs and assign to partitions
+        operation_ids = torch.ops.prims.iota.default(
+            num_operations,
+            start=0,
+            step=1,
+            dtype=flat_index.dtype,
+            device=flat_index.device,
+            requires_grad=False,
+        )
+        partition_ids = torch.ops.aten.bitwise_and.Scalar(
+            operation_ids, num_partitions - 1
+        )
+
+        # Create expanded buffer
+        expanded_shape = list(input_tensor.shape)
+        expanded_shape[scatter_dim] *= num_partitions
+        expanded_buffer = torch.ops.aten.full.default(
+            expanded_shape,
+            0,
+            dtype=flat_values.dtype,
+            layout=torch.strided,
+            device=flat_values.device,
+            pin_memory=False,
+        )
+
+        # Adjust indices for partitioning
+        partition_offsets = partition_ids * dim_size
+        adjusted_index = flat_index + partition_offsets
+
+        # Reconstruct indices list for scatter
+        if isinstance(indices, (list, tuple)):
+            adjusted_indices = [
+                adjusted_index if i == scatter_dim else idx
+                for i, idx in enumerate(indices)
+            ]
+        else:
+            adjusted_indices = [adjusted_index]
+
+        # Scatter with reduced contention
+        scattered_buffer = torch.ops.aten.index_put.default(
+            expanded_buffer, adjusted_indices, flat_values, True
+        )
+
+        # Reshape for reduction
+        reduce_shape = list(expanded_shape)
+        reduce_shape[scatter_dim] = num_partitions
+        reduce_shape.insert(scatter_dim + 1, dim_size)
+        reshaped = torch.ops.aten.view.default(scattered_buffer, reduce_shape)
+
+        # Sum across partitions (preserve dtype for int types)
+        if flat_values.dtype in [torch.int8, torch.int16, torch.int32, torch.uint8]:
+            reduced = torch.ops.aten.sum.dim_IntList(
+                reshaped, [scatter_dim], dtype=flat_values.dtype
+            )
+        else:
+            reduced = torch.ops.aten.sum.dim_IntList(reshaped, [scatter_dim])
+
+        # Add to original input
+        return input_tensor + reduced
+
+    counters["inductor"]["partitioned_scatter_applied"] += 1
+    # pyrefly: ignore [bad-argument-type]
+    match.replace_by_example(repl, [input_tensor, index_node, values])
+
+
+def _get_max_partitions_for_size(output_size: int) -> int:
+    """
+    Get maximum partitions based on output tensor size.
+
+    Larger tensors use fewer partitions to limit memory overhead.
+    """
+    if output_size >= 100_000_000:  # >= 100M elements
+        return 4
+    elif output_size >= 10_000_000:  # >= 10M elements
+        return 8
+    elif output_size >= 1_000_000:  # >= 1M elements
+        return 16
+    else:  # < 1M elements
+        return _get_max_partitions()
+
+
+def _estimate_optimal_partitions(output_size: int, index_size: int) -> int:
+    """Estimate optimal number of partitions based on contention ratio."""
+    # Safety check for edge cases
+    if output_size == 0 or index_size == 0:
+        return _get_min_partitions()
+
+    contention_ratio = index_size / output_size
+
+    # Size-aware partition limits (larger tensors = fewer partitions to limit memory)
+    max_partitions_for_size = _get_max_partitions_for_size(output_size)
+
+    # Contention-based calculation - square root scaling
+    # Use max to ensure we never go below min_partitions for the base calculation
+    base_partitions = max(_get_min_partitions(), int(math.sqrt(contention_ratio) * 16))
+
+    # Round to power of 2 and apply limits
+    partitions = 2 ** math.ceil(math.log2(base_partitions))
+    return min(partitions, max_partitions_for_size, _get_max_partitions())
+
+
+def _fit_to_memory_budget(
+    output_size: int, num_partitions: int, dtype: torch.dtype
+) -> int:
+    """
+    Reduce partitions to fit memory budget if needed.
+
+    Returns the maximum number of partitions that fit in memory budget.
+    Returns input num_partitions if it fits, or a reduced count, or 0 if
+    even min_partitions doesn't fit.
+    """
+    if not torch.cuda.is_available():
+        return num_partitions
+
+    try:
+        _, total_memory = torch.cuda.mem_get_info()
+        element_bytes = dtype.itemsize if hasattr(dtype, "itemsize") else 4
+        budget = total_memory * _get_memory_budget_fraction()
+
+        # Try reducing partitions (must be power of 2) until we fit
+        current_partitions = num_partitions
+        min_partitions = _get_min_partitions()
+        while current_partitions >= min_partitions:
+            overhead = output_size * element_bytes * (current_partitions - 1)
+
+            if overhead <= budget:
+                # Only format debug string if debug logging is enabled
+                if current_partitions < num_partitions and log.isEnabledFor(
+                    logging.DEBUG
+                ):
+                    log.debug(
+                        "Reduced partitions from %d to %d to fit memory budget "
+                        "(%.2fGB / %.2fGB)",
+                        num_partitions,
+                        current_partitions,
+                        overhead / 1e9,
+                        budget / 1e9,
+                    )
+                return current_partitions
+
+            # Reduce by half (maintain power of 2)
+            current_partitions //= 2
+
+        # If min_partitions doesn't fit in memory, return 0
+        if log.isEnabledFor(logging.DEBUG):
+            overhead = output_size * element_bytes * (min_partitions - 1)
+            log.debug(
+                "Insufficient memory even for %d partitions: %.2fGB > %.2fGB",
+                min_partitions,
+                overhead / 1e9,
+                budget / 1e9,
+            )
+        return 0
+
+    except Exception:
+        log.debug("Memory check failed, proceeding with %s", num_partitions)
+        return num_partitions  # Assume we have enough memory if we can't check
+
+
+def _extract_scatter_dim_and_index(
+    indices_arg: Any,
+) -> tuple[Optional[int], Optional[fx.Node]]:
+    """Extract scatter dimension and index node from indices argument."""
+    # Case 1: Single index → dim=0
+    if not isinstance(indices_arg, (list, tuple)):
+        return 0, indices_arg
+
+    # List with Nones → position of non-None is dim
+    index_node = None
+    scatter_dim = None
+
+    # Case 2 -> Find the first non-None index as the scatter dimension
+    for dim, idx in enumerate(indices_arg):
+        if idx is not None:
+            if index_node is not None:
+                # Multiple indices not supported
+                return None, None
+            index_node = idx
+            scatter_dim = dim
+
+    return scatter_dim, index_node
+
+
+def _get_tensor_meta(node: fx.Node) -> Optional[dict[str, Any]]:
+    """Extract tensor metadata from FX node."""
+    if not hasattr(node, "meta") or "val" not in node.meta:
+        return None
+
+    val = node.meta["val"]
+    if not isinstance(val, (torch.Tensor, type(val))) or not hasattr(val, "shape"):
+        return None
+
+    return {
+        "shape": tuple(val.shape),
+        "dtype": val.dtype,
+        "device": val.device,
+        "numel": val.numel(),
+    }
+
+
+__all__ = ["partitioned_scatter_optimization_pass"]


### PR DESCRIPTION
From https://github.com/pytorch/pytorch/pull/168073

It has been observed that in the case of heavy contended atomics poor performance is being achieved.

To solve this problem while minimizing kernel overhead this PR proposes an fx pass which will replace the index_put operation with an alternative scatter approach.

Algorithm:
1. Enumerate scatter operations: operation_id = [0, 1, 2, ..., N-1]
2. Assign to partitions: partition_id = operation_id % num_partitions
3. Create expanded buffers along scatter_dim: size = num_partitions × dim_size
4. Adjust indices: adjusted_idx = original_idx + (partition_id × dim_size)
5. Perform partitioned scatter with reduced contention
6. Reduce across partitions: sum(partitions, dim=scatter_dim)

This will reduce atomic contention at the cost of memory usage. In order to combat this we have built heuristics around the total number of partitions for the expanded buffer, as well as setting a cap on how large these expanded tensors can be (currently 10% of GPU memory)

Note the heuristic cannot be perfect as we do not know the true indices data at compile time, in real world models the indices will have duplicates and not be uniformly distributed which increases atomic contention, currently this cannot be modelled and we have to estimate contention based on input and output buffer sizes.

Benchmark code: https://gist.github.com/jataylo/dd3a6353ad2859efd65fa87b28aa3ebd
This code executes 3 index_add ops to 3 seperate buffers. 
N = 1000000
D = 100
n = 501

values = float32 [N,D]
indices = int64 [N]
output = float32 [n, D]

For each run we modify the range of randint to simulate various levels of atomic contention

Gathered two sets of results, one with partitioned_scatter_enabled=True, the other partitioned_scatter_enabled=False

**MI300**
uniform_range | no_compile_ms | compile_ms   (partitioned_scatter_enabled=False) | compile_ms   (partitioned_scatter_enabled=True) | speedup
-- | -- | -- | -- | --
0-0 | 85.52 | 28.50 | 3.55 | 8.03
0-1 | 46.99 | 15.66 | 2.47 | 6.33
0-3 | 25.16 | 8.31 | 2.20 | 3.78
0-7 | 12.92 | 4.32 | 1.63 | 2.66
0-15 | 6.66 | 4.24 | 1.60 | 2.66
0-31 | 3.43 | 3.19 | 1.33 | 2.40
0-63 | 1.79 | 1.62 | 1.32 | 1.23
0-127 | 1.76 | 1.59 | 1.24 | 1.28
0-255 | 1.73 | 1.32 | 1.24 | 1.07
0-500 | 1.61 | 1.27 | 1.23 | 1.04

**H100**
uniform_range | no_compile_ms | compile_ms     (partitioned_scatter_enabled=False) | compile_ms     (partitioned_scatter_enabled=True)
-- | -- | -- | --
0-0 | 19.842156 | 5.504691 | 0.756135
0-1 | 19.516249 | 5.526914 | 0.779779
0-3 | 10.450396 | 3.079321 | 0.702327
0-7 | 5.417728 | 1.906823 | 0.683553
0-15 | 3.545023 | 1.570733 | 0.655154
0-31 | 2.631531 | 1.223358 | 0.641384
0-63 | 2.629384 | 0.832651 | 0.63534
0-127 | 2.629735 | 0.726054 | 0.768287
0-255 | 2.62846 | 0.625181 | 1.317291
0-500 | 2.629526 | 0.548981 | 1.724292

We can see this could potentially benefit H100 on worst-case examples but would degrade perf in the best case, the atomic add cost on MI300 is heavier meaning this is more beneficial.

On MI300 we can see a mixed bag of e2e model improvements 
https://hud.pytorch.org/benchmark/v3/dashboard/compiler_inductor?renderGroupId=main&time.start=2025-11-05T00%3A00%3A00.000Z&time.end=2025-12-04T02%3A00%3A00.000Z&filters.repo=pytorch%2Fpytorch&filters.benchmarkName=compiler&filters.mode=training&filters.dtype=amp&filters.deviceName=rocm+%28mi300x%29&filters.device=rocm&filters.suite=all&filters.compiler=default&lcommit.commit=38c42c575d342a7ea6f4a555bf845071e03b5f35&lcommit.workflow_id=19635538449&lcommit.date=2025-11-24T14%3A00%3A00Z&lcommit.branch=refs%2Ftags%2Fciflow%2Finductor-perf-test-nightly-rocm-mi300%2F168073&rcommit.commit=fedb7f15d177a259bf25c94e888137e0a9a69a81&rcommit.workflow_id=19856622912&rcommit.date=2025-12-02T12%3A00%3A00Z&rcommit.branch=refs%2Ftags%2Fciflow%2Finductor-perf-test-nightly-rocm-mi300%2F168073&lbranch=refs%2Ftags%2Fciflow%2Finductor-perf-test-nightly-rocm-mi300%2F168073&rbranch=refs%2Ftags%2Fciflow%2Finductor-perf-test-nightly-rocm-mi300%2F168073&maxSampling=110

Due to mixed-bag of results we will initially enable this as non default feature but testing passed CI with this enabled here 
https://hud.pytorch.org/pytorch/pytorch/pull/168073?sha=fedb7f15d177a259bf25c94e888137e0a9a69a81

Note there are improvements to make after this lands:

1. Add dynamic shape support, needs to be conservative here to not explode memory usage.
2. Update IR and codegen directly to avoid iota op and needing to update indices via torch ops, we can likely do this in store codegen itself.
3. Develop new implementations for memory constrained environments

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @dllehr-amd @chenyang78