### PR TITLE
[release/2.8] Fix unexpected failure in test_prepare_softmax_nrow_2048_dim_0 when SM/CU count is <= 32

### DIFF
--- a/test/inductor/test_online_softmax.py
+++ b/test/inductor/test_online_softmax.py
@@ -7,6 +7,7 @@ import torch
 import torch._inductor.config as inductor_config
 import torch.nn.functional as F
 from torch._dynamo.utils import rmse, same
+from torch._inductor.runtime.hints import DeviceProperties
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import run_and_get_code
 from torch.testing._internal.common_utils import (
@@ -132,14 +133,26 @@ class TestOnlineSoftmax(TestCase):
     @parametrize("nrow", [2, 2048])
     @parametrize("dim", [-1, 0, 1])
     def test_prepare_softmax(self, dim, nrow):
-        x = torch.randn(nrow, 2048, dtype=torch.bfloat16, device=GPU_TYPE)
+        ncol = 2048
+        x = torch.randn(nrow, ncol, dtype=torch.bfloat16, device=GPU_TYPE)
         act, (code,) = run_and_get_code(torch.compile(_prepare_softmax), x, dim)
         ref = _prepare_softmax(x, dim)
         self.assertTrue(same(ref, act, tol=1e-2))
 
         if nrow == 2048 and dim == 0:
-            # split reduction is triggered. We have multiple kernels
-            self.assertTrue(code.count("def triton") >= 2)
+            # split reduction may be triggered depending on the device's SM/CU count.
+            # The heuristic in num_splits() in ir.py returns split=1 (no split) when:
+            #   numel_hint >= num_sm * 2 * 32
+            # When dim=0, numel_hint (output size) = ncol
+            # split is expected only when num_sm > 32
+            props = DeviceProperties.create(torch.device(GPU_TYPE))
+            num_sm = props.multi_processor_count
+            split_expected = ncol < num_sm * 2 * 32
+            if split_expected:
+                # split reduction is triggered. We have multiple kernels
+                self.assertTrue(code.count("def triton") >= 2)
+            else:
+                self.assertTrue(code.count("def triton") == 1)
         else:
             if nrow == 2 and dim == 0:
                 # persistent reduction triggered


### PR DESCRIPTION

### Description
The test `test_prepare_softmax_nrow_2048_dim_0` was failing on GPUs with lower SM/CU counts. The test assumed that split reduction would always be triggered for a (2048, 2048) tensor reduced along dim=0, expecting at least 2 triton kernels to be generated.
However, the split reduction heuristic `num_splits()` in `ir.py` returns split=1 (no split) when:
`numel_hint >= num_sm * 2 * 32`
For GPUs with num_sm <= 32 (like AMD Radeon R9700 with 32 CUs), this evaluates to 2048 >= 2048, which prevents split reduction from being triggered.
### Fix:
Made the test device-aware by checking the GPU's SM count at runtime and only asserting split reduction when it's actually expected based on the heuristics:
```
props = DeviceProperties.create(torch.device(GPU_TYPE))
num_sm = props.multi_processor_count
split_expected = ncol < num_sm * 2 * 32
if split_expected:
    # split reduction is triggered. We have multiple kernels
    self.assertTrue(code.count("def triton") >= 2)
else:
    self.assertTrue(code.count("def triton") == 1)
```

This ensures the test passes on all GPU configurations while still validating split reduction behavior on hardware where it's expected to occur.
### Test Plan:
Verified all `test_prepare_softmax*` tests pass on AMD Radeon R9700 (32 CUs)
