### PR TITLE
[release/2.10] fix typing extensions and requirements-ci.txt overwriting requirements.txt

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -269,8 +269,7 @@ scipy==1.16.2 ; python_version >= "3.14"
 #test that import:
 
 # needed by torchgen utils
-typing-extensions==4.12.2 ; python_version < "3.14"
-typing-extensions==4.15.0 ; python_version >= "3.14"
+typing-extensions==4.15.0 
 #Description: type hints for python
 #Pinned versions:
 #test that import:

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -372,9 +372,9 @@ pwlf==2.2.1
 # To build PyTorch itself
 pyyaml==6.0.3
 pyzstd==0.16.2
-setuptools==78.1.1
-packaging==23.1
-six==1.16.0
+setuptools==79.0.1
+packaging==25.0
+six==1.17.0
 
 scons==4.5.2 ; platform_machine == "aarch64"
 
@@ -388,7 +388,7 @@ dataclasses_json==0.6.7
 #Pinned versions: 0.6.7
 #test that import:
 
-cmake==3.31.6
+cmake==4.0.0
 #Description: required for building
 
 tlparse==0.4.0

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -7,5 +7,7 @@ packaging==25.0
 pyyaml==6.0.3
 requests==2.32.5
 six==1.17.0  # dependency chain: NNPACK -> PeachPy -> six
-typing_extensions==4.15.0
+typing_extensions==4.12.2 ; python_version < "3.14"
+typing_extensions==4.12.2 ; python_version < "3.14"
+typing_extensions==4.15.0 ; python_version >= "3.14" ; python_version >= "3.14"
 pip  # not technically needed, but this makes setup.py invocation work

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -8,6 +8,5 @@ pyyaml==6.0.3
 requests==2.32.5
 six==1.17.0  # dependency chain: NNPACK -> PeachPy -> six
 typing_extensions==4.12.2 ; python_version < "3.14"
-typing_extensions==4.12.2 ; python_version < "3.14"
 typing_extensions==4.15.0 ; python_version >= "3.14" ; python_version >= "3.14"
 pip  # not technically needed, but this makes setup.py invocation work

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -7,6 +7,5 @@ packaging==25.0
 pyyaml==6.0.3
 requests==2.32.5
 six==1.17.0  # dependency chain: NNPACK -> PeachPy -> six
-typing_extensions==4.12.2 ; python_version < "3.14"
-typing_extensions==4.15.0 ; python_version >= "3.14" ; python_version >= "3.14"
+typing_extensions==4.15.0
 pip  # not technically needed, but this makes setup.py invocation work

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,5 @@ optree==0.17.0 ; python_version >= "3.14"
 psutil==7.2.2
 spin==0.17
 sympy==1.13.3
-typing-extensions==4.12.2 ; python_version < "3.14"
-typing-extensions==4.15.0 ; python_version >= "3.14"
+typing-extensions==4.15.0
 wheel==0.45.1


### PR DESCRIPTION
```
Collecting typing_extensions==4.15.0 (from -r /pytorch/requirements-build.txt (line 10))
  Using cached typing_extensions-4.15.0-py3-none-any.whl.metadata (3.3 kB)

ERROR: Cannot install typing-extensions==4.12.2 and typing_extensions==4.15.0 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested typing_extensions==4.15.0
    The user requested typing-extensions==4.12.2

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip to attempt to solve the dependency conflict

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
```
Typing extensions is in no less than three places in pytorch, requirements.txt, requirements-ci.txt, and requirements-build.txt. 
Tested locally:
```
Successfully installed Deprecated-1.3.1 PyGithub-2.3.0 absl-py-2.4.0 aiohappyeyeballs-2.6.1 aiohttp-3.13.2 aiosignal-1.4.0 audioread-3.1.0 boto3-1.35.42 botocore-1.35.99 cattrs-25.3.0 cffi-2.0.0 colorama-0.4.6 coremltools-8.3.0 cuda-bindings-12.9.5 cuda-pathfinder-1.3.4 dataclasses_json-0.6.7 decorator-5.2.1 dill-0.3.7 execnet-2.1.2 fbscribelogger-0.1.7 flatbuffers-24.12.23 frozenlist-1.8.0 future-1.0.0 ghstack-0.8.0 grpcio-1.78.0 imageio-2.37.2 iniconfig-2.3.0 jmespath-1.1.0 joblib-1.5.3 junitparser-2.1.1 lark-0.12.0 lazy-loader-0.4 librosa-0.10.2 llvmlite-0.44.0 lxml-5.3.0 markdown-3.10.2 marshmallow-3.26.2 ml_dtypes-0.5.4 msgpack-1.1.2 multidict-6.7.1 mypy-1.16.0 mypy_extensions-1.1.0 numba-0.61.2 onnx-1.19.1 onnx-ir-0.1.12 onnxscript-0.5.4 opt-einsum-3.3.0 pandas-2.2.3 parameterized-0.8.1 pathspec-1.0.4 pillow-11.0.0 platformdirs-4.6.0 pluggy-1.6.0 ply-3.11 pooch-1.9.0 propcache-0.4.1 protobuf-5.29.5 pulp-2.9.0 pwlf-2.2.1 pyDOE-0.9.3 pyaml-26.2.1 pycparser-3.0 pygments-2.15.0 pyjwt-2.11.0 pynacl-1.6.2 pyre-extensions-0.0.32 pytest-7.3.2 pytest-cpp-2.3.0 pytest-flakefinder-1.1.0 pytest-rerunfailures-14.0 pytest-subtests-0.13.1 pytest-xdist-3.3.1 python-dateutil-2.9.0.post0 pytz-2025.2 pywavelets-1.7.0 pyzstd-0.16.2 redis-7.1.1 s3transfer-0.10.4 scikit-build-0.18.1 scikit-image-0.22.0 scikit-learn-1.8.0 scipy-1.14.1 setuptools-git-versioning-2.1.0 soundfile-0.13.1 soxr-1.0.0 tabulate-0.9.0 tensorboard-2.18.0 tensorboard-data-server-0.7.2 threadpoolctl-3.6.0 thriftpy2-0.5.3 tifffile-2026.1.28 tlparse-0.4.0 tqdm-4.67.3 typing-inspect-0.9.0 tzdata-2025.3 unittest-xml-reporting-3.2.0 werkzeug-3.1.5 wrapt-2.1.1 xdoctest-1.3.0 yarl-1.22.0 z3-solver-4.15.1.0
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable.It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.

[notice] A new release of pip is available: 24.3.1 -> 26.0.1
[notice] To update, run: python3.12 -m pip install --upgrade pip
root@rocm-framework-47:/pytorch#

```