### PR TITLE
 [release/2.9] add torch.version.rocm, distinct from torch.version.hip 

### DIFF
--- a/cmake/public/LoadHIP.cmake
+++ b/cmake/public/LoadHIP.cmake
@@ -83,8 +83,18 @@ find_package_and_print_version(HIP 1.0 MODULE)
 if(HIP_FOUND)
   set(PYTORCH_FOUND_HIP TRUE)
   find_package_and_print_version(hip REQUIRED CONFIG)
+  if(HIP_VERSION)
+    # Check if HIP_VERSION contains a dash (e.g., "7.1.25421-32f9fa6ca5")
+    # and strip everything after it to get clean numeric version
+    string(FIND "${HIP_VERSION}" "-" DASH_POS)
+    if(NOT DASH_POS EQUAL -1)
+      string(SUBSTRING "${HIP_VERSION}" 0 ${DASH_POS} HIP_VERSION_CLEAN)
+      set(HIP_VERSION "${HIP_VERSION_CLEAN}")
+  endif()
+  message("HIP version: ${HIP_VERSION}")
+endif()
 
-  # The rocm-core package was only introduced in ROCm 6.4, so we make it optional.
+# The rocm-core package was only introduced in ROCm 6.4, so we make it optional.
   find_package(rocm-core CONFIG)
 
   # Some old consumer HIP SDKs do not distribute rocm_version.h, so we allow

--- a/tools/generate_torch_version.py
+++ b/tools/generate_torch_version.py
@@ -76,6 +76,7 @@ if __name__ == "__main__":
     )
     parser.add_argument("--cuda-version", "--cuda_version", type=str)
     parser.add_argument("--hip-version", "--hip_version", type=str)
+    parser.add_argument("--rocm-version", "--rocm_version", type=str)
     parser.add_argument("--xpu-version", "--xpu_version", type=str)
 
     args = parser.parse_args()
@@ -83,6 +84,7 @@ if __name__ == "__main__":
     assert args.is_debug is not None
     args.cuda_version = None if args.cuda_version == "" else args.cuda_version
     args.hip_version = None if args.hip_version == "" else args.hip_version
+    args.rocm_version = None if args.rocm_version == "" else args.rocm_version
     args.xpu_version = None if args.xpu_version == "" else args.xpu_version
 
     pytorch_root = Path(__file__).parent.parent
@@ -98,7 +100,7 @@ if __name__ == "__main__":
     with open(version_path, "w") as f:
         f.write("from typing import Optional\n\n")
         f.write(
-            "__all__ = ['__version__', 'debug', 'cuda', 'git_version', 'hip', 'xpu']\n"
+            "__all__ = ['__version__', 'debug', 'cuda', 'git_version', 'hip', 'rocm', 'xpu']\n"
         )
         f.write(f"__version__ = '{version}'\n")
         # NB: This is not 100% accurate, because you could have built the
@@ -108,4 +110,5 @@ if __name__ == "__main__":
         f.write(f"cuda: Optional[str] = {repr(args.cuda_version)}\n")
         f.write(f"git_version = {repr(sha)}\n")
         f.write(f"hip: Optional[str] = {repr(args.hip_version)}\n")
+        f.write(f"rocm: Optional[str] = {repr(args.rocm_version)}\n")
         f.write(f"xpu: Optional[str] = {repr(args.xpu_version)}\n")

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -487,7 +487,8 @@ add_custom_target(
   "${Python_EXECUTABLE}" "${TOOLS_PATH}/generate_torch_version.py"
     --is-debug=${TORCH_VERSION_DEBUG}
     --cuda-version=${CUDA_VERSION}
-    --hip-version=${HIP_VERSION}
+    --hip-version=${HIP_VERSION_CLEAN}
+    --rocm-version=${ROCM_VERSION_DEV}
     --xpu-version=${SYCL_COMPILER_VERSION}
   BYPRODUCTS ${TORCH_SRC_DIR}/version.py
   COMMENT "Regenerating version file..."

--- a/torch/version.py.tpl
+++ b/torch/version.py.tpl
@@ -4,6 +4,7 @@ cuda = '{{CUDA_VERSION}}'
 # TODO: use workspace status to stamp the correct version
 git_version = ""
 hip = None
+rocm = None
 
 # This is a gross monkey-patch hack that depends on the order of imports
 # in torch/__init__.py


### PR DESCRIPTION
Historically, HIP and ROCm versions were interchangeable, but moving forward these versions are allowed to diverge.  ROCm version represents the full ROCm software stack, while HIP is a component of the ROCm stack.

Issue #166068 was fixed by [switching from using HIP_VERSION to ROCM_VERSION_DEV](https://github.com/pytorch/pytorch/pull/166336).  However, this broke the build of ROCm apex because the hip version from `hipcc --version` no longer matched `torch.version.hip`.  This highlights the need for both versions to be exposed.

Bitsandbytes has also been impacted by the change in behavior of `torch.version.hip`: https://github.com/bitsandbytes-foundation/bitsandbytes/issues/1799#issuecomment-3534269635

The solution is to fix the `torch.version.hip` so that it uses the hipcc header values and removes the trailing hash code. In addition, `torch.version.rocm` variable is created to store the ROCm version.

HIP_VERSION variable is computed in https://github.com/ROCm/hip/blob/develop/cmake/FindHIP.cmake. This runs hipcc –version and extracts the output of HIP version line, e.g.,
```
hipcc --version
HIP version: 7.1.25421-32f9fa6ca5
```

The HIP_VERSION variable may contain a hash code at the end.  This trailing hashcode is removed from the HIP_VERSION variable so that the torch.version.hip can be parsed by packaging version parse method, e.g.,
```
import torch
from packaging import version
print(version.parse(torch.version.hip))
```

Code changes:
- Add rocm variable to torch/version.py.tpl
- Add code to write rocm variable in tools/generate_torch_version.py
- Write rocm version in installation process - torch/CMakeLists.txt

Tested on a preview of ROCm 7.2.  Successfully built pytorch and apex. Tested above parsing torch.version.hip code.

```
>>> import torch
>>> torch.version.hip
'7.1.25421'
>>> torch.version.rocm
'7.2.0'
```

Pull Request resolved: https://github.com/pytorch/pytorch/pull/168097

