### PR TITLE
[rocm7.2_internal_testing] Enable variable-length attention unit tests (#170969) and Bump AOTriton to 0.11.2b (#174105)

### DIFF
--- a/aten/src/ATen/native/transformers/cuda/attention.cu
+++ b/aten/src/ATen/native/transformers/cuda/attention.cu
@@ -1169,10 +1169,20 @@ _flash_attention_forward(
   std::optional<Tensor> alibi_slopes = _alibi_slopes;
   const float softcap = 0.0;
 
-#ifndef USE_ROCM  // ROCM backend accepts std::optional for window_size_left/right directly.
-  const int non_null_window_left = window_size_left.value_or(-1);
-  const int non_null_window_right = window_size_right.value_or(-1);
+#ifdef USE_ROCM  // ROCM backend accepts std::optional for window_size_left/right directly.
+#ifdef DISABLE_AOTRITON  // CK backend, Passing window_size as it is
+  const auto window_left = window_size_left;
+  const auto window_right = window_size_right;
+#else  // AOTriton implements "generalized" SWA and negative size means negative shifting.
+  // aotriton_adapter::parse_window_size tries to match the behavior of CUTLASS backend
+  using sdp::aotriton_adapter::parse_window_size;
+  const auto [window_left, window_right] = parse_window_size(window_size_left,
+                                                             window_size_right);
 #endif
+#else  // USE_ROCM
+  const int window_left = window_size_left.value_or(-1);
+  const int window_right = window_size_right.value_or(-1);
+#endif  // USE_ROCM
 
   // We are going to have two paths:
   // 1. The standard MHA path for dense tensors
@@ -1209,13 +1219,8 @@ _flash_attention_forward(
             softmax_scale,
             false /*zero_tensors*/,
             is_causal,
-#ifdef USE_ROCM
-            window_size_left,
-            window_size_right,
-#else
-            non_null_window_left,
-            non_null_window_right,
-#endif
+            window_left,
+            window_right,
             softcap,
             return_debug_mask,
             std::nullopt /*gen_*/);
@@ -1238,13 +1243,8 @@ _flash_attention_forward(
             dropout_p,
             softmax_scale,
             is_causal,
-#ifdef USE_ROCM
-            window_size_left,
-            window_size_right,
-#else
-            non_null_window_left,
-            non_null_window_right,
-#endif
+            window_left,
+            window_right,
             softcap,
             return_debug_mask, /*return_softmax (this is used for testing)*/
             std::nullopt);

--- a/aten/src/ATen/native/transformers/hip/aotriton_adapter.h
+++ b/aten/src/ATen/native/transformers/hip/aotriton_adapter.h
@@ -8,6 +8,8 @@
 #include <aotriton/util.h>
 #include <aotriton/config.h>
 #include <ATen/native/transformers/hip/aotriton_versions.h>
+#include <tuple>
+#include <optional>
 
 ////////////////////////////////////////////////////////////////////////////////
 // Common macros copied from cuda/mem_eff_attention/gemm_kernel_utils.h
@@ -167,6 +169,23 @@ auto mklazy_fp32zeros(LazyTensorContext* cookie)
 {
   return mklazy_common<kRank, true>(cookie);
 }
+
+inline auto parse_window_size(std::optional<int64_t> window_size_left,
+                              std::optional<int64_t> window_size_right)
+{
+  const int fa_left = window_size_left.value_or(-1);
+  const int fa_right = window_size_right.value_or(-1);
+  auto get_window_value = [](const int window) -> std::optional<int64_t> {
+    if (window < 0) {
+      return std::nullopt;
+    }
+    return window;
+  };
+  const auto window_left = get_window_value(fa_left);
+  const auto window_right = get_window_value(fa_right);
+  return std::make_tuple(window_left, window_right);
+}
+
 
 #endif  // >= 0.11
 

--- a/aten/src/ATen/native/transformers/hip/flash_attn/aot/mha_all_aot.hip
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/aot/mha_all_aot.hip
@@ -451,7 +451,7 @@ mha_varlen_fwd_aot(const at::Tensor &q,  // total_q x num_heads x head_size, tot
 #endif
 
   // SWA in AOTriton Kernels is treated as "Generalized Causal masks"
-  is_causal = is_causal || needs_swa;
+  is_causal = is_causal || uses_swa;
 
   auto [seed_t, offset_t, philox_state, use_philox_state] =
     prepare_philox_arguments(p_dropout, batch_size * num_heads * 32);
@@ -693,7 +693,8 @@ mha_bwd_aot(const at::Tensor &dout,  // batch_size x seqlen_q x num_heads, x hea
     params.philox_seed_ptr =  mk_aoscalartensor(philox_seed);
     params.philox_offset1 = mk_aoscalartensor(philox_offset);
     params.philox_offset2 = 0;
-    params.causal_type = is_causal ? CausalType::WindowedAttention : CausalType::None;
+    // SWA in AOTriton Kernels is treated as "Generalized Causal masks"
+    params.causal_type = is_causal || uses_swa ? CausalType::WindowedAttention : CausalType::None;
     params.window_left = window_left;
     params.window_right = window_right;
     params.varlen_type = VarlenType::None;
@@ -946,7 +947,8 @@ mha_varlen_bwd_aot(const at::Tensor &dout,  // total_q x num_heads, x head_size
       params.philox_seed_ptr =  mk_aoscalartensor(philox_seed);
       params.philox_offset1 = mk_aoscalartensor(philox_offset);
       params.philox_offset2 = 0;
-      params.causal_type = is_causal ? CausalType::WindowedAttention : CausalType::None;
+      // SWA in AOTriton Kernels is treated as "Generalized Causal masks"
+      params.causal_type = is_causal || uses_swa ? CausalType::WindowedAttention : CausalType::None;
       params.varlen_type = VarlenType::CompactVarlen;
       params.window_left = window_left;
       params.window_right = window_right;

--- a/cmake/External/aotriton.cmake
+++ b/cmake/External/aotriton.cmake
@@ -9,7 +9,7 @@ if(NOT __AOTRITON_INCLUDED)
   # Replaces .ci/docker/aotriton_version.txt
   # Note packages information may have versions skipped (due to no ABI breaks)
   # But they must be listed from lower version to higher version
-  set(__AOTRITON_VER "0.11.1b")
+  set(__AOTRITON_VER "0.11.2b")
   set(__AOTRITON_MANYLINUX_LIST
       "manylinux_2_28"  # rocm6.2
       "manylinux_2_28"  # rocm6.3
@@ -26,14 +26,14 @@ if(NOT __AOTRITON_INCLUDED)
       "rocm7.1"
       "rocm7.2"
       )
-  set(__AOTRITON_CI_COMMIT "d34f3b6c824df77d5c5788a2e7555b2398be4b79")
+  set(__AOTRITON_CI_COMMIT "dd1b68b604b5258ee7a9f7b66ad95e7a82c18065")
   set(__AOTRITON_SHA256_LIST
-      "a3a7e391758b3580c42a1623d11606308ae52115b2a3eba5d1f440586a078391"  # rocm6.2
-      "662fc06239c8091f57e13793a4fac0e783241c9f5e86b1701bbb2ba308ef4279"  # rocm6.3
-      "367062cba487492e58b38bb54720fb239e65b8717d0e11084f8059f2c5748af0"  # rocm6.4
-      "deb8046e9ef976c2739fd0563b50239e12dc002d7d4f97c1c4a1874acb65abc4"  # rocm7.0
-      "c1613ed9e9eecc7359f04a1624bb528e54f5e6369e682dd446eaa936d9452358"  # rocm7.1
-      "56ca31254c1655fa4d5168e2db3159781c2442d5f6b01882155e93859b85cf16"  # rocm7.2
+      "d784314849ba1911181dfc80cd845064ff6f0cdad10e2f4c53eb84a8b89245b9"  # rocm6.2
+      "f4b14dc111c334e967b28a1cf9ed4c63264c634dbdccbb5849aa9490022992f7"  # rocm6.3
+      "6b51d8479c85b902334e4f5518f404a8f5d563fd8d4732cb8b621ed4b45c2876"  # rocm6.4
+      "5501a0a3b300890001b6625f2a3539a7bad60f386f0a061ebe7d4ed5ca0fafb9"  # rocm7.0
+      "fee36beb3ea484ce18155bbafe026c577fd6705e4469e59405b260bd74b8cc10"  # rocm7.1
+      "cd8abf27bbb63cec45c94135e9b28745966074263a6b0555e5878ae1cb6a2349"  # rocm7.2
       )
   set(__AOTRITON_IMAGE_LIST
       "amd-gfx90a"
@@ -46,7 +46,7 @@ if(NOT __AOTRITON_INCLUDED)
      "fe9f04b66bf52ac27cd025e1d89cfd04974dd3fb3ae076192f783641a4d80fdf" # amd-gfx90a
      "0a7bcee19d3bb6d548732248c3234f7b92736c2ab7a7aae65294b87a7fd64c06" # amd-gfx942
      "c1ba3bfe84217fd67df3dd1f8b67c80a7f7b33d0ad4d74b41d6567036e032ace" # amd-gfx950
-     "6632040c405d833be6ff72029249c776838baf5f03a3c13ba4e8d37a87b7a740" # amd-gfx11xx
+     "839299637fccb13fbe3e7823d57d1b2dcd0e0bed78abbcb7005ea5f4fd82b928" # amd-gfx11xx
      "0a4ff324bffdac0c2fde87a8a7f70563d3c84a80ad4e8f31345f2b40a1384e95" # amd-gfx120x
      )
   set(__AOTRITON_BASE_URL "https://github.com/ROCm/aotriton/releases/download/")  # @lint-ignore


### PR DESCRIPTION
Cherry-pick upstream PR
* https://github.com/pytorch/pytorch/pull/170969
* https://github.com/pytorch/pytorch/pull/174105

We need both to enable all tests in test/test_varlen_attention.py