### PR TITLE
[release/2.10] Pin requirements for release/2.10

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -15,13 +15,13 @@ build==1.3.0
 #Pinned versions: 1.3.0
 #test that import:
 
-click
+click==8.3.1
 #Description: Command Line Interface Creation Kit
-#Pinned versions:
+#Pinned versions: 8.3.1
 #test that import:
 
 coremltools==5.0b5 ; python_version < "3.12"
-coremltools==8.3 ; python_version == "3.12"
+coremltools==8.3.0 ; python_version == "3.12"
 #Description: Apple framework for ML integration
 #Pinned versions: 5.0b5
 #test that import:
@@ -68,7 +68,7 @@ lark==0.12.0
 #Pinned versions: 0.12.0
 #test that import:
 
-librosa>=0.6.2 ; python_version < "3.11" and platform_machine != "s390x"
+librosa==0.10.2 ; python_version < "3.11" and platform_machine != "s390x"
 librosa==0.10.2 ; python_version == "3.12" and platform_machine != "s390x"
 #Description: A python package for music and audio analysis
 #Pinned versions: >=0.6.2
@@ -148,7 +148,7 @@ pandas==2.2.3
 #Pinned versions: 1.9.0
 #test that import:
 
-opt-einsum==3.3
+opt-einsum==3.3.0
 #Description: Python library to optimize tensor contraction order, used in einsum
 #Pinned versions: 3.3
 #test that import: test_linalg.py
@@ -177,9 +177,9 @@ protobuf==5.29.5
 #Pinned versions: 5.29.5
 #test that import: test_tensorboard.py, test/onnx/*
 
-psutil
+psutil==7.2.2
 #Description: information on running processes and system utilization
-#Pinned versions:
+#Pinned versions: 7.2.2
 #test that import: test_profiler.py, test_openmp.py, test_dataloader.py
 
 pytest==7.3.2
@@ -197,9 +197,9 @@ pytest-flakefinder==1.1.0
 #Pinned versions: 1.1.0
 #test that import:
 
-pytest-rerunfailures>=10.3
+pytest-rerunfailures==14.0
 #Description: plugin for rerunning failure tests in pytest
-#Pinned versions:
+#Pinned versions: 14.0
 #test that import:
 
 pytest-subtests==0.13.1
@@ -280,9 +280,9 @@ typing-extensions==4.15.0 ; python_version >= "3.14"
 #Pinned versions:
 #test that import:
 
-unittest-xml-reporting<=3.2.0,>=2.0.0
+unittest-xml-reporting==3.2.0
 #Description: saves unit test results to xml
-#Pinned versions:
+#Pinned versions: 3.2.0
 #test that import:
 
 #lintrunner is supported on aarch64-linux only from 0.12.4 version
@@ -291,7 +291,7 @@ lintrunner==0.12.7
 #Pinned versions: 0.12.7
 #test that import:
 
-redis>=4.0.0
+redis==7.1.1
 #Description: redis database
 #test that import: anything that tests OSS caching/mocking (inductor/test_codecache.py, inductor/test_max_autotune.py)
 
@@ -371,10 +371,10 @@ pwlf==2.2.1
 
 # To build PyTorch itself
 pyyaml==6.0.3
-pyzstd
+pyzstd==0.16.2
 setuptools==78.1.1
 packaging==23.1
-six
+six==1.16.0
 
 scons==4.5.2 ; platform_machine == "aarch64"
 
@@ -397,7 +397,7 @@ tlparse==0.4.0
 filelock==3.18.0
 #Description: required for inductor testing
 
-cuda-bindings>=12.0,<13.0 ; platform_machine != "s390x" and platform_system != "Darwin"
+cuda-bindings==12.9.5 ; platform_machine != "s390x" and platform_system != "Darwin"
 #Description: required for testing CUDAGraph::raw_cuda_graph(). See https://nvidia.github.io/cuda-python/cuda-bindings/latest/support.html for how this version was chosen. Note "Any fix in the latest bindings would be backported to the prior major version" means that only the newest version of cuda-bindings will get fixes. Depending on the latest version of 12.x is okay because all 12.y versions will be supported via "CUDA minor version compatibility". Pytorch builds against 13.z versions of cuda toolkit work with 12.x versions of cuda-bindings as well because newer drivers work with old toolkits.
 #test that import: test_cuda.py
 
