### PR TITLE
[release/2.10] Fix triton package name and repo for ROCm builds

### DIFF
--- a/.github/scripts/build_triton_wheel.py
+++ b/.github/scripts/build_triton_wheel.py
@@ -101,7 +101,8 @@ def build_triton(
 
         triton_repo = "https://github.com/openai/triton"
         if device == "rocm":
-            triton_pkg_name = "triton-rocm"
+            triton_repo = "https://github.com/ROCm/triton"
+            triton_pkg_name = "triton"
         elif device == "xpu":
             triton_pkg_name = "triton-xpu"
             triton_repo = "https://github.com/intel/intel-xpu-backend-for-triton"


### PR DESCRIPTION
This PR fixes the triton wheel build for ROCm by:

1. Changing the triton package name from `triton-rocm` to `triton` to match pytorch's dependency
2. Using `https://github.com/ROCm/triton` as the repo for ROCm device builds

This aligns with the changes made in release/2.9 and older branches where pytorch's triton dependency was changed from `pytorch-triton-rocm` to `triton`.
