### PR TITLE
[Inductor] Fix AttributeError in sympy_subs by wrapping Python primitives in sympy types

### DIFF
--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1080,8 +1080,14 @@ def sympy_subs(expr: sympy.Expr, replacements: dict[sympy.Expr, Any]) -> sympy.E
                 integer=replaced.is_integer,  # type: ignore[attr-defined]
                 nonnegative=replaced.is_nonnegative,  # type: ignore[attr-defined]
             )
-        else:
-            return replacement
+
+        if isinstance(replacement, bool):
+            return sympy.true if replacement else sympy.false
+        if isinstance(replacement, int):
+            return sympy.Integer(replacement)
+        if isinstance(replacement, float):
+            return sympy.Float(replacement)
+        return replacement
 
     # xreplace is faster than subs, but is way more picky
     return sympy.sympify(expr).xreplace(


### PR DESCRIPTION
Fixes `AttributeError: 'int' object has no attribute 'is_Add'` in tests after commit 1f352c0.

**Root cause**: `sympy_subs()` could return plain Python `int` values, which later code expects to be sympy types with `.is_Add` attribute.

**Fix**: Wrap Python primitives in `sympy_subs()`:
- `int` → `sympy.Integer`
- `float` → `sympy.Float`
- `bool` → `sympy.true/false`

Fixes tests:
- `test_aoti_debug_printer_sym_inputs_cuda`
- `test_triton_kernel_grid_cuda`

Cherry-pick to `release/2.9`.