### PR TITLE
[rocm7.2_internal_testing] Pin onnx-ir version to 0.1.15

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -350,6 +350,11 @@ onnxscript==0.5.4
 #Pinned versions:
 #test that import:
 
+onnx-ir==0.1.15
+#Description: In-memory IR for ONNX, dependency of onnxscript. Pinned to avoid breaking changes in newer versions.
+#Pinned versions: 0.1.15
+#test that import:
+
 parameterized==0.8.1
 #Description: Parameterizes unittests, both the tests themselves and the entire testing class
 #Pinned versions:


### PR DESCRIPTION
## Motivation
Pinned to avoid breaking changes in newer versions.