### PR TITLE
[ROCm][release/2.8] Cherry-pick TunableOp validator UT fix from release/2.7

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -5220,7 +5220,7 @@ class TestLinalg(TestCase):
             # Check for rocBLAS and hipBLASLt
             self.assertTrue("ROCBLAS_VERSION" in validators)
             # format: [major].[minor].[patch].[tweak].[commit id]
-            self.assertTrue(re.match(r'^\d+.\d+.\d+.\d+.[a-z0-9]+$', validators["ROCBLAS_VERSION"]))
+            self.assertTrue(re.match(r'^\d+[a-z0-9.]+$', validators["ROCBLAS_VERSION"]))
             self.assertTrue("HIPBLASLT_VERSION" in validators)
             self.assertTrue(re.match(r'^\d+-[a-z0-9]+$', validators["HIPBLASLT_VERSION"]))
 


### PR DESCRIPTION
No code changes - clean cherry-pick from 2.7 branch. (https://github.com/ROCm/pytorch/pull/2576)

Fixes TunableOp validator UT regex that fails with different ROCm versions.

Fixes #SWDEV-534062
