### PR TITLE
[release/2.8] Revert to prev sccache by ROCm

### DIFF
--- a/.ci/docker/common/install_cache.sh
+++ b/.ci/docker/common/install_cache.sh
@@ -36,7 +36,12 @@ sed -e 's|PATH="\(.*\)"|PATH="/opt/cache/bin:\1"|g' -i /etc/environment
 export PATH="/opt/cache/bin:$PATH"
 
 # Setup compiler cache
-install_ubuntu
+if [ -n "$ROCM_VERSION" ]; then
+  curl --retry 3 http://repo.radeon.com/misc/.sccache_amd/sccache -o /opt/cache/bin/sccache
+else
+  install_ubuntu
+fi
+
 chmod a+x /opt/cache/bin/sccache
 
 function write_sccache_stub() {


### PR DESCRIPTION
Signed-off-by: Jagadish Krishnamoorthy <jagadish.krishnamoorthy@amd.com>

(cherry picked from commit 1ad5bb95d796283d5f56ac1edd16f1731d24a49d) (cherry picked from commit 519160d466782f5a62365be051fcb3ef90fa0b00)

Fixes build failures such as: https://ml-ci-internal.amd.com/job/pytorch/job/pytorch-ci-pipeline/job/release%252F2.8/69/

```
[2025-03-29T04:55:33.812Z] sccache: encountered fatal error
[2025-03-29T04:55:33.812Z] sccache: error: Failed to parse included file path
[2025-03-29T04:55:33.812Z] sccache: caused by: Failed to parse included file path
```