### PR TITLE
Atomics on 16 bits: prevent reading 4 bytes for 2-byte locations.

### DIFF
--- a/aten/src/ATen/cuda/Atomic.cuh
+++ b/aten/src/ATen/cuda/Atomic.cuh
@@ -17,10 +17,10 @@ template <>
 struct AtomicFPOp<at::Half> {
   template <typename func_t>
   inline __device__ at::Half operator() (at::Half *address, at::Half val, const func_t& func) {
-    unsigned int * address_as_ui =
-      (unsigned int *) ((char *)address - ((size_t)address & 2));
-    unsigned int old = *address_as_ui;
-    unsigned int assumed;
+    unsigned short * address_as_us =
+      (unsigned short *) ((char *)address - ((size_t)address & 2));
+    unsigned short old = *address_as_us;
+    unsigned short assumed;
 
     at::Half hsum;
     do {
@@ -28,7 +28,7 @@ struct AtomicFPOp<at::Half> {
       hsum.x = (size_t)address & 2 ? (old >> 16) : (old & 0xffff);
       hsum = func(hsum, val);
       old = (size_t)address & 2 ? (old & 0xffff) | (hsum.x << 16) : (old & 0xffff0000) | hsum.x;
-      old = atomicCAS(address_as_ui, assumed, old);
+      old = atomicCAS(address_as_us, assumed, old);
     } while (assumed != old);
     hsum.x = (size_t)address & 2 ? (old >> 16) : (old & 0xffff);
     return hsum;
@@ -39,10 +39,10 @@ template <>
 struct AtomicFPOp<at::BFloat16> {
   template <typename func_t>
   inline __device__ at::BFloat16 operator() (at::BFloat16 *address, at::BFloat16 val, const func_t& func) {
-    unsigned int * address_as_ui =
-      (unsigned int *) ((char *)address - ((size_t)address & 2));
-    unsigned int old = *address_as_ui;
-    unsigned int assumed;
+    unsigned short * address_as_us =
+      (unsigned short *) ((char *)address - ((size_t)address & 2));
+    unsigned short old = *address_as_us;
+    unsigned short assumed;
 
     at::BFloat16 bsum;
     do {
@@ -50,7 +50,7 @@ struct AtomicFPOp<at::BFloat16> {
       bsum.x = (size_t)address & 2 ? (old >> 16) : (old & 0xffff);
       bsum = func(bsum, val);
       old = (size_t)address & 2 ? (old & 0xffff) | (bsum.x << 16) : (old & 0xffff0000) | bsum.x;
-      old = atomicCAS(address_as_ui, assumed, old);
+      old = atomicCAS(address_as_us, assumed, old);
     } while (assumed != old);
     bsum.x = (size_t)address & 2 ? (old >> 16) : (old & 0xffff);
     return bsum.x;

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6307,6 +6307,20 @@ class TestDevicePrecision(TestCase):
 
         self.assertEqual(out_cpu, out_gpu, atol=1e-2, rtol=0)
 
+    @onlyCUDA
+    def test_index_add_half(self, device):
+        inp_tensor = torch.randn(5, 3, device='cpu').half()
+        t = torch.tensor([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype=torch.half, device='cpu')
+        index = torch.tensor([0, 4, 2], device='cpu')
+        out_cpu = inp_tensor.index_add(0, index, t)
+
+        inp_tensor = inp_tensor.to(device=device)
+        t = t.to(device=device)
+        index = index.to(device=device)
+        out_gpu = inp_tensor.index_add(0, index, t)
+
+        self.assertEqual(out_cpu, out_gpu, atol=1e-2, rtol=0)
+
     # FIXME: move to serialization test suite
     def test_device_serialization(self, device):
         x = torch.randn(4, 4, device=device)


### PR DESCRIPTION
This patch was triggered but a failure observed in ROCm GPU asan support. It happens when we attempt an atomic operation on the last element of a tensor and the element address has the correct alignment. Normally, we would use a 4-byte read + atomic cas loop for 4-bytes. However, in this case, we cannot backtrack 2 bytes before the last element because that would mean a mis-aligned atomic, resulting in a gpu memory error. The solution is to read 2 bytes (change unsigned int to short) and then use atomicCAS loop over 2 byte data type of the last element in the tensor.
