### PR TITLE
[release/2.9] Skip linalg.eig tests when MAGMA is not available

### DIFF
--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -58,6 +58,7 @@ from torch.testing._internal.common_device_type import (
     onlyCUDA,
     OpDTypes,
     ops,
+    skipCUDAIfNoMagma,
     tol,
     toleranceOverride,
 )
@@ -5042,6 +5043,7 @@ class TestVmapOperatorsOpInfo(TestCase):
 
         test(self, op, tuple(inputs), in_dims=tuple(in_dims))
 
+    @skipCUDAIfNoMagma
     def test_torch_return_types_returns(self, device):
         t = torch.randn(3, 2, 2, device=device)
         self.assertTrue(


### PR DESCRIPTION
Skip test_linalg_eig_stride_consistency_cuda & test_torch_return_types_returns_cuda as they are incorrectly running when MAGMA is not available.