### PR TITLE
Add hipdnn convolution support

### DIFF
--- a/aten/src/ATen/native/ConvUtils.h
+++ b/aten/src/ATen/native/ConvUtils.h
@@ -42,6 +42,14 @@ using miopen_depthwise_convolution_backward_fn = std::tuple<at::Tensor,at::Tenso
     const at::Tensor&, const at::Tensor&, const at::Tensor&, at::IntArrayRef, at::IntArrayRef,
     at::IntArrayRef, int64_t, bool, bool, std::array<bool,3>);
 DECLARE_DISPATCH(miopen_depthwise_convolution_backward_fn, miopen_depthwise_convolution_backward_stub)
+using hipdnn_convolution_backward_fn = std::tuple<at::Tensor,at::Tensor,at::Tensor>(*)(
+    const at::Tensor&, const at::Tensor&, const at::Tensor&, at::IntArrayRef, at::IntArrayRef,
+    at::IntArrayRef, int64_t, bool, bool, std::array<bool,3>);
+DECLARE_DISPATCH(hipdnn_convolution_backward_fn, hipdnn_convolution_backward_stub)
+using hipdnn_convolution_transpose_backward_fn = std::tuple<at::Tensor,at::Tensor,at::Tensor>(*)(
+    const at::Tensor&, const at::Tensor&, const at::Tensor&, at::IntArrayRef, at::IntArrayRef,
+    at::IntArrayRef, at::IntArrayRef, int64_t, bool, bool, std::array<bool,3>);
+DECLARE_DISPATCH(hipdnn_convolution_transpose_backward_fn, hipdnn_convolution_transpose_backward_stub)
 using mkldnn_convolution_backward_fn = std::tuple<at::Tensor,at::Tensor,at::Tensor>(*)(
     const at::Tensor&, const at::Tensor&, const at::Tensor&, at::IntArrayRef, at::IntArrayRef,
     at::IntArrayRef, int64_t, std::array<bool,3>);
@@ -117,6 +125,8 @@ enum class ConvBackend {
   Xnnpack2d,
   Mps,
   MpsTranspose,
+  Hipdnn,
+  HipdnnTranspose,
 };
 
 // Overload for selecting the convolution backend from the full set of convolution inputs.
@@ -392,6 +402,35 @@ inline at::MemoryFormat miopen_conv_suggest_memory_format(const at::Tensor& inpu
     (weight_memory_format == at::MemoryFormat::ChannelsLast3d)
   );
   if (can_use_miopen_channels_last_3d) {
+    return at::MemoryFormat::ChannelsLast3d;
+  }
+
+  return at::MemoryFormat::Contiguous;
+}
+
+inline at::MemoryFormat hipdnn_conv_suggest_memory_format(const at::Tensor& input, const at::Tensor& weight) {
+  if (input.scalar_type() == at::kDouble ||
+      weight.scalar_type() == at::kDouble) {
+    return at::MemoryFormat::Contiguous;
+  }
+
+  auto input_memory_format = input.suggest_memory_format();
+  auto weight_memory_format = weight.suggest_memory_format();
+  auto weight_ndim = weight.ndimension();
+
+  bool can_use_channels_last_2d = (weight_ndim == 4) && (
+    (input_memory_format  == at::MemoryFormat::ChannelsLast) ||
+    (weight_memory_format == at::MemoryFormat::ChannelsLast)
+  );
+  if (can_use_channels_last_2d) {
+    return at::MemoryFormat::ChannelsLast;
+  }
+
+  bool can_use_channels_last_3d = (weight_ndim == 5) && (
+    (input_memory_format  == at::MemoryFormat::ChannelsLast3d) ||
+    (weight_memory_format == at::MemoryFormat::ChannelsLast3d)
+  );
+  if (can_use_channels_last_3d) {
     return at::MemoryFormat::ChannelsLast3d;
   }
 

--- a/aten/src/ATen/native/ConvUtils.h
+++ b/aten/src/ATen/native/ConvUtils.h
@@ -46,10 +46,19 @@ using hipdnn_convolution_backward_fn = std::tuple<at::Tensor,at::Tensor,at::Tens
     const at::Tensor&, const at::Tensor&, const at::Tensor&, at::IntArrayRef, at::IntArrayRef,
     at::IntArrayRef, int64_t, bool, bool, std::array<bool,3>);
 DECLARE_DISPATCH(hipdnn_convolution_backward_fn, hipdnn_convolution_backward_stub)
+using hipdnn_convolution_fn = at::Tensor(*)(
+    const at::Tensor&, const at::Tensor&, const std::optional<at::Tensor>&,
+    at::IntArrayRef, at::IntArrayRef, at::IntArrayRef, int64_t, bool, bool);
+DECLARE_DISPATCH(hipdnn_convolution_fn, hipdnn_convolution_stub)
 using hipdnn_convolution_transpose_backward_fn = std::tuple<at::Tensor,at::Tensor,at::Tensor>(*)(
     const at::Tensor&, const at::Tensor&, const at::Tensor&, at::IntArrayRef, at::IntArrayRef,
     at::IntArrayRef, at::IntArrayRef, int64_t, bool, bool, std::array<bool,3>);
 DECLARE_DISPATCH(hipdnn_convolution_transpose_backward_fn, hipdnn_convolution_transpose_backward_stub)
