### PR TITLE
[release/2.10] Reverting prefered hipBLASLt backend for RDNA 3 and RDNA 3.5 (Strix Point/Halo)

### DIFF
--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -443,10 +443,7 @@ at::BlasBackend Context::blasPreferredBackend() {
       static const std::vector<std::string> archs = {
           "gfx90a", "gfx942",
 #if ROCM_VERSION >= 60300
-          "gfx1100", "gfx1101", "gfx1102", "gfx1200", "gfx1201",
-#endif
-#if ROCM_VERSION >= 60402
-          "gfx1150", "gfx1151",
+          "gfx1200", "gfx1201",
 #endif
 #if ROCM_VERSION >= 60500
           "gfx950"


### PR DESCRIPTION
Same change as #2876
