### PR TITLE
Added hipblaslt bias fused kernels into autotune backend for addmm

### DIFF
--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -931,10 +931,15 @@ def tuned_addmm(inp, mat1, mat2, *, alpha=1, beta=1, layout=None):
     m, n, k, layout, mat1, mat2, inp_expanded = mm_args(mat1, mat2, inp, layout=layout)
     static_shape, is_nonzero = _is_static_problem(layout)
     name = "addmm"
-    # Create MMKernelInputs for AddMM at the top
+    # Create MMKernelInputs for AddMM for triton fused kernels
     kernel_inputs = MMKernelInputs(
         [inp_expanded, mat1, mat2], scalars=dict(alpha=alpha, beta=beta)
     )
+    # Create MMKernelInputs for AddMM for Aten kernels
+    kernel_inputs_aten = MMKernelInputs(
+        [inp, mat1, mat2], scalars=dict(alpha=alpha, beta=beta)
+    )
+
     choices: list[ChoiceCaller] = []
 
     # below is for getting an overview logging info of inductor mms
@@ -960,15 +965,9 @@ def tuned_addmm(inp, mat1, mat2, *, alpha=1, beta=1, layout=None):
             aten_layout = FlexibleLayout(
                 device=layout.device, dtype=layout.dtype, size=layout.size
             )
-        # TODO(coconutruben): combine this with the main flow of addmm through
-        # a subgraph or something as inp vs inp_expanded causes some slight numeric
-        # differences
-        kernel_inputs = MMKernelInputs(
-            [inp, mat1, mat2], scalars=dict(alpha=alpha, beta=beta)
-        )
         choices.extend(
             V.choices.get_mm_configs(
-                kernel_inputs,
+                kernel_inputs_aten,
                 aten_layout,
                 [aten_addmm],
                 name,
@@ -979,7 +978,7 @@ def tuned_addmm(inp, mat1, mat2, *, alpha=1, beta=1, layout=None):
     if use_aten_gemm_kernels():
         choices.extend(
             V.choices.get_mm_configs(
-                kernel_inputs,
+                kernel_inputs_aten,
                 aten_layout,
                 [aten_bias_addmm],
                 name,
@@ -987,7 +986,7 @@ def tuned_addmm(inp, mat1, mat2, *, alpha=1, beta=1, layout=None):
         )
         choices.extend(
             V.choices.get_mm_configs(
-                kernel_inputs,
+                kernel_inputs_aten,
                 aten_layout,
                 [aten_addmm],
                 name,


### PR DESCRIPTION
## Motivation

We found that in some GEMM with bias cases, we got poorer performance with torch compile and max autotune than without it. And the root cause is that when we turn on max autotune, inductor cannot call hipblaslt bias fused kernels. And if it doesn't call fused kernel, it will call a triton fused kerenl or a separate Aten solution (a single GEMM kernel + an elementwise kernel). And the separate Aten solution has a worse perf than hipblaslt fused kernels.

## Technical Details

In the current code, inductor will use inp_expanded as the bias argument for addmm lowering kernel inputs. Inp_expanded is the bias argument expanded from 1D to 2D after arg processing. Hipblaslt bias fused kernel cannot support 2D bias input, so inductor cannot call hipblaslt bias fused kernels now.
This PR use original 1D bias argument as the kernel input for aten addmm to enable hipblaslt bias fused kernel in inductor.

## Test Plan

Here is a simple unittest to test perf of Linear with bias, which will lower into addmm in inductor.
[run-test.sh](https://github.com/user-attachments/files/25619263/run-test.sh)
[unittest_linear_mi308x_fp16.py](https://github.com/user-attachments/files/25619264/unittest_linear_mi308x_fp16.py)

## Test Result

In this case, mnk is [4352 ,  1024 ,  1024]
Without the PR, inductor will run two kernels, and the perf is GEMM 81.659us, elementwise 13.619us, the total execution time is 85us.
With the PR, inductor will choose a hipblaslt bias fused kernel, the execution time is 63.504us.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
