### PR TITLE
[release/2.10] Skip linalg.eig tests when MAGMA is not available

### DIFF
--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -5051,6 +5051,7 @@ class TestVmapOperatorsOpInfo(TestCase):
 
         test(self, op, tuple(inputs), in_dims=tuple(in_dims))
 
+    @skipCUDAIfNoMagma
     def test_torch_return_types_returns(self, device):
         t = torch.randn(3, 2, 2, device=device)
         self.assertTrue(

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -6005,6 +6005,7 @@ class CommonTemplate:
             reference_in_float=False,
         )
 
+    @skipCUDAIfNoMagma
     @skipIfMPS
     def test_linalg_eig_stride_consistency(self):
         def fn(x):


### PR DESCRIPTION
Skip test_linalg_eig_stride_consistency_cuda & test_torch_return_types_returns_cuda as they are incorrectly running when MAGMA is not available.