### PR TITLE
[Release/2.10] No-fence in normalization kernel (#175286)

### DIFF
--- a/aten/src/ATen/native/cuda/KernelUtils.cuh
+++ b/aten/src/ATen/native/cuda/KernelUtils.cuh
@@ -224,7 +224,9 @@ __device__ __forceinline__ void fastAtomicAdd(
 // This function implements a committed store.
 // Upon returning, the store is committed to global memory.
 // This is useful in avoiding the need for fences.
-template <typename T>
+// If multiple stores are done in a row there is option to skip
+// waiting for commit for all but the last store.
+template <typename T, bool wait_for_commit = true>
 __device__ inline void cmtdStore(void* address, T value) {
       int constexpr num_long_per_val = sizeof(value)/sizeof(long);
       int constexpr num_int_per_val = sizeof(value)/sizeof(int);
@@ -248,9 +250,16 @@ __device__ inline void cmtdStore(void* address, T value) {
       else if constexpr (num_char_per_val*sizeof(char) == sizeof(value))
         for (int i=0; i<num_char_per_val; i++)
           __hip_atomic_store(reinterpret_cast<char *>(address)+i, _pnr.c[i], __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-      __atomic_signal_fence(__ATOMIC_SEQ_CST);
-      asm volatile("s_waitcnt vmcnt(0)" ::: "memory");
-      __atomic_signal_fence(__ATOMIC_SEQ_CST);
+      if constexpr (wait_for_commit)
+      {
+        __atomic_signal_fence(__ATOMIC_SEQ_CST);
+#ifdef __gfx1250__
+        asm volatile("s_wait_loadcnt(0)" ::: "memory");
+#else
+        asm volatile("s_waitcnt vmcnt(0)" ::: "memory");
+#endif
+        __atomic_signal_fence(__ATOMIC_SEQ_CST);
+      }
 }
 #endif
 

--- a/aten/src/ATen/native/cuda/Normalization.cuh
+++ b/aten/src/ATen/native/cuda/Normalization.cuh
@@ -8,6 +8,7 @@
 #include <ATen/cuda/DeviceUtils.cuh>
 #include <ATen/native/cuda/block_reduce.cuh>
 #include <ATen/native/cuda/DeviceSqrt.cuh>
+#include <ATen/native/cuda/KernelUtils.cuh>
 #include <ATen/native/cuda/LaunchUtils.h>
 #include <c10/macros/Macros.h>
 
@@ -1063,12 +1064,22 @@ batch_norm_collect_statistics_channels_last_kernel(
     address_base = c_offset + blockIdx.y * stride;
     // write data to staging_data;
     if (threadIdx.y == 0 && c_offset < stride) {
+#ifndef USE_ROCM
       staging_mean[address_base] = mean_th;
       staging_m2n[address_base] = m2_th;
       staging_count[address_base] = count_th;
+#else
+      // In architectures with split caches, global fences are costly.
+      // Here we preempt need for fences by committing stores to global memory.
+      cmtdStore<accscalar_t, false>((void*)&staging_mean[address_base], mean_th);
+      cmtdStore<accscalar_t, false>((void*)&staging_m2n[address_base], m2_th);
+      cmtdStore((void*)&staging_count[address_base], count_th);
+#endif
     }
 
+#ifndef USE_ROCM
     __threadfence();
+#endif
     __syncthreads(); // ensuring writes to staging_ is visible to all blocks
 
     __shared__ bool is_last_block_done;
@@ -1288,11 +1299,20 @@ __global__ void batch_norm_backward_reduce_channels_last_kernel(
     address_base = c_offset + blockIdx.y * stride;
     // write data to staging_data;
     if (threadIdx.y == 0 && c_offset < stride) {
+#ifndef USE_ROCM
       staging_sum_dy[address_base] = sum_dy_th;
       staging_sum_dy_xmu[address_base] = sum_dy_xmu_th;
+#else
+      // In architectures with split caches, global fences are costly.
+      // Here we preempt need for fences by committing stores to global memory.
+      cmtdStore<accscalar_t, false>((void*)&staging_sum_dy[address_base], sum_dy_th);
+      cmtdStore((void*)&staging_sum_dy_xmu[address_base], sum_dy_xmu_th);
+#endif
     }
 
+#ifndef USE_ROCM
     __threadfence();
+#endif
     __syncthreads(); // ensuring writes to staging_ is visible to all blocks
 
     __shared__ bool is_last_block_done;


### PR DESCRIPTION
Removing need for fences in normalization kernel by converting the stores into atomics+return. This is crucial for perf in architectures with split caches (e.g. MI300), where fences are inherently costly. This change speedups `batch_norm_stats ` function for tensors in `channels_last` format. <img width="2311" height="1537" alt="batchnorm_latency_comparison" src="https://github.com/user-attachments/assets/dee39088-9f55-499a-a39b-b170805416bb" />

**Particular Example:**
Before:
Avg time for shape (20, 896, 59, 91): **1102.39 us**

After:
Avg time for shape (20, 896, 59, 91): **122.94 us**

Reproducer:
```

import torch

shapes = [(20, 896, 59, 91)]

eps = 1e-5

for shape in shapes:
    x = torch.randn(shape, device='cuda', dtype=torch.bfloat16)
    x = x.to(memory_format=torch.channels_last)
    for _ in range(20):
        _ = torch.batch_norm_stats(x, eps)
    torch.cuda.synchronize()

    start_evt = torch.cuda.Event(enable_timing=True)
    end_evt = torch.cuda.Event(enable_timing=True)
    start_evt.record()
    for _ in range(100):
        _ = torch.batch_norm_stats(x, eps)
    end_evt.record()
    torch.cuda.synchronize()
    print(f"Avg time for shape {shape}: {start_evt.elapsed_time(end_evt) / 100 * 1e3:.2f} us")

```

Related fix which is released: https://github.com/pytorch/pytorch/pull/161180

Pull Request resolved: https://github.com/pytorch/pytorch/pull/175286
Approved by: https://github.com/amd-hhashemi, https://github.com/jerrymannil, https://github.com/jeffdaily

