### PR TITLE
[release/2.9] Fix flatbuffers include order to resolve build issue with latest ROCm

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1786,8 +1786,8 @@ if(USE_ROCM)
     endif()
   endif()
   # Since PyTorch files contain HIP headers, this is also needed to capture the includes.
-  # ROCM_INCLUDE_DIRS is defined in LoadHIP.cmake
-  target_include_directories(torch_hip PRIVATE ${Caffe2_HIP_INCLUDE} ${ROCM_INCLUDE_DIRS})
+  # ROCM_INCLUDE_DIRS is defined in LoadHIP.cmake and added as SYSTEM includes in cmake/Dependencies.cmake
+  target_include_directories(torch_hip PRIVATE ${Caffe2_HIP_INCLUDE})
   target_include_directories(torch_hip INTERFACE $<INSTALL_INTERFACE:include>)
 endif()
 

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1094,6 +1094,12 @@ if(USE_ROCM)
   else()
     caffe2_update_option(USE_ROCM OFF)
   endif()
+
+  # Add ROCm includes as SYSTEM includes (lower priority than regular includes).
+  # This ensures third_party vendored headers take precedence over ROCm headers.
+  if(USE_ROCM AND ROCM_INCLUDE_DIRS)
+    include_directories(SYSTEM ${ROCM_INCLUDE_DIRS})
+  endif()
 endif()
 
 # ---[ NCCL


### PR DESCRIPTION
When building PyTorch with latest ROCm, the ROCm flatbuffers headers (version 25.9.23) in /opt/rocm/include are found before PyTorch's vendored flatbuffers headers (version 24.12.23). This causes a static_assert failure in mobile_bytecode_generated.h which expects FLATBUFFERS_VERSION_MAJOR == 24.

Fixes build error:
  mobile_bytecode_generated.h:11:41: error: static assertion failed: Non-compatible flatbuffers version include static_assert(FLATBUFFERS_VERSION_MAJOR == 24 &&
