### PR TITLE
[ROCm] Update test env according aotriton 0.11.1b release (#171293)

### DIFF
--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -60,9 +60,9 @@ def CDNA2OrLater():
 
 def evaluate_platform_supports_flash_attention():
     if TEST_WITH_ROCM:
-        arch_list = ["gfx90a", "gfx942", "gfx1201", "gfx950"]
+        arch_list = ["gfx90a", "gfx942", "gfx1100", "gfx1201", "gfx950"]
         if os.environ.get("TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL", "0") != "0":
-            arch_list += ["gfx1100", "gfx1101", "gfx1102", "gfx1150", "gfx1151", "gfx1200"]
+            arch_list += ["gfx1101", "gfx1102", "gfx1150", "gfx1151", "gfx1200"]
         return evaluate_gfx_arch_within(arch_list)
     if TEST_CUDA:
         return not IS_WINDOWS and SM80OrLater
@@ -70,9 +70,9 @@ def evaluate_platform_supports_flash_attention():
 
 def evaluate_platform_supports_efficient_attention():
     if TEST_WITH_ROCM:
-        arch_list = ["gfx90a", "gfx942", "gfx1201", "gfx950"]
+        arch_list = ["gfx90a", "gfx942", "gfx1100", "gfx1201", "gfx950"]
         if os.environ.get("TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL", "0") != "0":
-            arch_list += ["gfx1100", "gfx1101", "gfx1102", "gfx1150", "gfx1151", "gfx1200"]
+            arch_list += ["gfx1101", "gfx1102", "gfx1150", "gfx1151", "gfx1200"]
         return evaluate_gfx_arch_within(arch_list)
     if TEST_CUDA:
         return True


### PR DESCRIPTION
In commit https://github.com/pytorch/pytorch/pull/169696, gfx1100 is fully supported again without the experimental flag, but the fix for the test environment in torch/testing/_internal/common_cuda.py was missed.

Fixes for testcase:
```
PYTORCH_TEST_WITH_ROCM=1 python test/test_ops.py -v
TestCompositeComplianceCUDA.test_cow_input_nn_functional_scaled_dot_product_attention_cuda_float32
```

Pull Request resolved: https://github.com/pytorch/pytorch/pull/171293
Approved by: https://github.com/jeffdaily

(cherry picked from commit 09e74ab2d12ceceb1476501638b8b6296a71129e)