### PR TITLE
[release/2.10] Use FP32 as reference for max_autotune tests (#169830)

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -85,7 +85,17 @@ from torch.testing._internal.inductor_utils import (
 )
 
 
-torch.set_float32_matmul_precision("high")
+if torch.version.hip:
+    # Temporary addition to ensure inductor tests can be
+    # enabled. Currently TF32 accuracy issues cause these tests
+    # to fail. We will use FP32 as reference to ensure the generated
+    # triton kernels are adequately tested.
+    #
+    # Track in: https://github.com/pytorch/pytorch/issues/169392
+    torch.set_float32_matmul_precision("highest")
+else:
+    torch.set_float32_matmul_precision("high")
+
 if HAS_CUDA_AND_TRITON:
     torch.cuda.memory._set_allocator_settings("expandable_segments:False")
 


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/162121

    # Temporary addition to ensure inductor tests can be
    # enabled. Currently TF32 accuracy issues cause these tests
    # to fail. We will use FP32 as reference to ensure the generated
    # triton kernels are adequately tested.
    #
    # Track in: https://github.com/pytorch/pytorch/issues/169392

Pull Request resolved: https://github.com/pytorch/pytorch/pull/169830
Approved by: https://github.com/jeffdaily