### PR TITLE
[release/2.7] fix test_preferred_blas_library_settings for RDNA4

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -598,11 +598,11 @@ class TestCuda(TestCase):
                 # CUDA logic is easy, it's always cublas
                 self.assertTrue(default == torch._C._BlasBackend.Cublas)
             else:
-                # ROCm logic is less so, it's cublaslt for some Instinct, cublas for all else
+                # ROCm logic is less so, it's cublaslt for some Instinct and RDNA4, cublas for all else
                 gcn_arch = str(
                     torch.cuda.get_device_properties(0).gcnArchName.split(":", 1)[0]
                 )
-                if gcn_arch in ["gfx90a", "gfx942", "gfx950"]:
+                if gcn_arch in ["gfx90a", "gfx942", "gfx950", "gfx1200", "gfx1201"]:
                     self.assertTrue(default == torch._C._BlasBackend.Cublaslt)
                 else:
                     self.assertTrue(default == torch._C._BlasBackend.Cublas)


### PR DESCRIPTION
Starting from https://github.com/pytorch/pytorch/pull/153610 hipBLASLt is preferred BLAS backend for RDNA4
