### PR TITLE
fix hpdnn batchnorm decomp

### DIFF
--- a/test/expect/HasDecompTest.test_has_decomposition.expect
+++ b/test/expect/HasDecompTest.test_has_decomposition.expect
@@ -864,6 +864,8 @@ aten::hardshrink_backward
 aten::hardshrink_backward.grad_input
 aten::hash_tensor
 aten::hash_tensor.out
+aten::hipdnn_batch_norm
+aten::hipdnn_batch_norm.out
 aten::histc
 aten::histc.out
 aten::histogram.bin_ct

--- a/torch/_decomp/__init__.py
+++ b/torch/_decomp/__init__.py
@@ -335,6 +335,7 @@ def _core_aten_decompositions_post_autograd() -> dict[
             aten.cudnn_batch_norm,
             aten.cudnn_batch_norm_backward,
             aten.miopen_batch_norm_backward,
+            aten.hipdnn_batch_norm_backward,
             aten.deg2rad,
             aten.deg2rad_,
             aten.detach,

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -2604,6 +2604,31 @@ def miopen_batch_norm_backward(
         [True, True, True],
     )
 
+@register_decomposition(aten.hipdnn_batch_norm_backward)
+@out_wrapper("out0", "out1", "out2")
+def hipdnn_batch_norm_backward(
+    input: Tensor,
+    grad_output: Tensor,
+    weight: Tensor,
+    running_mean: Tensor | None,
+    running_var: Tensor | None,
+    save_mean: Tensor | None,
+    save_var: Tensor | None,
+    epsilon: float,
+):
+    return aten.native_batch_norm_backward(
+        grad_output,
+        input,
+        weight,
+        running_mean,
+        running_var,
+        save_mean,
+        save_var,
+        True,
+        epsilon,
+        [True, True, True],
+    )
+
 
 @register_decomposition(aten.cudnn_batch_norm_backward)
 @out_wrapper("out0", "out1", "out2")

--- a/torch/_decomp/decompositions_for_jvp.py
+++ b/torch/_decomp/decompositions_for_jvp.py
@@ -342,3 +342,4 @@ _register_jit_decomposition_for_jvp(torch.ops.aten.native_batch_norm_backward.de
 _register_jit_decomposition_for_jvp(torch.ops.aten.cudnn_batch_norm_backward.default)
 _register_jit_decomposition_for_jvp(torch.ops.aten.batch_norm_backward.default)
 _register_jit_decomposition_for_jvp(torch.ops.aten.miopen_batch_norm_backward.default)
+_register_jit_decomposition_for_jvp(torch.ops.aten.hipdnn_batch_norm_backward.default)


### PR DESCRIPTION
Decomposition for hipdnn_batch_norm
Fixes `test_decomp.py::HasDecompTest::test_has_decomposition`
Based on https://github.com/pytorch/pytorch/pull/125069
