### PR TITLE
[release/2.9] Optimize Flex-Attention occupancy for head_dim=128

### DIFF
--- a/torch/_inductor/template_heuristics/triton.py
+++ b/torch/_inductor/template_heuristics/triton.py
@@ -1104,7 +1104,7 @@ class ROCmConfigHeuristic(BaseConfigHeuristic):
             (torch.float32, 128): ROCmFlexConfig(128, 32, 1, 4),
             (torch.float32, 256): ROCmFlexConfig(64, 16, 1, 4),
             (torch.bfloat16, 64): ROCmFlexConfig(128, 64, 1, 8),
-            (torch.bfloat16, 128): ROCmFlexConfig(128, 64, 1, 8),
+            (torch.bfloat16, 128): ROCmFlexConfig(128, 64, 1, 4),
             (torch.bfloat16, 256): ROCmFlexConfig(32, 64, 1, 8),
             (torch.float16, 64): ROCmFlexConfig(128, 64, 1, 8),
             (torch.float16, 128): ROCmFlexConfig(128, 64, 1, 8),
@@ -1280,7 +1280,7 @@ class ROCmConfigHeuristic(BaseConfigHeuristic):
             if head_dim == 64:
                 default_config = ROCmFlexConfig(64, 64, 1, 4)
             elif head_dim == 128:
-                default_config = ROCmFlexConfig(64, 128, 1, 8)
+                default_config = ROCmFlexConfig(64, 128, 1, 4)
             else:
                 default_config = ROCmFlexConfig(64, 64, 1, 4)
         else:


### PR DESCRIPTION
### **Summary**
This PR adjusts `n_warps` from 8 to 4 for `head_dim=128` configurations on ROCm for gfx942. 

### **Performance Impact (320 Valid Cases)**
The following table shows the Geometric Mean (Geomean) speedups compared to the current `n_warps=8` baseline. 

| Attention Pattern | Test Count | Fwd Speedup | Bwd Speedup |
| :--- | :---: | :---: | :---: |
| **alibi** | 32 | 1.22x | **1.61x** |
| **causal** | 32 | 1.22x | 1.65x |
| **noop** | 32 | 1.26x | 1.55x |
| **prefix_lm** | 112 | 1.22x | 1.71x |
| **sliding_window** | 112 | 1.12x | 1.58x |
| **Overall (Geomean)** | **320** | **1.21x** | **1.62x** |

**Benchmark Coverage:**
* **Batch Size**: [1, 2, 4, 8]
* **Heads**: [16, 32]
* **Sequence Length**: [512, 1024, 2048, 4096]
* **Masking**: `window_size` and `prefix_lm` ∈ [128, 256, 512, 1024, 2048].
* *Note: Redundant cases (e.g., window_size > seq_len) were excluded.*