### PR TITLE
[release/2.9] Skip test_fake_crossref_backward_amp_nn_functional_bilinear

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -2584,6 +2584,7 @@ fake_backward_xfails = {skip(s) for s in fake_backward_skips} | {
 
 fake_autocast_backward_xfails = {
     skip("nn.functional.binary_cross_entropy"),
+    skip("nn.functional.bilinear"), # skip in ROCm fork, according upstream https://github.com/pytorch/pytorch/issues/159150
     skip("sparse.sampled_addmm"),
     skip("linalg.pinv"),
     skip("linalg.pinv", "hermitian"),


### PR DESCRIPTION
The testcase is skipped according to upstream issue https://github.com/pytorch/pytorch/issues/159150

Fixes #SWDEV-575848