### PR TITLE
Prefer cublas when TORCH_BLAS_PREFER_CUBLASLT is false (#https://github.com/pytorch/pytorch/pull/174377)

### DIFF
--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -502,7 +502,11 @@ class TORCH_API Context {
       (c10::utils::check_env("TORCH_BLAS_PREFER_CUBLASLT") == true ||
        c10::utils::check_env("TORCH_BLAS_PREFER_HIPBLASLT") == true) // alias
       ? at::BlasBackend::Cublaslt
-      : at::BlasBackend::Default;
+      : ((c10::utils::check_env("TORCH_BLAS_PREFER_CUBLASLT") == false ||
+          c10::utils::check_env("TORCH_BLAS_PREFER_HIPBLASLT") ==
+              false) // alias
+             ? at::BlasBackend::Cublas
+             : at::BlasBackend::Default);
   at::ROCmFABackend rocm_fa_preferred_backend =
       c10::utils::check_env("TORCH_ROCM_FA_PREFER_CK") == true
       ? at::ROCmFABackend::Ck

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -660,11 +660,13 @@ print(t.is_pinned())
             torch.backends.cuda.preferred_blas_library(1.0)
         # check env var override
         custom_envs = [
-            {"TORCH_BLAS_PREFER_CUBLASLT": "1"},
-            {"TORCH_BLAS_PREFER_HIPBLASLT": "1"},
+            ({"TORCH_BLAS_PREFER_CUBLASLT": "1"}, "_BlasBackend.Cublaslt"),
+            ({"TORCH_BLAS_PREFER_HIPBLASLT": "1"}, "_BlasBackend.Cublaslt"),
+            ({"TORCH_BLAS_PREFER_CUBLASLT": "0"}, "_BlasBackend.Cublas"),
+            ({"TORCH_BLAS_PREFER_HIPBLASLT": "0"}, "_BlasBackend.Cublas"),
         ]
         test_script = "import torch;print(torch.backends.cuda.preferred_blas_library())"
-        for env_config in custom_envs:
+        for env_config, expected in custom_envs:
             env = os.environ.copy()
             for key, value in env_config.items():
                 env[key] = value
@@ -673,7 +675,15 @@ print(t.is_pinned())
                 .decode("ascii")
                 .strip()
             )
-            self.assertEqual("_BlasBackend.Cublaslt", r)
+            self.assertEqual(expected, r)
+
+        # explicitly check default when no env vars are set
+        if not any(
+            os.environ.get(v)
+            for v in ("TORCH_BLAS_PREFER_CUBLASLT", "TORCH_BLAS_PREFER_HIPBLASLT")
+        ):
+            torch.backends.cuda.preferred_blas_library("default")
+            _check_default()
 
     @unittest.skipIf(TEST_CUDAMALLOCASYNC, "temporarily disabled for async")
     @setBlasBackendsToDefaultFinally


### PR DESCRIPTION
### Summary

Set blas_preferred_backend = at::BlasBackend::Cublas when TORCH_BLAS_PREFER_CUBLASLT / TORCH_BLAS_PREFER_HIPBLASLT is explicitly set to false.

For ROCm, if a gfx arch is in the list returned by getHipblasltPreferredArchs() hipBLASLt will be set as blas_preferred_backend by default regardless of TORCH_BLAS_PREFER_HIPBLASLT setting. This PR enables users to explicitly select cublas/rocblas and makes this env. variable behave like a binary toggle.

### Changes

- Modified checks for TORCH_BLAS_PREFER_CUBLASLT/TORCH_BLAS_PREFER_HIPBLASLT env. variables
- Updated test_preferred_blas_library_settings Pull Request resolved: https://github.com/pytorch/pytorch/pull/174377 Approved by: https://github.com/jeffdaily, https://github.com/nikitaved


Cherry-picked to release/2.10 branch via https://github.com/ROCm/pytorch/pull/3078