### PR TITLE
[release/2.8] Temporarily skip test_comprehensive_nn_functional_pad_reflect_cuda_bfloat16 on ROCm

### DIFF
--- a/test/test_decomp.py
+++ b/test/test_decomp.py
@@ -40,6 +40,7 @@ from torch.testing._internal.common_utils import (
     TEST_WITH_SLOW,
     TestCase,
     unMarkDynamoStrictTest,
+    TEST_WITH_ROCM,
 )
 from torch.utils import _pytree as pytree
 from torch.utils._python_dispatch import TorchDispatchMode
@@ -596,6 +597,8 @@ class TestDecomp(TestCase):
     @suppress_warnings
     @ops(op_db)
     def test_comprehensive(self, device, dtype, op):
+        if (TEST_WITH_ROCM and op.name == "nn.functional.pad" and op.variant_test_name == "reflect" and "cuda" in device and dtype == torch.bfloat16):
+            self.skipTest("pad reflect bf16 is temporarily skipped on ROCm")
         self.do_cross_ref(device, dtype, op, run_all=True)
 
     def test_uniform(self, device):


### PR DESCRIPTION
Temporarily skip test/test_decomp.py::TestDecompCUDA::test_comprehensive_nn_functional_pad_reflect_cuda_bfloat16 on ROCm.

This test is currently disabled on upstream in the issue, https://github.com/pytorch/pytorch/issues/131050

Cherry-picked from https://github.com/rraminen/pytorch/commit/ace39eab887fd5793de0cfc5b27639658c468a94