@@ -407,7 +407,7 @@ pyre-extensions==0.0.32
 tabulate==0.9.0
 #Description: These package are needed to build FBGEMM and torchrec on PyTorch CI
 
-tqdm>=4.66.0
+tqdm==4.67.3
 #Description: progress bar library required for dynamo benchmarks
 #test that import: benchmarks/dynamo/*
 

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,5 +1,5 @@
 # Build System requirements
-setuptools==78.1.1
+setuptools==79.0.1
 cmake==3.31.6
 ninja==1.11.1.4
 numpy==2.0.2 ; python_version == "3.9"

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,11 +1,13 @@
 # Build System requirements
-setuptools>=70.1.0
-cmake>=3.27
-ninja
-numpy
-packaging
-pyyaml
-requests
-six  # dependency chain: NNPACK -> PeachPy -> six
-typing-extensions>=4.10.0
+setuptools==78.1.1
+cmake==3.31.6
+ninja==1.11.1.4
+numpy==2.0.2 ; python_version == "3.9"
+numpy==2.1.2 ; python_version > "3.9"
+packaging==23.1
+pyyaml==6.0.3
+requests==2.32.5
+six==1.16.0  # dependency chain: NNPACK -> PeachPy -> six
+typing-extensions==4.12.2 ; python_version < "3.14"
+typing-extensions==4.15.0 ; python_version >= "3.14"
 pip  # not technically needed, but this makes setup.py invocation work

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,13 +1,11 @@
 # Build System requirements
 setuptools==79.0.1
-cmake==3.31.6
+cmake==4.0.0
 ninja==1.11.1.4
-numpy==2.0.2 ; python_version == "3.9"
-numpy==2.1.2 ; python_version > "3.9"
-packaging==23.1
+numpy==2.1.2
+packaging==25.0
 pyyaml==6.0.3
 requests==2.32.5
-six==1.16.0  # dependency chain: NNPACK -> PeachPy -> six
-typing-extensions==4.12.2 ; python_version < "3.14"
-typing-extensions==4.15.0 ; python_version >= "3.14"
+six==1.17.0  # dependency chain: NNPACK -> PeachPy -> six
+typing_extensions==4.15.0
 pip  # not technically needed, but this makes setup.py invocation work

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,20 +4,22 @@
 --requirement requirements-build.txt
 
 # Install / Development extra requirements
-build[uv]  # for building sdist and wheel
-expecttest>=0.3.0
-filelock
-fsspec>=0.8.5
-hypothesis
-jinja2
-lintrunner ; platform_machine != "s390x" and platform_machine != "riscv64"
-networkx>=2.5.1
-ninja
+build[uv]==1.3.0  # for building sdist and wheel
+expecttest==0.3.0
+filelock==3.18.0
+fsspec==2026.2.0
+hypothesis==6.56.4
+jinja2==3.1.6
+lintrunner==0.12.7 ; platform_machine != "s390x" and platform_machine != "riscv64"
+networkx==2.8.8
+ninja==1.11.1.4
 numpy==2.0.2 ; python_version == "3.9"
 numpy==2.1.2 ; python_version > "3.9"
-optree>=0.13.0
-psutil
-spin
-sympy>=1.13.3
-typing-extensions>=4.15.0
-wheel
+optree==0.13.0 ; python_version < "3.14"
+optree==0.17.0 ; python_version >= "3.14"
+psutil==7.2.2
+spin==0.17
+sympy==1.13.3
+typing-extensions==4.12.2 ; python_version < "3.14"
+typing-extensions==4.15.0 ; python_version >= "3.14"
+wheel==0.45.1


### PR DESCRIPTION
Pulled a plain ubuntu image and pip installed the requirements-ci.txt, requirements-build.txt, and requirements.txt. Then did a pip freeze and pinned the requirements. 