+using hipdnn_convolution_transpose_fn = at::Tensor(*)(
+    const at::Tensor&, const at::Tensor&, const std::optional<at::Tensor>&,
+    at::IntArrayRef, at::IntArrayRef, at::IntArrayRef, at::IntArrayRef, int64_t, bool, bool);
+DECLARE_DISPATCH(hipdnn_convolution_transpose_fn, hipdnn_convolution_transpose_stub)
+
 using mkldnn_convolution_backward_fn = std::tuple<at::Tensor,at::Tensor,at::Tensor>(*)(
     const at::Tensor&, const at::Tensor&, const at::Tensor&, at::IntArrayRef, at::IntArrayRef,
     at::IntArrayRef, int64_t, std::array<bool,3>);

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -501,7 +501,6 @@ struct ConvParams {
     auto dtype = input.scalar_type();
     if (dtype != at::kFloat && dtype != at::kHalf && dtype != at::kBFloat16) return false;
     if (input.dim() < 4 || input.dim() > 5) return false;
-    if (!cudnn_enabled) return false;
     return true;
   }
   bool use_mkldnn(const at::Tensor& input, const at::Tensor& weight) const  {

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -1659,13 +1659,13 @@ at::Tensor _convolution(
     case ConvBackend::Hipdnn:
       check_input_same_type_as_parameters(input, weight, bias);
       output = at::hipdnn_convolution(
-          input.contiguous(backend_memory_format), weight, bias, params.padding, params.stride,
+          input, weight, bias, params.padding, params.stride,
           params.dilation, params.groups, params.benchmark, params.deterministic);
       break;
     case ConvBackend::HipdnnTranspose:
       check_input_same_type_as_parameters(input, weight, bias);
       output = at::hipdnn_convolution_transpose(
-          input.contiguous(backend_memory_format), weight, bias, params.padding, params.output_padding,
+          input, weight, bias, params.padding, params.output_padding,
           params.stride, params.dilation, params.groups, params.benchmark, params.deterministic);
       break;
     case ConvBackend::Miopen:

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -70,6 +70,8 @@
 #include <ATen/ops/empty.h>
 #include <ATen/ops/empty_like.h>
 #include <ATen/ops/empty_native.h>
+#include <ATen/ops/hipdnn_convolution.h>
+#include <ATen/ops/hipdnn_convolution_transpose.h>
 #include <ATen/ops/miopen_convolution.h>
 #include <ATen/ops/miopen_convolution_transpose.h>
 #include <ATen/ops/miopen_depthwise_convolution.h>
@@ -492,6 +494,16 @@ struct ConvParams {
            && !(groups > 1 && is_dilated()) // MIOpen currently does not support dilation with groups of size > 1
            ;
   }
+  bool use_hipdnn(const at::Tensor& input, const at::Tensor& weight) const {
+    if (!at::globalContext().userEnabledHipdnn()) return false;
+    if (!detail::getCUDAHooks().compiledWithHipDNN()) return false;
+    if (!input.is_cuda()) return false;
+    auto dtype = input.scalar_type();
+    if (dtype != at::kFloat && dtype != at::kHalf && dtype != at::kBFloat16) return false;
+    if (input.dim() < 4 || input.dim() > 5) return false;
+    if (!cudnn_enabled) return false;
+    return true;
+  }
   bool use_mkldnn(const at::Tensor& input, const at::Tensor& weight) const  {
 #if AT_MKLDNN_ENABLED()
     if (!at::globalContext().userEnabledMkldnn()) {
@@ -623,6 +635,8 @@ DEFINE_DISPATCH(convolution_depthwise3x3_winograd_stub);
 DEFINE_DISPATCH(miopen_convolution_backward_stub);
 DEFINE_DISPATCH(miopen_convolution_transpose_backward_stub);
 DEFINE_DISPATCH(miopen_depthwise_convolution_backward_stub);
+DEFINE_DISPATCH(hipdnn_convolution_backward_stub);
+DEFINE_DISPATCH(hipdnn_convolution_transpose_backward_stub);
 DEFINE_DISPATCH(mkldnn_convolution_backward_stub);
 DEFINE_DISPATCH(mkldnn_convolution_transpose_stub);
 DEFINE_DISPATCH(mkldnn_convolution_transpose_backward_stub);
@@ -636,6 +650,8 @@ REGISTER_NO_CPU_DISPATCH(cudnn_convolution_transpose_backward_stub)
 REGISTER_NO_CPU_DISPATCH(miopen_convolution_backward_stub)
 REGISTER_NO_CPU_DISPATCH(miopen_convolution_transpose_backward_stub)
 REGISTER_NO_CPU_DISPATCH(miopen_depthwise_convolution_backward_stub)
+REGISTER_NO_CPU_DISPATCH(hipdnn_convolution_backward_stub)
+REGISTER_NO_CPU_DISPATCH(hipdnn_convolution_transpose_backward_stub)
 
 template <typename T>
 static std::ostream& operator<<(std::ostream & out, const ConvParams<T>& params) {
@@ -1275,6 +1291,8 @@ static ConvBackend _select_conv_backend(
   if (params.is_depthwise(input, weight)) {
     if (params.use_cudnn_depthwise(input, weight)) {
       return ConvBackend::Cudnn;
+    } else if (params.use_hipdnn(input, weight)) {
+      return ConvBackend::Hipdnn;
     } else if (params.use_miopen(input, weight, bias_sizes_opt.has_value())) {
       return ConvBackend::MiopenDepthwise;
     } else {
@@ -1291,6 +1309,12 @@ static ConvBackend _select_conv_backend(
       return ConvBackend::CudnnTranspose;
     } else {
       return ConvBackend::Cudnn;
+    }
+  } else if (params.use_hipdnn(input, weight)) {
+    if (params.transposed) {
+      return ConvBackend::HipdnnTranspose;
+    } else {
+      return ConvBackend::Hipdnn;
     }
   } else if (params.use_miopen(input, weight, bias_sizes_opt.has_value())) {
     if (params.transposed) {
@@ -1489,6 +1513,10 @@ static inline at::MemoryFormat determine_backend_memory_format(
         backend_memory_format = miopen_conv_suggest_memory_format(input, weight);
       }
       break;
+    case ConvBackend::Hipdnn:
+    case ConvBackend::HipdnnTranspose:
+      backend_memory_format = hipdnn_conv_suggest_memory_format(input, weight);
+      break;
     case ConvBackend::Mkldnn:
     case ConvBackend::MkldnnTranspose:
       if (mkldnn_conv_use_channels_last(input, weight)) {
@@ -1629,6 +1657,18 @@ at::Tensor _convolution(
       output = output.view(calc_output_size(input, weight, params));
       break;
     }
+    case ConvBackend::Hipdnn:
+      check_input_same_type_as_parameters(input, weight, bias);
+      output = at::hipdnn_convolution(
+          input.contiguous(backend_memory_format), weight, bias, params.padding, params.stride,
+          params.dilation, params.groups, params.benchmark, params.deterministic);
+      break;
+    case ConvBackend::HipdnnTranspose:
+      check_input_same_type_as_parameters(input, weight, bias);
+      output = at::hipdnn_convolution_transpose(
+          input.contiguous(backend_memory_format), weight, bias, params.padding, params.output_padding,
+          params.stride, params.dilation, params.groups, params.benchmark, params.deterministic);
+      break;
     case ConvBackend::Miopen:
       check_input_same_type_as_parameters(input, weight, bias);
       output = at::miopen_convolution(
@@ -2200,6 +2240,22 @@ std::tuple<Tensor, Tensor, Tensor> convolution_backward(
 #else
       TORCH_INTERNAL_ASSERT(false, "Mkldnn backend was selected in PyTorch compiled without mkldnn support");
 #endif
+      break;
+    case ConvBackend::Hipdnn:
+      check_input_same_type_as_parameters(input, weight);
+      std::tie(backend_grad_input, backend_grad_weight, backend_grad_bias) =
+        hipdnn_convolution_backward_stub(
+          input.device().type(),
+          input.contiguous(backend_memory_format), grad_output, weight, params.padding, params.stride,
+          params.dilation, params.groups, params.benchmark, params.deterministic, output_mask);
+      break;
+    case ConvBackend::HipdnnTranspose:
+      check_input_same_type_as_parameters(input, weight);
+      std::tie(backend_grad_input, backend_grad_weight, backend_grad_bias) =
+        hipdnn_convolution_transpose_backward_stub(
+          input.device().type(),
+          input.contiguous(backend_memory_format), grad_output, weight, params.padding, params.output_padding,
+          params.stride, params.dilation, params.groups, params.benchmark, params.deterministic, output_mask);
       break;
     case ConvBackend::Miopen:
       check_input_same_type_as_parameters(input, weight);

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -70,8 +70,6 @@
 #include <ATen/ops/empty.h>
 #include <ATen/ops/empty_like.h>
 #include <ATen/ops/empty_native.h>
-#include <ATen/ops/hipdnn_convolution.h>
-#include <ATen/ops/hipdnn_convolution_transpose.h>
 #include <ATen/ops/miopen_convolution.h>
 #include <ATen/ops/miopen_convolution_transpose.h>
 #include <ATen/ops/miopen_depthwise_convolution.h>
@@ -636,6 +634,8 @@ DEFINE_DISPATCH(miopen_convolution_transpose_backward_stub);
 DEFINE_DISPATCH(miopen_depthwise_convolution_backward_stub);
 DEFINE_DISPATCH(hipdnn_convolution_backward_stub);
 DEFINE_DISPATCH(hipdnn_convolution_transpose_backward_stub);
+DEFINE_DISPATCH(hipdnn_convolution_stub);
+DEFINE_DISPATCH(hipdnn_convolution_transpose_stub);
 DEFINE_DISPATCH(mkldnn_convolution_backward_stub);
 DEFINE_DISPATCH(mkldnn_convolution_transpose_stub);
 DEFINE_DISPATCH(mkldnn_convolution_transpose_backward_stub);
@@ -651,6 +651,8 @@ REGISTER_NO_CPU_DISPATCH(miopen_convolution_transpose_backward_stub)
 REGISTER_NO_CPU_DISPATCH(miopen_depthwise_convolution_backward_stub)
 REGISTER_NO_CPU_DISPATCH(hipdnn_convolution_backward_stub)
 REGISTER_NO_CPU_DISPATCH(hipdnn_convolution_transpose_backward_stub)
+REGISTER_NO_CPU_DISPATCH(hipdnn_convolution_stub)
+REGISTER_NO_CPU_DISPATCH(hipdnn_convolution_transpose_stub)
 
 template <typename T>
 static std::ostream& operator<<(std::ostream & out, const ConvParams<T>& params) {
@@ -1658,13 +1660,15 @@ at::Tensor _convolution(
     }
     case ConvBackend::Hipdnn:
       check_input_same_type_as_parameters(input, weight, bias);
-      output = at::hipdnn_convolution(
+      output = hipdnn_convolution_stub(
+          input.device().type(),
           input, weight, bias, params.padding, params.stride,
           params.dilation, params.groups, params.benchmark, params.deterministic);
       break;
     case ConvBackend::HipdnnTranspose:
       check_input_same_type_as_parameters(input, weight, bias);
-      output = at::hipdnn_convolution_transpose(
+      output = hipdnn_convolution_transpose_stub(
+          input.device().type(),
           input, weight, bias, params.padding, params.output_padding,
           params.stride, params.dilation, params.groups, params.benchmark, params.deterministic);
       break;

--- a/aten/src/ATen/native/hipdnn/Conv_hipdnn.cpp
+++ b/aten/src/ATen/native/hipdnn/Conv_hipdnn.cpp
@@ -249,6 +249,7 @@ static HipdnnConvCachedGraph buildConvFpropGraph(
   auto inputType = getHipdnnDataType(input);
   auto graph = std::make_shared<hipdnn_frontend::graph::Graph>();
   graph->set_io_data_type(inputType)
+      .set_intermediate_data_type(hipdnn_frontend::DataType::FLOAT)
       .set_compute_data_type(hipdnn_frontend::DataType::FLOAT);
 
   auto x_attr = createTensorAttributes(input);
@@ -265,7 +266,6 @@ static HipdnnConvCachedGraph buildConvFpropGraph(
 
   int64_t bias_uid = 0;
   if (bias) {
-    // Set intermediate tensor dims/strides so pointwise can derive shapes
     conv_out->set_dim(output.sizes().vec());
     conv_out->set_stride(output.strides().vec());
 
@@ -276,6 +276,7 @@ static HipdnnConvCachedGraph buildConvFpropGraph(
 
     hipdnn_frontend::graph::PointwiseAttributes add_attrs;
     add_attrs.set_mode(hipdnn_frontend::PointwiseMode::ADD);
+    add_attrs.set_compute_data_type(inputType);
 
     auto y_attr = graph->pointwise(conv_out, b_attr, add_attrs);
     y_attr->set_output(true).set_uid(UID_OUTPUT);

--- a/aten/src/ATen/native/hipdnn/Conv_hipdnn.cpp
+++ b/aten/src/ATen/native/hipdnn/Conv_hipdnn.cpp
@@ -303,6 +303,7 @@ static HipdnnConvCachedGraph buildConvDgradGraph(
 
   auto inputType = getHipdnnDataType(grad_output);
   auto graph = std::make_shared<hipdnn_frontend::graph::Graph>();
+  // No set_intermediate_data_type needed: single-op graph has no virtual tensors.
   graph->set_io_data_type(inputType)
       .set_compute_data_type(hipdnn_frontend::DataType::FLOAT);
 
@@ -317,6 +318,7 @@ static HipdnnConvCachedGraph buildConvDgradGraph(
   conv_attrs.set_dilation(std::vector<int64_t>(dilation.begin(), dilation.end()));
 
   auto dx_attr = graph->conv_dgrad(dy_attr, w_attr, conv_attrs);
+  dx_attr->set_dim(std::vector<int64_t>(input_size.begin(), input_size.end()));
   dx_attr->set_output(true).set_uid(UID_OUTPUT);
 
   HIPDNN_FE_CHECK(graph->build(handle));
@@ -338,6 +340,7 @@ static HipdnnConvCachedGraph buildConvWgradGraph(
 
   auto inputType = getHipdnnDataType(input);
   auto graph = std::make_shared<hipdnn_frontend::graph::Graph>();
+  // No set_intermediate_data_type needed: single-op graph has no virtual tensors.
   graph->set_io_data_type(inputType)
       .set_compute_data_type(hipdnn_frontend::DataType::FLOAT);
 
@@ -352,6 +355,7 @@ static HipdnnConvCachedGraph buildConvWgradGraph(
   conv_attrs.set_dilation(std::vector<int64_t>(dilation.begin(), dilation.end()));
 
   auto dw_attr = graph->conv_wgrad(dy_attr, x_attr, conv_attrs);
+  dw_attr->set_dim(std::vector<int64_t>(weight_size.begin(), weight_size.end()));
   dw_attr->set_output(true).set_uid(UID_OUTPUT);
 
   HIPDNN_FE_CHECK(graph->build(handle));

--- a/aten/src/ATen/native/hipdnn/Conv_hipdnn.cpp
+++ b/aten/src/ATen/native/hipdnn/Conv_hipdnn.cpp
@@ -84,6 +84,7 @@ struct HipdnnConvParams {
   uint8_t input_dim;
   at::MemoryFormat memory_format;
   int weight_size[2 + hipdnn_max_dim];
+  int output_size[2 + hipdnn_max_dim]; // dgrad/wgrad: disambiguates output_padding
   int padding[hipdnn_max_dim];
   int stride[hipdnn_max_dim];
   int dilation[hipdnn_max_dim];
@@ -102,7 +103,8 @@ static void setHipdnnConvParams(
     int64_t groups,
     bool has_bias,
     at::MemoryFormat memory_format,
-    int operation) {
+    int operation,
+    IntArrayRef output_size = {}) {
   memset(params, 0, sizeof(*params));
   params->device_id = input.device().index();
   params->dataType = getHipdnnDataType(input);
@@ -116,6 +118,9 @@ static void setHipdnnConvParams(
   }
   for (int i = 0; i < weight.dim(); i++) {
     params->weight_size[i] = static_cast<int>(weight.size(i));
+  }
+  for (size_t i = 0; i < output_size.size(); i++) {
+    params->output_size[i] = static_cast<int>(output_size[i]);
   }
   int spatial_dims = input.dim() - 2;
   for (int i = 0; i < spatial_dims; i++) {
@@ -382,9 +387,11 @@ static void runHipdnnConvDgrad(
   auto* cache = getHipdnnConvCache();
 
   HipdnnConvParams key;
-  // For dgrad, use grad_output as the "input" for the cache key
+  // For dgrad, use grad_output as the "input" for the cache key.
+  // input_size disambiguates cases with different output_padding.
   setHipdnnConvParams(&key, grad_output, weight, padding, stride, dilation,
-                      groups, /*has_bias=*/false, memory_format, /*operation=*/1);
+                      groups, /*has_bias=*/false, memory_format, /*operation=*/1,
+                      input_size);
 
   auto* cached = cache->find(key);
   if (!cached) {
@@ -419,9 +426,9 @@ static void runHipdnnConvWgrad(
   auto* cache = getHipdnnConvCache();
 
   HipdnnConvParams key;
-  // For wgrad, use grad_output+input shape as key
   setHipdnnConvParams(&key, grad_output, input, padding, stride, dilation,
-                      groups, /*has_bias=*/false, memory_format, /*operation=*/2);
+                      groups, /*has_bias=*/false, memory_format, /*operation=*/2,
+                      weight_size);
 
   auto* cached = cache->find(key);
   if (!cached) {

--- a/aten/src/ATen/native/hipdnn/Conv_hipdnn.cpp
+++ b/aten/src/ATen/native/hipdnn/Conv_hipdnn.cpp
@@ -259,6 +259,8 @@ static HipdnnConvCachedGraph buildConvDgradGraph(
     hipdnnHandle_t handle,
     const Tensor& grad_output,
     const Tensor& weight,
+    const Tensor& output,
+    const Tensor* bias,
     IntArrayRef input_size,
     IntArrayRef padding,
     IntArrayRef stride,
@@ -266,8 +268,8 @@ static HipdnnConvCachedGraph buildConvDgradGraph(
 
   auto inputType = getHipdnnDataType(grad_output);
   auto graph = std::make_shared<hipdnn_frontend::graph::Graph>();
-  // No set_intermediate_data_type needed: single-op graph has no virtual tensors.
   graph->set_io_data_type(inputType)
+      .set_intermediate_data_type(hipdnn_frontend::DataType::FLOAT)
       .set_compute_data_type(hipdnn_frontend::DataType::FLOAT);
 
   auto dy_attr = createTensorAttributes(grad_output);
@@ -282,7 +284,23 @@ static HipdnnConvCachedGraph buildConvDgradGraph(
 
   auto dx_attr = graph->conv_dgrad(dy_attr, w_attr, conv_attrs);
   dx_attr->set_dim(std::vector<int64_t>(input_size.begin(), input_size.end()));
-  dx_attr->set_output(true).set_uid(UID_OUTPUT);
+
+  if (bias) {
+    dx_attr->set_stride(output.strides().vec());
+
+    auto bias_reshaped = reshape_bias(grad_output.dim(), *bias);
+    auto b_attr = createTensorAttributes(bias_reshaped);
+    b_attr->set_uid(UID_BIAS);
+
+    hipdnn_frontend::graph::PointwiseAttributes add_attrs;
+    add_attrs.set_mode(hipdnn_frontend::PointwiseMode::ADD);
+    add_attrs.set_compute_data_type(inputType);
+
+    auto y_attr = graph->pointwise(dx_attr, b_attr, add_attrs);
+    y_attr->set_output(true).set_uid(UID_OUTPUT);
+  } else {
+    dx_attr->set_output(true).set_uid(UID_OUTPUT);
+  }
 
   HIPDNN_FE_CHECK(graph->build(handle));
 
@@ -376,6 +394,7 @@ static void runHipdnnConvDgrad(
     const Tensor& grad_output,
     const Tensor& weight,
     const Tensor& grad_input,
+    const Tensor* bias,
     IntArrayRef input_size,
     IntArrayRef padding,
     IntArrayRef stride,
@@ -386,17 +405,18 @@ static void runHipdnnConvDgrad(
   auto handle = getHipdnnHandle();
   auto* cache = getHipdnnConvCache();
 
+  bool has_bias = bias != nullptr;
   HipdnnConvParams key;
   // For dgrad, use grad_output as the "input" for the cache key.
   // input_size disambiguates cases with different output_padding.
   setHipdnnConvParams(&key, grad_output, weight, padding, stride, dilation,
-                      groups, /*has_bias=*/false, memory_format, /*operation=*/1,
+                      groups, has_bias, memory_format, /*operation=*/1,
                       input_size);
 
   auto* cached = cache->find(key);
   if (!cached) {
-    auto entry = buildConvDgradGraph(handle, grad_output, weight, input_size,
-                                     padding, stride, dilation);
+    auto entry = buildConvDgradGraph(handle, grad_output, weight, grad_input,
+                                     bias, input_size, padding, stride, dilation);
     cache->update(key, std::move(entry));
     cached = cache->find(key);
   }
@@ -405,6 +425,9 @@ static void runHipdnnConvDgrad(
   variantPack[UID_DGRAD_GRAD_OUTPUT] = grad_output.data_ptr();
   variantPack[UID_DGRAD_WEIGHT] = weight.data_ptr();
   variantPack[UID_DGRAD_GRAD_INPUT] = grad_input.data_ptr();
+  if (bias) {
+    variantPack[UID_BIAS] = bias->data_ptr();
+  }
 
   // Workspace inherits device from grad_output.options()
   auto workspace = at::empty({cached->workspace_size}, grad_output.options().dtype(at::kByte));
@@ -510,8 +533,10 @@ Tensor hipdnn_convolution_transpose(
       input_c.sizes(), weight_c.sizes(), padding, output_padding, stride, dilation, groups);
   auto output = at::empty(trans_output_size, input_c.options(), memory_format);
 
-  // Transposed conv forward is dgrad (no bias fusion — dgrad graph has no bias path)
-  runHipdnnConvDgrad(input_c, weight_c, output,
+  // No hipDNN backend plugin currently supports dgrad+pointwise fusion,
+  // so bias is applied separately.
+  // TODO: pass bias to graph builder when supported in hipDNN.
+  runHipdnnConvDgrad(input_c, weight_c, output, /*bias=*/nullptr,
                      trans_output_size, padding, stride, dilation,
                      groups, memory_format);
 
@@ -546,8 +571,9 @@ std::tuple<Tensor, Tensor, Tensor> hipdnn_convolution_backward(
 
   if (output_mask[0]) {
     grad_input = at::empty(input_c.sizes(), input_c.options(), memory_format);
-    runHipdnnConvDgrad(grad_output, weight_c, grad_input, input_c.sizes(),
-                       padding, stride, dilation, groups, memory_format);
+    runHipdnnConvDgrad(grad_output, weight_c, grad_input, /*bias=*/nullptr,
+                       input_c.sizes(), padding, stride, dilation,
+                       groups, memory_format);
   }
 
   if (output_mask[1]) {

--- a/aten/src/ATen/native/hipdnn/Conv_hipdnn.cpp
+++ b/aten/src/ATen/native/hipdnn/Conv_hipdnn.cpp
@@ -90,8 +90,6 @@ struct HipdnnConvParams {
   int dilation[hipdnn_max_dim];
   int64_t groups;
   bool has_bias;
-  bool deterministic;
-  bool benchmark;
   int operation; // 0=fprop, 1=dgrad, 2=wgrad
 };
 
@@ -106,8 +104,6 @@ static void setHipdnnConvParams(
     bool has_bias,
     at::MemoryFormat memory_format,
     int operation,
-    bool deterministic = false,
-    bool benchmark = false,
     IntArrayRef output_size = {}) {
   memset(params, 0, sizeof(*params));
   params->device_id = input.device().index();
@@ -116,8 +112,6 @@ static void setHipdnnConvParams(
   params->memory_format = memory_format;
   params->groups = groups;
   params->has_bias = has_bias;
-  params->deterministic = deterministic;
-  params->benchmark = benchmark;
   params->operation = operation;
   for (int i = 0; i < input.dim(); i++) {
     params->input_size[i] = static_cast<int>(input.size(i));
@@ -373,14 +367,23 @@ static void runHipdnnConvFprop(
     bool benchmark,
     bool deterministic) {
 
+  TORCH_CHECK(
+      !deterministic,
+      "hipdnn_convolution does not support deterministic mode yet. "
+      "hipDNN does not currently provide engine-level determinism guarantees.");
+  if (benchmark) {
+    TORCH_WARN_ONCE(
+        "hipdnn_convolution: benchmark mode is not supported yet and will be ignored. "
+        "hipDNN does not currently support algorithm search.");
+  }
+
   auto handle = getHipdnnHandle();
   auto* cache = getHipdnnConvCache();
 
   bool has_bias = bias != nullptr;
   HipdnnConvParams key;
   setHipdnnConvParams(&key, input, weight, padding, stride, dilation,
-                      groups, has_bias, memory_format, /*operation=*/0,
-                      deterministic, benchmark);
+                      groups, has_bias, memory_format, /*operation=*/0);
 
   auto* cached = cache->find(key);
   if (!cached) {
@@ -417,6 +420,16 @@ static void runHipdnnConvDgrad(
     bool benchmark,
     bool deterministic) {
 
+  TORCH_CHECK(
+      !deterministic,
+      "hipdnn_convolution does not support deterministic mode yet. "
+      "hipDNN does not currently provide engine-level determinism guarantees.");
+  if (benchmark) {
+    TORCH_WARN_ONCE(
+        "hipdnn_convolution: benchmark mode is not supported yet and will be ignored. "
+        "hipDNN does not currently support algorithm search.");
+  }
+
   auto handle = getHipdnnHandle();
   auto* cache = getHipdnnConvCache();
 
@@ -426,7 +439,7 @@ static void runHipdnnConvDgrad(
   // input_size disambiguates cases with different output_padding.
   setHipdnnConvParams(&key, grad_output, weight, padding, stride, dilation,
                       groups, has_bias, memory_format, /*operation=*/1,
-                      deterministic, benchmark, input_size);
+                      input_size);
 
   auto* cached = cache->find(key);
   if (!cached) {
@@ -462,13 +475,23 @@ static void runHipdnnConvWgrad(
     bool benchmark,
     bool deterministic) {
 
+  TORCH_CHECK(
+      !deterministic,
+      "hipdnn_convolution does not support deterministic mode yet. "
+      "hipDNN does not currently provide engine-level determinism guarantees.");
+  if (benchmark) {
+    TORCH_WARN_ONCE(
+        "hipdnn_convolution: benchmark mode is not supported yet and will be ignored. "
+        "hipDNN does not currently support algorithm search.");
+  }
+
   auto handle = getHipdnnHandle();
   auto* cache = getHipdnnConvCache();
 
   HipdnnConvParams key;
   setHipdnnConvParams(&key, grad_output, input, padding, stride, dilation,
                       groups, /*has_bias=*/false, memory_format, /*operation=*/2,
-                      deterministic, benchmark, weight_size);
+                      weight_size);
 
   auto* cached = cache->find(key);
   if (!cached) {

--- a/aten/src/ATen/native/hipdnn/Conv_hipdnn.cpp
+++ b/aten/src/ATen/native/hipdnn/Conv_hipdnn.cpp
@@ -66,12 +66,9 @@ Tensor hipdnn_convolution_transpose(
 
 #include <ATen/TensorUtils.h>
 #include <ATen/native/ConvUtils.h>
-#include <ATen/native/utils/ParamsHash.h>
+#include <ATen/native/utils/ParamsLRUCache.h>
 #include <c10/util/env.h>
 #include <c10/util/irange.h>
-
-#include <list>
-#include <unordered_map>
 
 namespace at::native {
 
@@ -134,10 +131,6 @@ static void setHipdnnConvParams(
 struct HipdnnConvCachedGraph {
   std::shared_ptr<hipdnn_frontend::graph::Graph> graph;
   int64_t workspace_size;
-  int64_t input_uid;
-  int64_t weight_uid;
-  int64_t bias_uid; // 0 if no bias in graph
-  int64_t output_uid;
 };
 
 // ---------------------------------------------------------------------------
@@ -170,52 +163,10 @@ static int getHipdnnConvCacheLimit() {
   return limit;
 }
 
-template <typename KeyType>
-struct HipdnnGraphCache {
-  using KeyWrapper = ParamsWrapper<KeyType>;
-  std::list<KeyWrapper> cache_order;
-  std::unordered_map<
-      KeyWrapper,
-      std::pair<HipdnnConvCachedGraph, typename std::list<KeyWrapper>::iterator>,
-      ParamsWrapperHash<KeyWrapper>> cache;
+using HipdnnConvCache = ParamsLRUCache<HipdnnConvParams, HipdnnConvCachedGraph>;
 
-  HipdnnConvCachedGraph* find(const KeyType& key) {
-    int cache_limit = getHipdnnConvCacheLimit();
-    if (cache_limit < 0) return nullptr;
-    KeyWrapper wrapped;
-    wrapped.pod = key;
-    auto it = cache.find(wrapped);
-    if (it == cache.end()) return nullptr;
-    if (cache_limit) {
-      cache_order.splice(cache_order.begin(), cache_order, it->second.second);
-    }
-    return &(it->second.first);
-  }
-
-  void update(const KeyType& key, HipdnnConvCachedGraph entry) {
-    int cache_limit = getHipdnnConvCacheLimit();
-    if (cache_limit < 0) return;
-    KeyWrapper wrapped;
-    wrapped.pod = key;
-    auto it = cache.find(wrapped);
-    if (it == cache.end()) {
-      if (cache_limit && static_cast<long>(cache.size()) >= cache_limit) {
-        cache.erase(cache_order.back());
-        cache_order.pop_back();
-      }
-      cache_order.emplace_front(wrapped);
-      cache.emplace(wrapped, std::make_pair(std::move(entry), cache_order.begin()));
-    } else {
-      it->second.first = std::move(entry);
-      if (cache_limit) {
-        cache_order.splice(cache_order.begin(), cache_order, it->second.second);
-      }
-    }
-  }
-};
-
-static HipdnnGraphCache<HipdnnConvParams>* getHipdnnConvCache() {
-  static thread_local auto* cache = new HipdnnGraphCache<HipdnnConvParams>();
+static HipdnnConvCache* getHipdnnConvCache() {
+  static thread_local auto* cache = new HipdnnConvCache(getHipdnnConvCacheLimit());
   return cache;
 }
 
@@ -223,10 +174,19 @@ static HipdnnGraphCache<HipdnnConvParams>* getHipdnnConvCache() {
 // Deterministic UID assignment for graph tensors
 // ---------------------------------------------------------------------------
 enum HipdnnConvUid : int64_t {
-  UID_INPUT = 1,
+  // Forward (fprop)
+  UID_INPUT  = 1,
   UID_WEIGHT = 2,
   UID_OUTPUT = 3,
-  UID_BIAS = 4,
+  UID_BIAS   = 4,
+  // Backward data (dgrad) — aliases
+  UID_DGRAD_GRAD_OUTPUT = UID_INPUT,
+  UID_DGRAD_WEIGHT      = UID_WEIGHT,
+  UID_DGRAD_GRAD_INPUT  = UID_OUTPUT,
+  // Backward weight (wgrad) — aliases
+  UID_WGRAD_GRAD_OUTPUT = UID_INPUT,
+  UID_WGRAD_INPUT       = UID_WEIGHT,
+  UID_WGRAD_GRAD_WEIGHT = UID_OUTPUT,
 };
 
 // ---------------------------------------------------------------------------
@@ -264,7 +224,6 @@ static HipdnnConvCachedGraph buildConvFpropGraph(
 
   auto conv_out = graph->conv_fprop(x_attr, w_attr, conv_attrs);
 
-  int64_t bias_uid = 0;
   if (bias) {
     conv_out->set_dim(output.sizes().vec());
     conv_out->set_stride(output.strides().vec());
@@ -272,7 +231,6 @@ static HipdnnConvCachedGraph buildConvFpropGraph(
     auto bias_reshaped = reshape_bias(input.dim(), *bias);
     auto b_attr = createTensorAttributes(bias_reshaped);
     b_attr->set_uid(UID_BIAS);
-    bias_uid = UID_BIAS;
 
     hipdnn_frontend::graph::PointwiseAttributes add_attrs;
     add_attrs.set_mode(hipdnn_frontend::PointwiseMode::ADD);
@@ -289,7 +247,7 @@ static HipdnnConvCachedGraph buildConvFpropGraph(
   int64_t ws = 0;
   HIPDNN_FE_CHECK(graph->get_workspace_size(ws));
 
-  return {std::move(graph), ws, UID_INPUT, UID_WEIGHT, bias_uid, UID_OUTPUT};
+  return {std::move(graph), ws};
 }
 
 static HipdnnConvCachedGraph buildConvDgradGraph(
@@ -326,7 +284,7 @@ static HipdnnConvCachedGraph buildConvDgradGraph(
   int64_t ws = 0;
   HIPDNN_FE_CHECK(graph->get_workspace_size(ws));
 
-  return {std::move(graph), ws, UID_INPUT, UID_WEIGHT, /*bias_uid=*/0, UID_OUTPUT};
+  return {std::move(graph), ws};
 }
 
 static HipdnnConvCachedGraph buildConvWgradGraph(
@@ -363,7 +321,7 @@ static HipdnnConvCachedGraph buildConvWgradGraph(
   int64_t ws = 0;
   HIPDNN_FE_CHECK(graph->get_workspace_size(ws));
 
-  return {std::move(graph), ws, UID_INPUT, UID_WEIGHT, /*bias_uid=*/0, UID_OUTPUT};
+  return {std::move(graph), ws};
 }
 
 // ---------------------------------------------------------------------------
@@ -397,13 +355,14 @@ static void runHipdnnConvFprop(
   }
 
   std::unordered_map<int64_t, void*> variantPack;
-  variantPack[cached->input_uid] = input.data_ptr();
-  variantPack[cached->weight_uid] = weight.data_ptr();
-  variantPack[cached->output_uid] = output.data_ptr();
-  if (cached->bias_uid) {
-    variantPack[cached->bias_uid] = bias->data_ptr();
+  variantPack[UID_INPUT] = input.data_ptr();
+  variantPack[UID_WEIGHT] = weight.data_ptr();
+  variantPack[UID_OUTPUT] = output.data_ptr();
+  if (bias) {
+    variantPack[UID_BIAS] = bias->data_ptr();
   }
 
+  // Workspace inherits device from input.options()
   auto workspace = at::empty({cached->workspace_size}, input.options().dtype(at::kByte));
   HIPDNN_FE_CHECK(cached->graph->execute(handle, variantPack, workspace.data_ptr()));
 }
@@ -436,10 +395,11 @@ static void runHipdnnConvDgrad(
   }
 
   std::unordered_map<int64_t, void*> variantPack;
-  variantPack[cached->input_uid] = grad_output.data_ptr();
-  variantPack[cached->weight_uid] = weight.data_ptr();
-  variantPack[cached->output_uid] = grad_input.data_ptr();
+  variantPack[UID_DGRAD_GRAD_OUTPUT] = grad_output.data_ptr();
+  variantPack[UID_DGRAD_WEIGHT] = weight.data_ptr();
+  variantPack[UID_DGRAD_GRAD_INPUT] = grad_input.data_ptr();
 
+  // Workspace inherits device from grad_output.options()
   auto workspace = at::empty({cached->workspace_size}, grad_output.options().dtype(at::kByte));
   HIPDNN_FE_CHECK(cached->graph->execute(handle, variantPack, workspace.data_ptr()));
 }
@@ -472,10 +432,11 @@ static void runHipdnnConvWgrad(
   }
 
   std::unordered_map<int64_t, void*> variantPack;
-  variantPack[cached->input_uid] = grad_output.data_ptr();
-  variantPack[cached->weight_uid] = input.data_ptr();
-  variantPack[cached->output_uid] = grad_weight.data_ptr();
+  variantPack[UID_WGRAD_GRAD_OUTPUT] = grad_output.data_ptr();
+  variantPack[UID_WGRAD_INPUT] = input.data_ptr();
+  variantPack[UID_WGRAD_GRAD_WEIGHT] = grad_weight.data_ptr();
 
+  // Workspace inherits device from grad_output.options()
   auto workspace = at::empty({cached->workspace_size}, grad_output.options().dtype(at::kByte));
   HIPDNN_FE_CHECK(cached->graph->execute(handle, variantPack, workspace.data_ptr()));
 }

--- a/aten/src/ATen/native/hipdnn/Conv_hipdnn.cpp
+++ b/aten/src/ATen/native/hipdnn/Conv_hipdnn.cpp
@@ -90,6 +90,8 @@ struct HipdnnConvParams {
   int dilation[hipdnn_max_dim];
   int64_t groups;
   bool has_bias;
+  bool deterministic;
+  bool benchmark;
   int operation; // 0=fprop, 1=dgrad, 2=wgrad
 };
 
@@ -104,6 +106,8 @@ static void setHipdnnConvParams(
     bool has_bias,
     at::MemoryFormat memory_format,
     int operation,
+    bool deterministic = false,
+    bool benchmark = false,
     IntArrayRef output_size = {}) {
   memset(params, 0, sizeof(*params));
   params->device_id = input.device().index();
@@ -112,6 +116,8 @@ static void setHipdnnConvParams(
   params->memory_format = memory_format;
   params->groups = groups;
   params->has_bias = has_bias;
+  params->deterministic = deterministic;
+  params->benchmark = benchmark;
   params->operation = operation;
   for (int i = 0; i < input.dim(); i++) {
     params->input_size[i] = static_cast<int>(input.size(i));
@@ -141,6 +147,10 @@ struct HipdnnConvCachedGraph {
 // ---------------------------------------------------------------------------
 // Thread-local LRU cache (same pattern as cuDNN v8 Conv_v8.cpp)
 // ---------------------------------------------------------------------------
+// Returns the LRU cache limit for convolution graphs.
+// Special values (matching cuDNN v8):
+//   0       = unlimited (no eviction)
+//   negative = caching disabled
 static int getHipdnnConvCacheLimit() {
   static int limit = []{
     constexpr int DEFAULT_LIMIT = 10000;
@@ -359,7 +369,9 @@ static void runHipdnnConvFprop(
     IntArrayRef stride,
     IntArrayRef dilation,
     int64_t groups,
-    at::MemoryFormat memory_format) {
+    at::MemoryFormat memory_format,
+    bool benchmark,
+    bool deterministic) {
 
   auto handle = getHipdnnHandle();
   auto* cache = getHipdnnConvCache();
@@ -367,7 +379,8 @@ static void runHipdnnConvFprop(
   bool has_bias = bias != nullptr;
   HipdnnConvParams key;
   setHipdnnConvParams(&key, input, weight, padding, stride, dilation,
-                      groups, has_bias, memory_format, /*operation=*/0);
+                      groups, has_bias, memory_format, /*operation=*/0,
+                      deterministic, benchmark);
 
   auto* cached = cache->find(key);
   if (!cached) {
@@ -400,7 +413,9 @@ static void runHipdnnConvDgrad(
     IntArrayRef stride,
     IntArrayRef dilation,
     int64_t groups,
-    at::MemoryFormat memory_format) {
+    at::MemoryFormat memory_format,
+    bool benchmark,
+    bool deterministic) {
 
   auto handle = getHipdnnHandle();
   auto* cache = getHipdnnConvCache();
@@ -411,7 +426,7 @@ static void runHipdnnConvDgrad(
   // input_size disambiguates cases with different output_padding.
   setHipdnnConvParams(&key, grad_output, weight, padding, stride, dilation,
                       groups, has_bias, memory_format, /*operation=*/1,
-                      input_size);
+                      deterministic, benchmark, input_size);
 
   auto* cached = cache->find(key);
   if (!cached) {
@@ -443,7 +458,9 @@ static void runHipdnnConvWgrad(
     IntArrayRef stride,
     IntArrayRef dilation,
     int64_t groups,
-    at::MemoryFormat memory_format) {
+    at::MemoryFormat memory_format,
+    bool benchmark,
+    bool deterministic) {
 
   auto handle = getHipdnnHandle();
   auto* cache = getHipdnnConvCache();
@@ -451,7 +468,7 @@ static void runHipdnnConvWgrad(
   HipdnnConvParams key;
   setHipdnnConvParams(&key, grad_output, input, padding, stride, dilation,
                       groups, /*has_bias=*/false, memory_format, /*operation=*/2,
-                      weight_size);
+                      deterministic, benchmark, weight_size);
 
   auto* cached = cache->find(key);
   if (!cached) {
@@ -502,7 +519,8 @@ Tensor hipdnn_convolution(
   bool has_bias = bias_opt.has_value() && bias_opt->defined();
   const Tensor* bias_ptr = has_bias ? &(*bias_opt) : nullptr;
   runHipdnnConvFprop(input_c, weight_c, output, bias_ptr,
-                     padding, stride, dilation, groups, memory_format);
+                     padding, stride, dilation, groups, memory_format,
+                     benchmark, deterministic);
 
   return output;
 }
@@ -538,7 +556,7 @@ Tensor hipdnn_convolution_transpose(
   // TODO: pass bias to graph builder when supported in hipDNN.
   runHipdnnConvDgrad(input_c, weight_c, output, /*bias=*/nullptr,
                      trans_output_size, padding, stride, dilation,
-                     groups, memory_format);
+                     groups, memory_format, benchmark, deterministic);
 
   if (bias_opt.has_value() && bias_opt->defined()) {
     output.add_(reshape_bias(input_c.dim(), *bias_opt));
@@ -573,13 +591,14 @@ std::tuple<Tensor, Tensor, Tensor> hipdnn_convolution_backward(
     grad_input = at::empty(input_c.sizes(), input_c.options(), memory_format);
     runHipdnnConvDgrad(grad_output, weight_c, grad_input, /*bias=*/nullptr,
                        input_c.sizes(), padding, stride, dilation,
-                       groups, memory_format);
+                       groups, memory_format, benchmark, deterministic);
   }
 
   if (output_mask[1]) {
     grad_weight = at::empty(weight_c.sizes(), weight_c.options(), memory_format);
     runHipdnnConvWgrad(grad_output, input_c, grad_weight, weight_c.sizes(),
-                       padding, stride, dilation, groups, memory_format);
+                       padding, stride, dilation, groups, memory_format,
+                       benchmark, deterministic);
   }
 
   if (output_mask[2]) {
@@ -619,14 +638,16 @@ std::tuple<Tensor, Tensor, Tensor> hipdnn_convolution_transpose_backward(
     // Transpose backward-input = fprop
     grad_input = at::empty(input_c.sizes(), input_c.options(), memory_format);
     runHipdnnConvFprop(grad_output, weight_c, grad_input, /*bias=*/nullptr,
-                       padding, stride, dilation, groups, memory_format);
+                       padding, stride, dilation, groups, memory_format,
+                       benchmark, deterministic);
   }
 
   if (output_mask[1]) {
     // Transpose backward-weight = wgrad
     grad_weight = at::empty(weight_c.sizes(), weight_c.options(), memory_format);
     runHipdnnConvWgrad(input_c, grad_output, grad_weight, weight_c.sizes(),
-                       padding, stride, dilation, groups, memory_format);
+                       padding, stride, dilation, groups, memory_format,
+                       benchmark, deterministic);
   }
 
   if (output_mask[2]) {

--- a/aten/src/ATen/native/hipdnn/Conv_hipdnn.cpp
+++ b/aten/src/ATen/native/hipdnn/Conv_hipdnn.cpp
@@ -71,10 +71,9 @@ Tensor hipdnn_convolution_transpose(
 #include <c10/util/irange.h>
 
 #include <list>
-#include <mutex>
 #include <unordered_map>
 
-namespace at { namespace native {
+namespace at::native {
 
 // ---------------------------------------------------------------------------
 // Cache key: captures everything that determines graph topology
@@ -92,6 +91,7 @@ struct HipdnnConvParams {
   int stride[hipdnn_max_dim];
   int dilation[hipdnn_max_dim];
   int64_t groups;
+  bool has_bias;
   int operation; // 0=fprop, 1=dgrad, 2=wgrad
 };
 
@@ -103,6 +103,7 @@ static void setHipdnnConvParams(
     IntArrayRef stride,
     IntArrayRef dilation,
     int64_t groups,
+    bool has_bias,
     at::MemoryFormat memory_format,
     int operation) {
   memset(params, 0, sizeof(*params));
@@ -111,6 +112,7 @@ static void setHipdnnConvParams(
   params->input_dim = static_cast<uint8_t>(input.dim());
   params->memory_format = memory_format;
   params->groups = groups;
+  params->has_bias = has_bias;
   params->operation = operation;
   for (int i = 0; i < input.dim(); i++) {
     params->input_size[i] = static_cast<int>(input.size(i));
@@ -134,6 +136,7 @@ struct HipdnnConvCachedGraph {
   int64_t workspace_size;
   int64_t input_uid;
   int64_t weight_uid;
+  int64_t bias_uid; // 0 if no bias in graph
   int64_t output_uid;
 };
 
@@ -142,8 +145,27 @@ struct HipdnnConvCachedGraph {
 // ---------------------------------------------------------------------------
 static int getHipdnnConvCacheLimit() {
   static int limit = []{
-    auto val = c10::utils::check_env("TORCH_HIPDNN_CONV_LRU_CACHE_LIMIT");
-    return val.has_value() ? (val.value() ? 10000 : -1) : 10000;
+    constexpr int DEFAULT_LIMIT = 10000;
+    const auto val = c10::utils::get_env("TORCH_HIPDNN_CONV_LRU_CACHE_LIMIT");
+    if (!val) {
+      return DEFAULT_LIMIT;
+    }
+    try {
+      return std::stoi(val.value());
+    } catch (std::invalid_argument const&) {
+      TORCH_WARN(
+          "invalid TORCH_HIPDNN_CONV_LRU_CACHE_LIMIT,",
+          " using default LRU cache limit of ",
+          DEFAULT_LIMIT,
+          " entries.");
+    } catch (std::out_of_range const&) {
+      TORCH_WARN(
+          "invalid TORCH_HIPDNN_CONV_LRU_CACHE_LIMIT,",
+          " using default LRU cache limit of ",
+          DEFAULT_LIMIT,
+          " entries.");
+    }
+    return DEFAULT_LIMIT;
   }();
   return limit;
 }
@@ -204,15 +226,22 @@ enum HipdnnConvUid : int64_t {
   UID_INPUT = 1,
   UID_WEIGHT = 2,
   UID_OUTPUT = 3,
+  UID_BIAS = 4,
 };
 
 // ---------------------------------------------------------------------------
 // Graph builders
+//
+// Note: groups are not explicitly passed to graph builders. HipDNN infers
+// groupCount from tensor dimensions (input_channels / weight_channels_per_group).
+// PyTorch provides correctly-shaped weight tensors [C_out, C_in/groups, kH, kW].
 // ---------------------------------------------------------------------------
 static HipdnnConvCachedGraph buildConvFpropGraph(
     hipdnnHandle_t handle,
     const Tensor& input,
     const Tensor& weight,
+    const Tensor& output,
+    const Tensor* bias,
     IntArrayRef padding,
     IntArrayRef stride,
     IntArrayRef dilation) {
@@ -232,15 +261,34 @@ static HipdnnConvCachedGraph buildConvFpropGraph(
   conv_attrs.set_stride(std::vector<int64_t>(stride.begin(), stride.end()));
   conv_attrs.set_dilation(std::vector<int64_t>(dilation.begin(), dilation.end()));
 
-  auto y_attr = graph->conv_fprop(x_attr, w_attr, conv_attrs);
-  y_attr->set_output(true).set_uid(UID_OUTPUT);
+  auto conv_out = graph->conv_fprop(x_attr, w_attr, conv_attrs);
+
+  int64_t bias_uid = 0;
+  if (bias) {
+    // Set intermediate tensor dims/strides so pointwise can derive shapes
+    conv_out->set_dim(output.sizes().vec());
+    conv_out->set_stride(output.strides().vec());
+
+    auto bias_reshaped = reshape_bias(input.dim(), *bias);
+    auto b_attr = createTensorAttributes(bias_reshaped);
+    b_attr->set_uid(UID_BIAS);
+    bias_uid = UID_BIAS;
+
+    hipdnn_frontend::graph::PointwiseAttributes add_attrs;
+    add_attrs.set_mode(hipdnn_frontend::PointwiseMode::ADD);
+
+    auto y_attr = graph->pointwise(conv_out, b_attr, add_attrs);
+    y_attr->set_output(true).set_uid(UID_OUTPUT);
+  } else {
+    conv_out->set_output(true).set_uid(UID_OUTPUT);
+  }
 
   HIPDNN_FE_CHECK(graph->build(handle));
 
   int64_t ws = 0;
   HIPDNN_FE_CHECK(graph->get_workspace_size(ws));
 
-  return {std::move(graph), ws, UID_INPUT, UID_WEIGHT, UID_OUTPUT};
+  return {std::move(graph), ws, UID_INPUT, UID_WEIGHT, bias_uid, UID_OUTPUT};
 }
 
 static HipdnnConvCachedGraph buildConvDgradGraph(
@@ -275,7 +323,7 @@ static HipdnnConvCachedGraph buildConvDgradGraph(
   int64_t ws = 0;
   HIPDNN_FE_CHECK(graph->get_workspace_size(ws));
 
-  return {std::move(graph), ws, UID_INPUT, UID_WEIGHT, UID_OUTPUT};
+  return {std::move(graph), ws, UID_INPUT, UID_WEIGHT, /*bias_uid=*/0, UID_OUTPUT};
 }
 
 static HipdnnConvCachedGraph buildConvWgradGraph(
@@ -310,7 +358,7 @@ static HipdnnConvCachedGraph buildConvWgradGraph(
   int64_t ws = 0;
   HIPDNN_FE_CHECK(graph->get_workspace_size(ws));
 
-  return {std::move(graph), ws, UID_INPUT, UID_WEIGHT, UID_OUTPUT};
+  return {std::move(graph), ws, UID_INPUT, UID_WEIGHT, /*bias_uid=*/0, UID_OUTPUT};
 }
 
 // ---------------------------------------------------------------------------
@@ -320,6 +368,7 @@ static void runHipdnnConvFprop(
     const Tensor& input,
     const Tensor& weight,
     const Tensor& output,
+    const Tensor* bias,
     IntArrayRef padding,
     IntArrayRef stride,
     IntArrayRef dilation,
@@ -329,13 +378,15 @@ static void runHipdnnConvFprop(
   auto handle = getHipdnnHandle();
   auto* cache = getHipdnnConvCache();
 
+  bool has_bias = bias != nullptr;
   HipdnnConvParams key;
   setHipdnnConvParams(&key, input, weight, padding, stride, dilation,
-                      groups, memory_format, /*operation=*/0);
+                      groups, has_bias, memory_format, /*operation=*/0);
 
   auto* cached = cache->find(key);
   if (!cached) {
-    auto entry = buildConvFpropGraph(handle, input, weight, padding, stride, dilation);
+    auto entry = buildConvFpropGraph(
+        handle, input, weight, output, bias, padding, stride, dilation);
     cache->update(key, std::move(entry));
     cached = cache->find(key);
   }
@@ -344,6 +395,9 @@ static void runHipdnnConvFprop(
   variantPack[cached->input_uid] = input.data_ptr();
   variantPack[cached->weight_uid] = weight.data_ptr();
   variantPack[cached->output_uid] = output.data_ptr();
+  if (cached->bias_uid) {
+    variantPack[cached->bias_uid] = bias->data_ptr();
+  }
 
   auto workspace = at::empty({cached->workspace_size}, input.options().dtype(at::kByte));
   HIPDNN_FE_CHECK(cached->graph->execute(handle, variantPack, workspace.data_ptr()));
@@ -366,7 +420,7 @@ static void runHipdnnConvDgrad(
   HipdnnConvParams key;
   // For dgrad, use grad_output as the "input" for the cache key
   setHipdnnConvParams(&key, grad_output, weight, padding, stride, dilation,
-                      groups, memory_format, /*operation=*/1);
+                      groups, /*has_bias=*/false, memory_format, /*operation=*/1);
 
   auto* cached = cache->find(key);
   if (!cached) {
@@ -402,7 +456,7 @@ static void runHipdnnConvWgrad(
   HipdnnConvParams key;
   // For wgrad, use grad_output+input shape as key
   setHipdnnConvParams(&key, grad_output, input, padding, stride, dilation,
-                      groups, memory_format, /*operation=*/2);
+                      groups, /*has_bias=*/false, memory_format, /*operation=*/2);
 
   auto* cached = cache->find(key);
   if (!cached) {
@@ -449,12 +503,10 @@ Tensor hipdnn_convolution(
       input_c.sizes(), weight_c.sizes(), padding, stride, dilation);
   auto output = at::empty(output_size, input_c.options(), memory_format);
 
-  runHipdnnConvFprop(input_c, weight_c, output, padding, stride, dilation,
-                     groups, memory_format);
-
-  if (bias_opt.has_value() && bias_opt->defined()) {
-    output.add_(reshape_bias(input_c.dim(), *bias_opt));
-  }
+  bool has_bias = bias_opt.has_value() && bias_opt->defined();
+  const Tensor* bias_ptr = has_bias ? &(*bias_opt) : nullptr;
+  runHipdnnConvFprop(input_c, weight_c, output, bias_ptr,
+                     padding, stride, dilation, groups, memory_format);
 
   return output;
 }
@@ -485,7 +537,7 @@ Tensor hipdnn_convolution_transpose(
       input_c.sizes(), weight_c.sizes(), padding, output_padding, stride, dilation, groups);
   auto output = at::empty(trans_output_size, input_c.options(), memory_format);
 
-  // Transposed conv forward is dgrad
+  // Transposed conv forward is dgrad (no bias fusion — dgrad graph has no bias path)
   runHipdnnConvDgrad(input_c, weight_c, output,
                      trans_output_size, padding, stride, dilation,
                      groups, memory_format);
@@ -532,7 +584,6 @@ std::tuple<Tensor, Tensor, Tensor> hipdnn_convolution_backward(
   }
 
   if (output_mask[2]) {
-    // Sum over all dims except channel dim (dim 1)
     std::vector<int64_t> reduce_dims;
     reduce_dims.push_back(0);
     for (int64_t i = 2; i < grad_output.dim(); i++) {
@@ -568,7 +619,7 @@ std::tuple<Tensor, Tensor, Tensor> hipdnn_convolution_transpose_backward(
   if (output_mask[0]) {
     // Transpose backward-input = fprop
     grad_input = at::empty(input_c.sizes(), input_c.options(), memory_format);
-    runHipdnnConvFprop(grad_output, weight_c, grad_input,
+    runHipdnnConvFprop(grad_output, weight_c, grad_input, /*bias=*/nullptr,
                        padding, stride, dilation, groups, memory_format);
   }
 
@@ -598,6 +649,6 @@ std::tuple<Tensor, Tensor, Tensor> hipdnn_convolution_transpose_backward(
 REGISTER_CUDA_DISPATCH(hipdnn_convolution_backward_stub, &hipdnn_convolution_backward)
 REGISTER_CUDA_DISPATCH(hipdnn_convolution_transpose_backward_stub, &hipdnn_convolution_transpose_backward)
 
-}} // namespace at::native
+} // namespace at::native
 
 #endif

--- a/aten/src/ATen/native/hipdnn/Conv_hipdnn.cpp
+++ b/aten/src/ATen/native/hipdnn/Conv_hipdnn.cpp
@@ -574,16 +574,11 @@ Tensor hipdnn_convolution_transpose(
       input_c.sizes(), weight_c.sizes(), padding, output_padding, stride, dilation, groups);
   auto output = at::empty(trans_output_size, input_c.options(), memory_format);
 
-  // No hipDNN backend plugin currently supports dgrad+pointwise fusion,
-  // so bias is applied separately.
-  // TODO: pass bias to graph builder when supported in hipDNN.
-  runHipdnnConvDgrad(input_c, weight_c, output, /*bias=*/nullptr,
+  bool has_bias = bias_opt.has_value() && bias_opt->defined();
+  const Tensor* bias_ptr = has_bias ? &(*bias_opt) : nullptr;
+  runHipdnnConvDgrad(input_c, weight_c, output, bias_ptr,
                      trans_output_size, padding, stride, dilation,
                      groups, memory_format, benchmark, deterministic);
-
-  if (bias_opt.has_value() && bias_opt->defined()) {
-    output.add_(reshape_bias(input_c.dim(), *bias_opt));
-  }
 
   return output;
 }

--- a/aten/src/ATen/native/hipdnn/Conv_hipdnn.cpp
+++ b/aten/src/ATen/native/hipdnn/Conv_hipdnn.cpp
@@ -20,16 +20,16 @@ namespace at::native {
 
 Tensor hipdnn_convolution(
     const Tensor& input, const Tensor& weight, const std::optional<Tensor>& bias_opt,
-    c10::SymIntArrayRef padding, c10::SymIntArrayRef stride, c10::SymIntArrayRef dilation,
-    c10::SymInt groups, bool benchmark, bool deterministic) {
+    IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation,
+    int64_t groups, bool benchmark, bool deterministic) {
   TORCH_CHECK(false, "hipdnn_convolution: ATen not compiled with ROCm support");
 }
 
 Tensor hipdnn_convolution_transpose(
     const Tensor& input, const Tensor& weight, const std::optional<Tensor>& bias_opt,
-    c10::SymIntArrayRef padding, c10::SymIntArrayRef output_padding,
-    c10::SymIntArrayRef stride, c10::SymIntArrayRef dilation,
-    c10::SymInt groups, bool benchmark, bool deterministic) {
+    IntArrayRef padding, IntArrayRef output_padding,
+    IntArrayRef stride, IntArrayRef dilation,
+    int64_t groups, bool benchmark, bool deterministic) {
   TORCH_CHECK(false, "hipdnn_convolution_transpose: ATen not compiled with ROCm support");
 }
 
@@ -41,16 +41,16 @@ namespace at::native {
 
 Tensor hipdnn_convolution(
     const Tensor& input, const Tensor& weight, const std::optional<Tensor>& bias_opt,
-    c10::SymIntArrayRef padding, c10::SymIntArrayRef stride, c10::SymIntArrayRef dilation,
-    c10::SymInt groups, bool benchmark, bool deterministic) {
+    IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation,
+    int64_t groups, bool benchmark, bool deterministic) {
   TORCH_CHECK(false, "hipdnn_convolution: not compiled with hipDNN support");
 }
 
 Tensor hipdnn_convolution_transpose(
     const Tensor& input, const Tensor& weight, const std::optional<Tensor>& bias_opt,
-    c10::SymIntArrayRef padding, c10::SymIntArrayRef output_padding,
-    c10::SymIntArrayRef stride, c10::SymIntArrayRef dilation,
-    c10::SymInt groups, bool benchmark, bool deterministic) {
+    IntArrayRef padding, IntArrayRef output_padding,
+    IntArrayRef stride, IntArrayRef dilation,
+    int64_t groups, bool benchmark, bool deterministic) {
   TORCH_CHECK(false, "hipdnn_convolution_transpose: not compiled with hipDNN support");
 }
 
@@ -428,17 +428,12 @@ Tensor hipdnn_convolution(
     const Tensor& input_t,
     const Tensor& weight_t,
     const std::optional<Tensor>& bias_opt,
-    c10::SymIntArrayRef padding_,
-    c10::SymIntArrayRef stride_,
-    c10::SymIntArrayRef dilation_,
-    c10::SymInt groups_,
+    IntArrayRef padding,
+    IntArrayRef stride,
+    IntArrayRef dilation,
+    int64_t groups,
     bool benchmark,
     bool deterministic) {
-
-  auto padding = C10_AS_INTARRAYREF_SLOW(padding_);
-  auto stride = C10_AS_INTARRAYREF_SLOW(stride_);
-  auto dilation = C10_AS_INTARRAYREF_SLOW(dilation_);
-  auto groups = groups_.expect_int();
 
   TensorArg input{input_t, "input", 1};
   TensorArg weight{weight_t, "weight", 2};
@@ -468,19 +463,13 @@ Tensor hipdnn_convolution_transpose(
     const Tensor& input_t,
     const Tensor& weight_t,
     const std::optional<Tensor>& bias_opt,
-    c10::SymIntArrayRef padding_,
-    c10::SymIntArrayRef output_padding_,
-    c10::SymIntArrayRef stride_,
-    c10::SymIntArrayRef dilation_,
-    c10::SymInt groups_,
+    IntArrayRef padding,
+    IntArrayRef output_padding,
+    IntArrayRef stride,
+    IntArrayRef dilation,
+    int64_t groups,
     bool benchmark,
     bool deterministic) {
-
-  auto padding = C10_AS_INTARRAYREF_SLOW(padding_);
-  auto output_padding = C10_AS_INTARRAYREF_SLOW(output_padding_);
-  auto stride = C10_AS_INTARRAYREF_SLOW(stride_);
-  auto dilation = C10_AS_INTARRAYREF_SLOW(dilation_);
-  auto groups = groups_.expect_int();
 
   TensorArg input{input_t, "input", 1};
   TensorArg weight{weight_t, "weight", 2};

--- a/aten/src/ATen/native/hipdnn/Conv_hipdnn.cpp
+++ b/aten/src/ATen/native/hipdnn/Conv_hipdnn.cpp
@@ -1,0 +1,614 @@
+#define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+#include <ATen/core/Tensor.h>
+#include <ATen/Config.h>
+
+#ifndef AT_PER_OPERATOR_HEADERS
+#include <ATen/Functions.h>
+#include <ATen/NativeFunctions.h>
+#else
+#include <ATen/ops/empty.h>
+#include <ATen/ops/empty_like.h>
+#include <ATen/ops/hipdnn_convolution_native.h>
+#include <ATen/ops/hipdnn_convolution_transpose_native.h>
+#endif
+
+#include <ATen/cuda/CUDAConfig.h>
+
+#if !AT_ROCM_ENABLED()
+
+namespace at::native {
+
+Tensor hipdnn_convolution(
+    const Tensor& input, const Tensor& weight, const std::optional<Tensor>& bias_opt,
+    c10::SymIntArrayRef padding, c10::SymIntArrayRef stride, c10::SymIntArrayRef dilation,
+    c10::SymInt groups, bool benchmark, bool deterministic) {
+  TORCH_CHECK(false, "hipdnn_convolution: ATen not compiled with ROCm support");
+}
+
+Tensor hipdnn_convolution_transpose(
+    const Tensor& input, const Tensor& weight, const std::optional<Tensor>& bias_opt,
+    c10::SymIntArrayRef padding, c10::SymIntArrayRef output_padding,
+    c10::SymIntArrayRef stride, c10::SymIntArrayRef dilation,
+    c10::SymInt groups, bool benchmark, bool deterministic) {
+  TORCH_CHECK(false, "hipdnn_convolution_transpose: ATen not compiled with ROCm support");
+}
+
+} // namespace at::native
+
+#elif !defined(USE_HIPDNN)
+
+namespace at::native {
+
+Tensor hipdnn_convolution(
+    const Tensor& input, const Tensor& weight, const std::optional<Tensor>& bias_opt,
+    c10::SymIntArrayRef padding, c10::SymIntArrayRef stride, c10::SymIntArrayRef dilation,
+    c10::SymInt groups, bool benchmark, bool deterministic) {
+  TORCH_CHECK(false, "hipdnn_convolution: not compiled with hipDNN support");
+}
+
+Tensor hipdnn_convolution_transpose(
+    const Tensor& input, const Tensor& weight, const std::optional<Tensor>& bias_opt,
+    c10::SymIntArrayRef padding, c10::SymIntArrayRef output_padding,
+    c10::SymIntArrayRef stride, c10::SymIntArrayRef dilation,
+    c10::SymInt groups, bool benchmark, bool deterministic) {
+  TORCH_CHECK(false, "hipdnn_convolution_transpose: not compiled with hipDNN support");
+}
+
+} // namespace at::native
+
+#else // AT_ROCM_ENABLED && USE_HIPDNN
+
+#include <hipdnn_frontend.hpp>
+#include <ATen/hipdnn/Types.h>
+#include <ATen/hipdnn/Handle.h>
+#include <ATen/hipdnn/Exceptions.h>
+#include <ATen/hipdnn/Utils.h>
+
+#include <ATen/TensorUtils.h>
+#include <ATen/native/ConvUtils.h>
+#include <ATen/native/utils/ParamsHash.h>
+#include <c10/util/env.h>
+#include <c10/util/irange.h>
+
+#include <list>
+#include <mutex>
+#include <unordered_map>
+
+namespace at { namespace native {
+
+// ---------------------------------------------------------------------------
+// Cache key: captures everything that determines graph topology
+// ---------------------------------------------------------------------------
+constexpr int hipdnn_max_dim = 3;
+
+struct HipdnnConvParams {
+  c10::DeviceIndex device_id;
+  hipdnn_frontend::DataType dataType;
+  int input_size[2 + hipdnn_max_dim];
+  uint8_t input_dim;
+  at::MemoryFormat memory_format;
+  int weight_size[2 + hipdnn_max_dim];
+  int padding[hipdnn_max_dim];
+  int stride[hipdnn_max_dim];
+  int dilation[hipdnn_max_dim];
+  int64_t groups;
+  int operation; // 0=fprop, 1=dgrad, 2=wgrad
+};
+
+static void setHipdnnConvParams(
+    HipdnnConvParams* params,
+    const Tensor& input,
+    const Tensor& weight,
+    IntArrayRef padding,
+    IntArrayRef stride,
+    IntArrayRef dilation,
+    int64_t groups,
+    at::MemoryFormat memory_format,
+    int operation) {
+  memset(params, 0, sizeof(*params));
+  params->device_id = input.device().index();
+  params->dataType = getHipdnnDataType(input);
+  params->input_dim = static_cast<uint8_t>(input.dim());
+  params->memory_format = memory_format;
+  params->groups = groups;
+  params->operation = operation;
+  for (int i = 0; i < input.dim(); i++) {
+    params->input_size[i] = static_cast<int>(input.size(i));
+  }
+  for (int i = 0; i < weight.dim(); i++) {
+    params->weight_size[i] = static_cast<int>(weight.size(i));
+  }
+  int spatial_dims = input.dim() - 2;
+  for (int i = 0; i < spatial_dims; i++) {
+    params->padding[i] = static_cast<int>(padding[i]);
+    params->stride[i] = static_cast<int>(stride[i]);
+    params->dilation[i] = static_cast<int>(dilation[i]);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Cached graph value
+// ---------------------------------------------------------------------------
+struct HipdnnConvCachedGraph {
+  std::shared_ptr<hipdnn_frontend::graph::Graph> graph;
+  int64_t workspace_size;
+  int64_t input_uid;
+  int64_t weight_uid;
+  int64_t output_uid;
+};
+
+// ---------------------------------------------------------------------------
+// Thread-local LRU cache (same pattern as cuDNN v8 Conv_v8.cpp)
+// ---------------------------------------------------------------------------
+static int getHipdnnConvCacheLimit() {
+  static int limit = []{
+    auto val = c10::utils::check_env("TORCH_HIPDNN_CONV_LRU_CACHE_LIMIT");
+    return val.has_value() ? (val.value() ? 10000 : -1) : 10000;
+  }();
+  return limit;
+}
+
+template <typename KeyType>
+struct HipdnnGraphCache {
+  using KeyWrapper = ParamsWrapper<KeyType>;
+  std::list<KeyWrapper> cache_order;
+  std::unordered_map<
+      KeyWrapper,
+      std::pair<HipdnnConvCachedGraph, typename std::list<KeyWrapper>::iterator>,
+      ParamsWrapperHash<KeyWrapper>> cache;
+
+  HipdnnConvCachedGraph* find(const KeyType& key) {
+    int cache_limit = getHipdnnConvCacheLimit();
+    if (cache_limit < 0) return nullptr;
+    KeyWrapper wrapped;
+    wrapped.pod = key;
+    auto it = cache.find(wrapped);
+    if (it == cache.end()) return nullptr;
+    if (cache_limit) {
+      cache_order.splice(cache_order.begin(), cache_order, it->second.second);
+    }
+    return &(it->second.first);
+  }
+
+  void update(const KeyType& key, HipdnnConvCachedGraph entry) {
+    int cache_limit = getHipdnnConvCacheLimit();
+    if (cache_limit < 0) return;
+    KeyWrapper wrapped;
+    wrapped.pod = key;
+    auto it = cache.find(wrapped);
+    if (it == cache.end()) {
+      if (cache_limit && static_cast<long>(cache.size()) >= cache_limit) {
+        cache.erase(cache_order.back());
+        cache_order.pop_back();
+      }
+      cache_order.emplace_front(wrapped);
+      cache.emplace(wrapped, std::make_pair(std::move(entry), cache_order.begin()));
+    } else {
+      it->second.first = std::move(entry);
+      if (cache_limit) {
+        cache_order.splice(cache_order.begin(), cache_order, it->second.second);
+      }
+    }
+  }
+};
+
+static HipdnnGraphCache<HipdnnConvParams>* getHipdnnConvCache() {
+  static thread_local auto* cache = new HipdnnGraphCache<HipdnnConvParams>();
+  return cache;
+}
+
+// ---------------------------------------------------------------------------
+// Deterministic UID assignment for graph tensors
+// ---------------------------------------------------------------------------
+enum HipdnnConvUid : int64_t {
+  UID_INPUT = 1,
+  UID_WEIGHT = 2,
+  UID_OUTPUT = 3,
+};
+
+// ---------------------------------------------------------------------------
+// Graph builders
+// ---------------------------------------------------------------------------
+static HipdnnConvCachedGraph buildConvFpropGraph(
+    hipdnnHandle_t handle,
+    const Tensor& input,
+    const Tensor& weight,
+    IntArrayRef padding,
+    IntArrayRef stride,
+    IntArrayRef dilation) {
+
+  auto inputType = getHipdnnDataType(input);
+  auto graph = std::make_shared<hipdnn_frontend::graph::Graph>();
+  graph->set_io_data_type(inputType)
+      .set_compute_data_type(hipdnn_frontend::DataType::FLOAT);
+
+  auto x_attr = createTensorAttributes(input);
+  x_attr->set_uid(UID_INPUT);
+  auto w_attr = createTensorAttributes(weight);
+  w_attr->set_uid(UID_WEIGHT);
+
+  hipdnn_frontend::graph::ConvFpropAttributes conv_attrs;
+  conv_attrs.set_padding(std::vector<int64_t>(padding.begin(), padding.end()));
+  conv_attrs.set_stride(std::vector<int64_t>(stride.begin(), stride.end()));
+  conv_attrs.set_dilation(std::vector<int64_t>(dilation.begin(), dilation.end()));
+
+  auto y_attr = graph->conv_fprop(x_attr, w_attr, conv_attrs);
+  y_attr->set_output(true).set_uid(UID_OUTPUT);
+
+  HIPDNN_FE_CHECK(graph->build(handle));
+
+  int64_t ws = 0;
+  HIPDNN_FE_CHECK(graph->get_workspace_size(ws));
+
+  return {std::move(graph), ws, UID_INPUT, UID_WEIGHT, UID_OUTPUT};
+}
+
+static HipdnnConvCachedGraph buildConvDgradGraph(
+    hipdnnHandle_t handle,
+    const Tensor& grad_output,
+    const Tensor& weight,
+    IntArrayRef input_size,
+    IntArrayRef padding,
+    IntArrayRef stride,
+    IntArrayRef dilation) {
+
+  auto inputType = getHipdnnDataType(grad_output);
+  auto graph = std::make_shared<hipdnn_frontend::graph::Graph>();
+  graph->set_io_data_type(inputType)
+      .set_compute_data_type(hipdnn_frontend::DataType::FLOAT);
+
+  auto dy_attr = createTensorAttributes(grad_output);
+  dy_attr->set_uid(UID_INPUT);
+  auto w_attr = createTensorAttributes(weight);
+  w_attr->set_uid(UID_WEIGHT);
+
+  hipdnn_frontend::graph::ConvDgradAttributes conv_attrs;
+  conv_attrs.set_padding(std::vector<int64_t>(padding.begin(), padding.end()));
+  conv_attrs.set_stride(std::vector<int64_t>(stride.begin(), stride.end()));
+  conv_attrs.set_dilation(std::vector<int64_t>(dilation.begin(), dilation.end()));
+
+  auto dx_attr = graph->conv_dgrad(dy_attr, w_attr, conv_attrs);
+  dx_attr->set_output(true).set_uid(UID_OUTPUT);
+
+  HIPDNN_FE_CHECK(graph->build(handle));
+
+  int64_t ws = 0;
+  HIPDNN_FE_CHECK(graph->get_workspace_size(ws));
+
+  return {std::move(graph), ws, UID_INPUT, UID_WEIGHT, UID_OUTPUT};
+}
+
+static HipdnnConvCachedGraph buildConvWgradGraph(
+    hipdnnHandle_t handle,
+    const Tensor& grad_output,
+    const Tensor& input,
+    IntArrayRef weight_size,
+    IntArrayRef padding,
+    IntArrayRef stride,
+    IntArrayRef dilation) {
+
+  auto inputType = getHipdnnDataType(input);
+  auto graph = std::make_shared<hipdnn_frontend::graph::Graph>();
+  graph->set_io_data_type(inputType)
+      .set_compute_data_type(hipdnn_frontend::DataType::FLOAT);
+
+  auto dy_attr = createTensorAttributes(grad_output);
+  dy_attr->set_uid(UID_INPUT);
+  auto x_attr = createTensorAttributes(input);
+  x_attr->set_uid(UID_WEIGHT);
+
+  hipdnn_frontend::graph::ConvWgradAttributes conv_attrs;
+  conv_attrs.set_padding(std::vector<int64_t>(padding.begin(), padding.end()));
+  conv_attrs.set_stride(std::vector<int64_t>(stride.begin(), stride.end()));
+  conv_attrs.set_dilation(std::vector<int64_t>(dilation.begin(), dilation.end()));
+
+  auto dw_attr = graph->conv_wgrad(dy_attr, x_attr, conv_attrs);
+  dw_attr->set_output(true).set_uid(UID_OUTPUT);
+
+  HIPDNN_FE_CHECK(graph->build(handle));
+
+  int64_t ws = 0;
+  HIPDNN_FE_CHECK(graph->get_workspace_size(ws));
+
+  return {std::move(graph), ws, UID_INPUT, UID_WEIGHT, UID_OUTPUT};
+}
+
+// ---------------------------------------------------------------------------
+// Graph execution helpers (cache-check-then-build-and-execute)
+// ---------------------------------------------------------------------------
+static void runHipdnnConvFprop(
+    const Tensor& input,
+    const Tensor& weight,
+    const Tensor& output,
+    IntArrayRef padding,
+    IntArrayRef stride,
+    IntArrayRef dilation,
+    int64_t groups,
+    at::MemoryFormat memory_format) {
+
+  auto handle = getHipdnnHandle();
+  auto* cache = getHipdnnConvCache();
+
+  HipdnnConvParams key;
+  setHipdnnConvParams(&key, input, weight, padding, stride, dilation,
+                      groups, memory_format, /*operation=*/0);
+
+  auto* cached = cache->find(key);
+  if (!cached) {
+    auto entry = buildConvFpropGraph(handle, input, weight, padding, stride, dilation);
+    cache->update(key, std::move(entry));
+    cached = cache->find(key);
+  }
+
+  std::unordered_map<int64_t, void*> variantPack;
+  variantPack[cached->input_uid] = input.data_ptr();
+  variantPack[cached->weight_uid] = weight.data_ptr();
+  variantPack[cached->output_uid] = output.data_ptr();
+
+  auto workspace = at::empty({cached->workspace_size}, input.options().dtype(at::kByte));
+  HIPDNN_FE_CHECK(cached->graph->execute(handle, variantPack, workspace.data_ptr()));
+}
+
+static void runHipdnnConvDgrad(
+    const Tensor& grad_output,
+    const Tensor& weight,
+    const Tensor& grad_input,
+    IntArrayRef input_size,
+    IntArrayRef padding,
+    IntArrayRef stride,
+    IntArrayRef dilation,
+    int64_t groups,
+    at::MemoryFormat memory_format) {
+
+  auto handle = getHipdnnHandle();
+  auto* cache = getHipdnnConvCache();
+
+  HipdnnConvParams key;
+  // For dgrad, use grad_output as the "input" for the cache key
+  setHipdnnConvParams(&key, grad_output, weight, padding, stride, dilation,
+                      groups, memory_format, /*operation=*/1);
+
+  auto* cached = cache->find(key);
+  if (!cached) {
+    auto entry = buildConvDgradGraph(handle, grad_output, weight, input_size,
+                                     padding, stride, dilation);
+    cache->update(key, std::move(entry));
+    cached = cache->find(key);
+  }
+
+  std::unordered_map<int64_t, void*> variantPack;
+  variantPack[cached->input_uid] = grad_output.data_ptr();
+  variantPack[cached->weight_uid] = weight.data_ptr();
+  variantPack[cached->output_uid] = grad_input.data_ptr();
+
+  auto workspace = at::empty({cached->workspace_size}, grad_output.options().dtype(at::kByte));
+  HIPDNN_FE_CHECK(cached->graph->execute(handle, variantPack, workspace.data_ptr()));
+}
+
+static void runHipdnnConvWgrad(
+    const Tensor& grad_output,
+    const Tensor& input,
+    const Tensor& grad_weight,
+    IntArrayRef weight_size,
+    IntArrayRef padding,
+    IntArrayRef stride,
+    IntArrayRef dilation,
+    int64_t groups,
+    at::MemoryFormat memory_format) {
+
+  auto handle = getHipdnnHandle();
+  auto* cache = getHipdnnConvCache();
+
+  HipdnnConvParams key;
+  // For wgrad, use grad_output+input shape as key
+  setHipdnnConvParams(&key, grad_output, input, padding, stride, dilation,
+                      groups, memory_format, /*operation=*/2);
+
+  auto* cached = cache->find(key);
+  if (!cached) {
+    auto entry = buildConvWgradGraph(handle, grad_output, input, weight_size,
+                                     padding, stride, dilation);
+    cache->update(key, std::move(entry));
+    cached = cache->find(key);
+  }
+
+  std::unordered_map<int64_t, void*> variantPack;
+  variantPack[cached->input_uid] = grad_output.data_ptr();
+  variantPack[cached->weight_uid] = input.data_ptr();
+  variantPack[cached->output_uid] = grad_weight.data_ptr();
+
+  auto workspace = at::empty({cached->workspace_size}, grad_output.options().dtype(at::kByte));
+  HIPDNN_FE_CHECK(cached->graph->execute(handle, variantPack, workspace.data_ptr()));
+}
+
+// ---------------------------------------------------------------------------
+// Public entry points
+// ---------------------------------------------------------------------------
+Tensor hipdnn_convolution(
+    const Tensor& input_t,
+    const Tensor& weight_t,
+    const std::optional<Tensor>& bias_opt,
+    c10::SymIntArrayRef padding_,
+    c10::SymIntArrayRef stride_,
+    c10::SymIntArrayRef dilation_,
+    c10::SymInt groups_,
+    bool benchmark,
+    bool deterministic) {
+
+  auto padding = C10_AS_INTARRAYREF_SLOW(padding_);
+  auto stride = C10_AS_INTARRAYREF_SLOW(stride_);
+  auto dilation = C10_AS_INTARRAYREF_SLOW(dilation_);
+  auto groups = groups_.expect_int();
+
+  TensorArg input{input_t, "input", 1};
+  TensorArg weight{weight_t, "weight", 2};
+  CheckedFrom c = "hipdnn_convolution";
+  checkAllSameType(c, {input, weight});
+  checkAllSameGPU(c, {input, weight});
+
+  auto memory_format = hipdnn_conv_suggest_memory_format(input_t, weight_t);
+  auto input_c = input_t.contiguous(memory_format);
+  auto weight_c = weight_t.contiguous(memory_format);
+
+  auto output_size = conv_output_size(
+      input_c.sizes(), weight_c.sizes(), padding, stride, dilation);
+  auto output = at::empty(output_size, input_c.options(), memory_format);
+
+  runHipdnnConvFprop(input_c, weight_c, output, padding, stride, dilation,
+                     groups, memory_format);
+
+  if (bias_opt.has_value() && bias_opt->defined()) {
+    output.add_(reshape_bias(input_c.dim(), *bias_opt));
+  }
+
+  return output;
+}
+
+Tensor hipdnn_convolution_transpose(
+    const Tensor& input_t,
+    const Tensor& weight_t,
+    const std::optional<Tensor>& bias_opt,
+    c10::SymIntArrayRef padding_,
+    c10::SymIntArrayRef output_padding_,
+    c10::SymIntArrayRef stride_,
+    c10::SymIntArrayRef dilation_,
+    c10::SymInt groups_,
+    bool benchmark,
+    bool deterministic) {
+
+  auto padding = C10_AS_INTARRAYREF_SLOW(padding_);
+  auto output_padding = C10_AS_INTARRAYREF_SLOW(output_padding_);
+  auto stride = C10_AS_INTARRAYREF_SLOW(stride_);
+  auto dilation = C10_AS_INTARRAYREF_SLOW(dilation_);
+  auto groups = groups_.expect_int();
+
+  TensorArg input{input_t, "input", 1};
+  TensorArg weight{weight_t, "weight", 2};
+  CheckedFrom c = "hipdnn_convolution_transpose";
+  checkAllSameType(c, {input, weight});
+  checkAllSameGPU(c, {input, weight});
+
+  auto memory_format = hipdnn_conv_suggest_memory_format(input_t, weight_t);
+  auto input_c = input_t.contiguous(memory_format);
+  auto weight_c = weight_t.contiguous(memory_format);
+
+  auto trans_output_size = conv_input_size(
+      input_c.sizes(), weight_c.sizes(), padding, output_padding, stride, dilation, groups);
+  auto output = at::empty(trans_output_size, input_c.options(), memory_format);
+
+  // Transposed conv forward is dgrad
+  runHipdnnConvDgrad(input_c, weight_c, output,
+                     trans_output_size, padding, stride, dilation,
+                     groups, memory_format);
+
+  if (bias_opt.has_value() && bias_opt->defined()) {
+    output.add_(reshape_bias(input_c.dim(), *bias_opt));
+  }
+
+  return output;
+}
+
+// ---------------------------------------------------------------------------
+// Backward
+// ---------------------------------------------------------------------------
+std::tuple<Tensor, Tensor, Tensor> hipdnn_convolution_backward(
+    const Tensor& input,
+    const Tensor& grad_output_t,
+    const Tensor& weight,
+    IntArrayRef padding,
+    IntArrayRef stride,
+    IntArrayRef dilation,
+    int64_t groups,
+    bool benchmark,
+    bool deterministic,
+    std::array<bool, 3> output_mask) {
+
+  auto memory_format = hipdnn_conv_suggest_memory_format(input, weight);
+  auto grad_output = grad_output_t.contiguous(memory_format);
+  auto input_c = input.contiguous(memory_format);
+  auto weight_c = weight.contiguous(memory_format);
+
+  Tensor grad_input, grad_weight, grad_bias;
+
+  if (output_mask[0]) {
+    grad_input = at::empty(input_c.sizes(), input_c.options(), memory_format);
+    runHipdnnConvDgrad(grad_output, weight_c, grad_input, input_c.sizes(),
+                       padding, stride, dilation, groups, memory_format);
+  }
+
+  if (output_mask[1]) {
+    grad_weight = at::empty(weight_c.sizes(), weight_c.options(), memory_format);
+    runHipdnnConvWgrad(grad_output, input_c, grad_weight, weight_c.sizes(),
+                       padding, stride, dilation, groups, memory_format);
+  }
+
+  if (output_mask[2]) {
+    // Sum over all dims except channel dim (dim 1)
+    std::vector<int64_t> reduce_dims;
+    reduce_dims.push_back(0);
+    for (int64_t i = 2; i < grad_output.dim(); i++) {
+      reduce_dims.push_back(i);
+    }
+    grad_bias = grad_output.sum(reduce_dims);
+  }
+
+  return std::make_tuple(
+      std::move(grad_input), std::move(grad_weight), std::move(grad_bias));
+}
+
+std::tuple<Tensor, Tensor, Tensor> hipdnn_convolution_transpose_backward(
+    const Tensor& input,
+    const Tensor& grad_output_t,
+    const Tensor& weight,
+    IntArrayRef padding,
+    IntArrayRef output_padding,
+    IntArrayRef stride,
+    IntArrayRef dilation,
+    int64_t groups,
+    bool benchmark,
+    bool deterministic,
+    std::array<bool, 3> output_mask) {
+
+  auto memory_format = hipdnn_conv_suggest_memory_format(input, weight);
+  auto grad_output = grad_output_t.contiguous(memory_format);
+  auto input_c = input.contiguous(memory_format);
+  auto weight_c = weight.contiguous(memory_format);
+
+  Tensor grad_input, grad_weight, grad_bias;
+
+  if (output_mask[0]) {
+    // Transpose backward-input = fprop
+    grad_input = at::empty(input_c.sizes(), input_c.options(), memory_format);
+    runHipdnnConvFprop(grad_output, weight_c, grad_input,
+                       padding, stride, dilation, groups, memory_format);
+  }
+
+  if (output_mask[1]) {
+    // Transpose backward-weight = wgrad
+    grad_weight = at::empty(weight_c.sizes(), weight_c.options(), memory_format);
+    runHipdnnConvWgrad(input_c, grad_output, grad_weight, weight_c.sizes(),
+                       padding, stride, dilation, groups, memory_format);
+  }
+
+  if (output_mask[2]) {
+    std::vector<int64_t> reduce_dims;
+    reduce_dims.push_back(0);
+    for (int64_t i = 2; i < grad_output.dim(); i++) {
+      reduce_dims.push_back(i);
+    }
+    grad_bias = grad_output.sum(reduce_dims);
+  }
+
+  return std::make_tuple(
+      std::move(grad_input), std::move(grad_weight), std::move(grad_bias));
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch stub registration
+// ---------------------------------------------------------------------------
+REGISTER_CUDA_DISPATCH(hipdnn_convolution_backward_stub, &hipdnn_convolution_backward)
+REGISTER_CUDA_DISPATCH(hipdnn_convolution_transpose_backward_stub, &hipdnn_convolution_transpose_backward)
+
+}} // namespace at::native
+
+#endif

--- a/aten/src/ATen/native/hipdnn/Conv_hipdnn.cpp
+++ b/aten/src/ATen/native/hipdnn/Conv_hipdnn.cpp
@@ -8,53 +8,15 @@
 #else
 #include <ATen/ops/empty.h>
 #include <ATen/ops/empty_like.h>
-#include <ATen/ops/hipdnn_convolution_native.h>
-#include <ATen/ops/hipdnn_convolution_transpose_native.h>
 #endif
 
 #include <ATen/cuda/CUDAConfig.h>
 
-#if !AT_ROCM_ENABLED()
+#if !AT_ROCM_ENABLED() || !defined(USE_HIPDNN)
 
-namespace at::native {
-
-Tensor hipdnn_convolution(
-    const Tensor& input, const Tensor& weight, const std::optional<Tensor>& bias_opt,
-    IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation,
-    int64_t groups, bool benchmark, bool deterministic) {
-  TORCH_CHECK(false, "hipdnn_convolution: ATen not compiled with ROCm support");
-}
-
-Tensor hipdnn_convolution_transpose(
-    const Tensor& input, const Tensor& weight, const std::optional<Tensor>& bias_opt,
-    IntArrayRef padding, IntArrayRef output_padding,
-    IntArrayRef stride, IntArrayRef dilation,
-    int64_t groups, bool benchmark, bool deterministic) {
-  TORCH_CHECK(false, "hipdnn_convolution_transpose: ATen not compiled with ROCm support");
-}
-
-} // namespace at::native
-
-#elif !defined(USE_HIPDNN)
-
-namespace at::native {
-
-Tensor hipdnn_convolution(
-    const Tensor& input, const Tensor& weight, const std::optional<Tensor>& bias_opt,
-    IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation,
-    int64_t groups, bool benchmark, bool deterministic) {
-  TORCH_CHECK(false, "hipdnn_convolution: not compiled with hipDNN support");
-}
-
-Tensor hipdnn_convolution_transpose(
-    const Tensor& input, const Tensor& weight, const std::optional<Tensor>& bias_opt,
-    IntArrayRef padding, IntArrayRef output_padding,
-    IntArrayRef stride, IntArrayRef dilation,
-    int64_t groups, bool benchmark, bool deterministic) {
-  TORCH_CHECK(false, "hipdnn_convolution_transpose: not compiled with hipDNN support");
-}
-
-} // namespace at::native
+// No forward stubs needed: dispatch stubs (REGISTER_NO_CPU_DISPATCH) handle
+// the non-CUDA case, and backend selection (use_hipdnn()) prevents dispatch
+// to hipDNN when not compiled with hipDNN support.
 
 #else // AT_ROCM_ENABLED && USE_HIPDNN
 
@@ -684,6 +646,8 @@ std::tuple<Tensor, Tensor, Tensor> hipdnn_convolution_transpose_backward(
 // ---------------------------------------------------------------------------
 // Dispatch stub registration
 // ---------------------------------------------------------------------------
+REGISTER_CUDA_DISPATCH(hipdnn_convolution_stub, &hipdnn_convolution)
+REGISTER_CUDA_DISPATCH(hipdnn_convolution_transpose_stub, &hipdnn_convolution_transpose)
 REGISTER_CUDA_DISPATCH(hipdnn_convolution_backward_stub, &hipdnn_convolution_backward)
 REGISTER_CUDA_DISPATCH(hipdnn_convolution_transpose_backward_stub, &hipdnn_convolution_transpose_backward)
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -4183,6 +4183,16 @@
     CUDA: hipdnn_batch_norm_backward
   autogen: hipdnn_batch_norm_backward.out
 
+- func: hipdnn_convolution(Tensor self, Tensor weight, Tensor? bias, SymInt[] padding, SymInt[] stride, SymInt[] dilation, SymInt groups, bool benchmark, bool deterministic) -> Tensor
+  dispatch:
+    CUDA: hipdnn_convolution
+  autogen: hipdnn_convolution.out
+
+- func: hipdnn_convolution_transpose(Tensor self, Tensor weight, Tensor? bias, SymInt[] padding, SymInt[] output_padding, SymInt[] stride, SymInt[] dilation, SymInt groups, bool benchmark, bool deterministic) -> Tensor
+  dispatch:
+    CUDA: hipdnn_convolution_transpose
+  autogen: hipdnn_convolution_transpose.out
+
 - func: miopen_convolution(Tensor self, Tensor weight, Tensor? bias, SymInt[] padding, SymInt[] stride, SymInt[] dilation, SymInt groups, bool benchmark, bool deterministic) -> Tensor
   dispatch:
     CUDA: miopen_convolution

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -4183,16 +4183,6 @@
     CUDA: hipdnn_batch_norm_backward
   autogen: hipdnn_batch_norm_backward.out
 
-- func: hipdnn_convolution(Tensor self, Tensor weight, Tensor? bias, SymInt[] padding, SymInt[] stride, SymInt[] dilation, SymInt groups, bool benchmark, bool deterministic) -> Tensor
-  dispatch:
-    CUDA: hipdnn_convolution
-  autogen: hipdnn_convolution.out
-
-- func: hipdnn_convolution_transpose(Tensor self, Tensor weight, Tensor? bias, SymInt[] padding, SymInt[] output_padding, SymInt[] stride, SymInt[] dilation, SymInt groups, bool benchmark, bool deterministic) -> Tensor
-  dispatch:
-    CUDA: hipdnn_convolution_transpose
-  autogen: hipdnn_convolution_transpose.out
-
 - func: miopen_convolution(Tensor self, Tensor weight, Tensor? bias, SymInt[] padding, SymInt[] stride, SymInt[] dilation, SymInt groups, bool benchmark, bool deterministic) -> Tensor
   dispatch:
     CUDA: miopen_convolution

--- a/aten/src/ATen/native/utils/ParamsLRUCache.h
+++ b/aten/src/ATen/native/utils/ParamsLRUCache.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ATen/native/utils/ParamsHash.h>
+#include <c10/util/Exception.h>
 
 #include <list>
 #include <unordered_map>
@@ -39,12 +40,18 @@ struct ParamsLRUCache {
     wrapped.pod = key;
     auto it = cache.find(wrapped);
     if (it == cache.end()) {
-      if (cache_limit && static_cast<long>(cache.size()) >= cache_limit) {
-        cache.erase(cache_order.back());
-        cache_order.pop_back();
+      if (cache_limit == 0) {
+        // Unlimited cache — insert into map only, no LRU tracking
+        cache.emplace(wrapped, std::make_pair(std::move(entry), cache_order.end()));
+      } else {
+        if (static_cast<long>(cache.size()) >= cache_limit) {
+          auto count = cache.erase(cache_order.back());
+          TORCH_INTERNAL_ASSERT(count == 1, "LRU cache eviction failed to erase key");
+          cache_order.pop_back();
+        }
+        cache_order.emplace_front(wrapped);
+        cache.emplace(wrapped, std::make_pair(std::move(entry), cache_order.begin()));
       }
-      cache_order.emplace_front(wrapped);
-      cache.emplace(wrapped, std::make_pair(std::move(entry), cache_order.begin()));
     } else {
       it->second.first = std::move(entry);
       if (cache_limit) {

--- a/aten/src/ATen/native/utils/ParamsLRUCache.h
+++ b/aten/src/ATen/native/utils/ParamsLRUCache.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <ATen/native/utils/ParamsHash.h>
+
+#include <list>
+#include <unordered_map>
+#include <utility>
+
+namespace at::native {
+
+template <typename KeyType, typename ValueType>
+struct ParamsLRUCache {
+  using KeyWrapper = ParamsWrapper<KeyType>;
+
+  int cache_limit;
+  std::list<KeyWrapper> cache_order;
+  std::unordered_map<
+      KeyWrapper,
+      std::pair<ValueType, typename std::list<KeyWrapper>::iterator>,
+      ParamsWrapperHash<KeyWrapper>> cache;
+
+  explicit ParamsLRUCache(int limit) : cache_limit(limit) {}
+
+  ValueType* find(const KeyType& key) {
+    if (cache_limit < 0) return nullptr;
+    KeyWrapper wrapped;
+    wrapped.pod = key;
+    auto it = cache.find(wrapped);
+    if (it == cache.end()) return nullptr;
+    if (cache_limit) {
+      cache_order.splice(cache_order.begin(), cache_order, it->second.second);
+    }
+    return &(it->second.first);
+  }
+
+  void update(const KeyType& key, ValueType entry) {
+    if (cache_limit < 0) return;
+    KeyWrapper wrapped;
+    wrapped.pod = key;
+    auto it = cache.find(wrapped);
+    if (it == cache.end()) {
+      if (cache_limit && static_cast<long>(cache.size()) >= cache_limit) {
+        cache.erase(cache_order.back());
+        cache_order.pop_back();
+      }
+      cache_order.emplace_front(wrapped);
+      cache.emplace(wrapped, std::make_pair(std::move(entry), cache_order.begin()));
+    } else {
+      it->second.first = std::move(entry);
+      if (cache_limit) {
+        cache_order.splice(cache_order.begin(), cache_order, it->second.second);
+      }
+    }
+  }
+};
+
+} // namespace at::native

--- a/test/test_hipdnn_conv.py
+++ b/test/test_hipdnn_conv.py
@@ -142,6 +142,13 @@ class TestHipdnnConvolution(TestCase):
             dtype=torch.float32, transposed=True, output_padding=1,
         )
 
+    def test_conv_transpose2d_no_output_padding(self):
+        self._compare_conv(
+            (2, 128, 16, 16), (128, 64, 3, 3),
+            bias=False, stride=2, padding=1, dilation=1, groups=1,
+            dtype=torch.float32, transposed=True, output_padding=0,
+        )
+
     def test_conv2d_depthwise(self):
         self._compare_conv(
             (2, 128, 32, 32), (128, 1, 3, 3),

--- a/test/test_hipdnn_conv.py
+++ b/test/test_hipdnn_conv.py
@@ -26,10 +26,14 @@ class TestHipdnnConvolution(TestCase):
     ):
         atol, rtol = (1e-4, 1e-4) if dtype == torch.float32 else (5e-2, 5e-2)
 
-        x_cpu = torch.randn(*x_shape, dtype=torch.float32, requires_grad=True)
-        w_cpu = torch.randn(*w_shape, dtype=torch.float32, requires_grad=True)
-        b_cpu = torch.randn(w_shape[1] if transposed else w_shape[0],
-                            dtype=torch.float32, requires_grad=True) if bias else None
+        x_gpu = torch.randn(*x_shape, dtype=dtype, device="cuda")
+        w_gpu = torch.randn(*w_shape, dtype=dtype, device="cuda")
+        b_gpu = torch.randn(w_shape[1] if transposed else w_shape[0],
+                            dtype=dtype, device="cuda") if bias else None
+
+        x_cpu = x_gpu.float().cpu().requires_grad_(True)
+        w_cpu = w_gpu.float().cpu().requires_grad_(True)
+        b_cpu = b_gpu.float().cpu().requires_grad_(True) if bias else None
 
         conv_fn = F.conv_transpose2d if transposed else F.conv2d
         kwargs = dict(stride=stride, padding=padding, dilation=dilation, groups=groups)
@@ -39,9 +43,9 @@ class TestHipdnnConvolution(TestCase):
         out_cpu = conv_fn(x_cpu, w_cpu, b_cpu, **kwargs)
         out_cpu.sum().backward()
 
-        x_gpu = x_cpu.detach().to(device="cuda", dtype=dtype).requires_grad_(True)
-        w_gpu = w_cpu.detach().to(device="cuda", dtype=dtype).requires_grad_(True)
-        b_gpu = b_cpu.detach().to(device="cuda", dtype=dtype).requires_grad_(True) if bias else None
+        x_gpu = x_gpu.detach().requires_grad_(True)
+        w_gpu = w_gpu.detach().requires_grad_(True)
+        b_gpu = b_gpu.detach().requires_grad_(True) if bias else None
 
         with torch.backends.hipdnn.flags(enabled=True):
             out_gpu = conv_fn(x_gpu, w_gpu, b_gpu, **kwargs)
@@ -65,7 +69,7 @@ class TestHipdnnConvolution(TestCase):
 
     def test_conv2d_fp16(self):
         self._compare_conv(
-            (2, 64, 32, 32), (128, 64, 3, 3),
+            (2, 8, 32, 32), (16, 8, 3, 3),
             bias=False, stride=1, padding=1, dilation=1, groups=1,
             dtype=torch.float16,
         )
@@ -89,10 +93,6 @@ class TestHipdnnConvolution(TestCase):
 
         self.assertEqual(out_hipdnn, out_miopen, atol=1e-4, rtol=1e-4)
 
-    # -----------------------------------------------------------------------
-    # xfail: backward broken for stride>1, groups>1, large kernels
-    # -----------------------------------------------------------------------
-    @unittest.expectedFailure
     def test_conv2d_stride2(self):
         self._compare_conv(
             (2, 64, 32, 32), (128, 64, 3, 3),
@@ -100,7 +100,6 @@ class TestHipdnnConvolution(TestCase):
             dtype=torch.float32,
         )
 
-    @unittest.expectedFailure
     def test_conv2d_grouped(self):
         self._compare_conv(
             (2, 128, 32, 32), (128, 32, 3, 3),
@@ -108,7 +107,6 @@ class TestHipdnnConvolution(TestCase):
             dtype=torch.float32,
         )
 
-    @unittest.expectedFailure
     def test_conv2d_resnet_first_layer(self):
         self._compare_conv(
             (1, 3, 224, 224), (64, 3, 7, 7),
@@ -116,19 +114,13 @@ class TestHipdnnConvolution(TestCase):
             dtype=torch.float32,
         )
 
-    @unittest.expectedFailure
     def test_conv2d_bf16(self):
         self._compare_conv(
-            (2, 64, 32, 32), (128, 64, 3, 3),
+            (2, 8, 32, 32), (16, 8, 3, 3),
             bias=False, stride=1, padding=1, dilation=1, groups=1,
             dtype=torch.bfloat16,
         )
 
-    # -----------------------------------------------------------------------
-    # xfail: bias — hipDNN plugin requires conv+bias+activ (3-node graph),
-    # conv+bias alone (2-node) is not supported
-    # -----------------------------------------------------------------------
-    @unittest.expectedFailure
     def test_conv2d_bias_fp32(self):
         self._compare_conv(
             (2, 64, 32, 32), (128, 64, 3, 3),
@@ -136,18 +128,13 @@ class TestHipdnnConvolution(TestCase):
             dtype=torch.float32,
         )
 
-    @unittest.expectedFailure
     def test_conv2d_bias_fp16(self):
         self._compare_conv(
-            (2, 64, 32, 32), (128, 64, 3, 3),
+            (2, 8, 32, 32), (16, 8, 3, 3),
             bias=True, stride=1, padding=1, dilation=1, groups=1,
             dtype=torch.float16,
         )
 
-    # -----------------------------------------------------------------------
-    # xfail: transposed conv — correctness bug in forward (uses dgrad path)
-    # -----------------------------------------------------------------------
-    @unittest.expectedFailure
     def test_conv_transpose2d_fp32(self):
         self._compare_conv(
             (2, 128, 16, 16), (128, 64, 3, 3),
@@ -155,10 +142,6 @@ class TestHipdnnConvolution(TestCase):
             dtype=torch.float32, transposed=True, output_padding=1,
         )
 
-    # -----------------------------------------------------------------------
-    # skip: GPU memory fault (unsupported config)
-    # -----------------------------------------------------------------------
-    @unittest.skip("GPU memory fault — depthwise not supported by hipDNN")
     def test_conv2d_depthwise(self):
         self._compare_conv(
             (2, 128, 32, 32), (128, 1, 3, 3),

--- a/test/test_hipdnn_conv.py
+++ b/test/test_hipdnn_conv.py
@@ -1,0 +1,171 @@
+# Owner(s): ["module: rocm"]
+
+import unittest
+
+import torch
+import torch.nn.functional as F
+from torch.testing._internal.common_cuda import TEST_HIPDNN
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+@unittest.skipIf(not TEST_HIPDNN, "hipDNN not available")
+class TestHipdnnConvolution(TestCase):
+
+    def _compare_conv(
+        self,
+        x_shape,
+        w_shape,
+        bias,
+        stride,
+        padding,
+        dilation,
+        groups,
+        dtype,
+        transposed=False,
+        output_padding=0,
+    ):
+        atol, rtol = (1e-4, 1e-4) if dtype == torch.float32 else (5e-2, 5e-2)
+
+        x_cpu = torch.randn(*x_shape, dtype=torch.float32, requires_grad=True)
+        w_cpu = torch.randn(*w_shape, dtype=torch.float32, requires_grad=True)
+        b_cpu = torch.randn(w_shape[1] if transposed else w_shape[0],
+                            dtype=torch.float32, requires_grad=True) if bias else None
+
+        conv_fn = F.conv_transpose2d if transposed else F.conv2d
+        kwargs = dict(stride=stride, padding=padding, dilation=dilation, groups=groups)
+        if transposed:
+            kwargs["output_padding"] = output_padding
+
+        out_cpu = conv_fn(x_cpu, w_cpu, b_cpu, **kwargs)
+        out_cpu.sum().backward()
+
+        x_gpu = x_cpu.detach().to(device="cuda", dtype=dtype).requires_grad_(True)
+        w_gpu = w_cpu.detach().to(device="cuda", dtype=dtype).requires_grad_(True)
+        b_gpu = b_cpu.detach().to(device="cuda", dtype=dtype).requires_grad_(True) if bias else None
+
+        with torch.backends.hipdnn.flags(enabled=True):
+            out_gpu = conv_fn(x_gpu, w_gpu, b_gpu, **kwargs)
+            out_gpu.sum().backward()
+
+        self.assertEqual(out_cpu.float(), out_gpu.float().cpu(), atol=atol, rtol=rtol)
+        self.assertEqual(x_cpu.grad.float(), x_gpu.grad.float().cpu(), atol=atol, rtol=rtol)
+        self.assertEqual(w_cpu.grad.float(), w_gpu.grad.float().cpu(), atol=atol, rtol=rtol)
+        if bias:
+            self.assertEqual(b_cpu.grad.float(), b_gpu.grad.float().cpu(), atol=atol, rtol=rtol)
+
+    # -----------------------------------------------------------------------
+    # Passing: basic configs (stride=1, groups=1)
+    # -----------------------------------------------------------------------
+    def test_conv2d_fp32(self):
+        self._compare_conv(
+            (2, 64, 32, 32), (128, 64, 3, 3),
+            bias=False, stride=1, padding=1, dilation=1, groups=1,
+            dtype=torch.float32,
+        )
+
+    def test_conv2d_fp16(self):
+        self._compare_conv(
+            (2, 64, 32, 32), (128, 64, 3, 3),
+            bias=False, stride=1, padding=1, dilation=1, groups=1,
+            dtype=torch.float16,
+        )
+
+    def test_conv2d_dilation(self):
+        self._compare_conv(
+            (2, 64, 32, 32), (128, 64, 3, 3),
+            bias=False, stride=1, padding=2, dilation=2, groups=1,
+            dtype=torch.float32,
+        )
+
+    def test_backend_selection(self):
+        x = torch.randn(2, 64, 32, 32, device="cuda")
+        w = torch.randn(128, 64, 3, 3, device="cuda")
+
+        with torch.backends.hipdnn.flags(enabled=True):
+            out_hipdnn = F.conv2d(x, w, padding=1)
+
+        with torch.backends.hipdnn.flags(enabled=False):
+            out_miopen = F.conv2d(x, w, padding=1)
+
+        self.assertEqual(out_hipdnn, out_miopen, atol=1e-4, rtol=1e-4)
+
+    # -----------------------------------------------------------------------
+    # xfail: backward broken for stride>1, groups>1, large kernels
+    # -----------------------------------------------------------------------
+    @unittest.expectedFailure
+    def test_conv2d_stride2(self):
+        self._compare_conv(
+            (2, 64, 32, 32), (128, 64, 3, 3),
+            bias=False, stride=2, padding=1, dilation=1, groups=1,
+            dtype=torch.float32,
+        )
+
+    @unittest.expectedFailure
+    def test_conv2d_grouped(self):
+        self._compare_conv(
+            (2, 128, 32, 32), (128, 32, 3, 3),
+            bias=False, stride=1, padding=1, dilation=1, groups=4,
+            dtype=torch.float32,
+        )
+
+    @unittest.expectedFailure
+    def test_conv2d_resnet_first_layer(self):
+        self._compare_conv(
+            (1, 3, 224, 224), (64, 3, 7, 7),
+            bias=False, stride=2, padding=3, dilation=1, groups=1,
+            dtype=torch.float32,
+        )
+
+    @unittest.expectedFailure
+    def test_conv2d_bf16(self):
+        self._compare_conv(
+            (2, 64, 32, 32), (128, 64, 3, 3),
+            bias=False, stride=1, padding=1, dilation=1, groups=1,
+            dtype=torch.bfloat16,
+        )
+
+    # -----------------------------------------------------------------------
+    # xfail: bias — hipDNN plugin requires conv+bias+activ (3-node graph),
+    # conv+bias alone (2-node) is not supported
+    # -----------------------------------------------------------------------
+    @unittest.expectedFailure
+    def test_conv2d_bias_fp32(self):
+        self._compare_conv(
+            (2, 64, 32, 32), (128, 64, 3, 3),
+            bias=True, stride=1, padding=1, dilation=1, groups=1,
+            dtype=torch.float32,
+        )
+
+    @unittest.expectedFailure
+    def test_conv2d_bias_fp16(self):
+        self._compare_conv(
+            (2, 64, 32, 32), (128, 64, 3, 3),
+            bias=True, stride=1, padding=1, dilation=1, groups=1,
+            dtype=torch.float16,
+        )
+
+    # -----------------------------------------------------------------------
+    # xfail: transposed conv — correctness bug in forward (uses dgrad path)
+    # -----------------------------------------------------------------------
+    @unittest.expectedFailure
+    def test_conv_transpose2d_fp32(self):
+        self._compare_conv(
+            (2, 128, 16, 16), (128, 64, 3, 3),
+            bias=False, stride=2, padding=1, dilation=1, groups=1,
+            dtype=torch.float32, transposed=True, output_padding=1,
+        )
+
+    # -----------------------------------------------------------------------
+    # skip: GPU memory fault (unsupported config)
+    # -----------------------------------------------------------------------
+    @unittest.skip("GPU memory fault — depthwise not supported by hipDNN")
+    def test_conv2d_depthwise(self):
+        self._compare_conv(
+            (2, 128, 32, 32), (128, 1, 3, 3),
+            bias=False, stride=1, padding=1, dilation=1, groups=128,
+            dtype=torch.float32,
+        )
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/test_hipdnn_conv.py
+++ b/test/test_hipdnn_conv.py
@@ -149,6 +149,13 @@ class TestHipdnnConvolution(TestCase):
             dtype=torch.float32, transposed=True, output_padding=0,
         )
 
+    def test_conv_transpose2d_bias(self):
+        self._compare_conv(
+            (2, 128, 16, 16), (128, 64, 3, 3),
+            bias=True, stride=2, padding=1, dilation=1, groups=1,
+            dtype=torch.float32, transposed=True, output_padding=1,
+        )
+
     def test_conv2d_depthwise(self):
         self._compare_conv(
             (2, 128, 32, 32), (128, 1, 3, 3),

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -2546,7 +2546,9 @@ Call this whenever a new thread is created in order to propagate values from
           "Winograd3x3Depthwise", at::native::ConvBackend::Winograd3x3Depthwise)
       .value("Xnnpack2d", at::native::ConvBackend::Xnnpack2d)
       .value("Mps", at::native::ConvBackend::Mps)
-      .value("MpsTranspose,", at::native::ConvBackend::MpsTranspose);
+      .value("MpsTranspose,", at::native::ConvBackend::MpsTranspose)
+      .value("Hipdnn", at::native::ConvBackend::Hipdnn)
+      .value("HipdnnTranspose", at::native::ConvBackend::HipdnnTranspose);
 
   py_module.def(
       "_select_conv_backend",


### PR DESCRIPTION
Implements forward and backward convolution (2D/3D) through the hipDNN frontend graph API, providing an alternative to the MIOpen backend on ROCm.

- **Shared utilities**: Extract `createTensorAttributes()` into `ATen/hipdnn/Utils.h` for reuse across hipDNN ops (BatchNorm, Conv)
- **Graph-cached convolution**: Forward (fprop), backward-data (dgrad), and backward-weight (wgrad) via hipDNN frontend graphs with a thread-local LRU cache (`ParamsLRUCache<K,V>`) to amortize `graph->build()` cost
- **Dispatch integration**: New `ConvBackend::Hipdnn` and `ConvBackend::HipdnnTranspose` variants wired through backend selection, memory format selection, forward/backward switches, and Python enum exposure. hipDNN takes priority over MIOpen when `torch.backends.hipdnn.enabled` is `True`
- **Bias fusion**: Forward conv fuses bias via a pointwise ADD node in the graph, avoiding a separate `output.add_()` call
- **Transposed convolution**: Implemented as dgrad (forward) / fprop (backward-input) / wgrad (backward-weight), with bias applied separately (for now) since dgrad + pointwise graphs aren't supported by any hipDNN backends currently.
- **Grouped/depthwise support**: hipDNN infers group count from tensor dimensions; explicit output dims are set on dgrad/wgrad graphs so grouping is resolved correctly
