### PR TITLE
[release/2.10] Fix linalg.eig skip in test_torchinductor.py

### DIFF
--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -71,6 +71,7 @@ from torch.testing._internal.common_utils import (
     run_tests,
     skipIfTorchDynamo,
     subtest,
+    TEST_WITH_ROCM,
     TEST_WITH_TORCHDYNAMO,
     TestCase,
     unMarkDynamoStrictTest,
@@ -5051,7 +5052,10 @@ class TestVmapOperatorsOpInfo(TestCase):
 
         test(self, op, tuple(inputs), in_dims=tuple(in_dims))
 
-    @skipCUDAIfNoMagma
+    @unittest.skipIf(
+        TEST_WITH_ROCM and not torch.cuda.has_magma,
+        "ROCm hipsolver backend does not currently support eig",
+    )
     def test_torch_return_types_returns(self, device):
         t = torch.randn(3, 2, 2, device=device)
         self.assertTrue(

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -6005,7 +6005,10 @@ class CommonTemplate:
             reference_in_float=False,
         )
 
-    @skipCUDAIfNoMagma
+    @unittest.skipIf(
+        TEST_WITH_ROCM and not torch.cuda.has_magma,
+        "ROCm hipsolver backend does not currently support eig",
+    )
     @skipIfMPS
     def test_linalg_eig_stride_consistency(self):
         def fn(x):


### PR DESCRIPTION
Local testing shows that 
```
PYTORCH_TEST_WITH_ROCM=1 python -m pytest /var/lib/jenkins/pytorch/test/functorch/test_vmap.py::TestVmapOperatorsOpInfoCUDA::test_torch_return_types_returns_cuda -v
PYTORCH_TEST_WITH_ROCM=1 python -m pytest /var/lib/jenkins/pytorch/test/inductor/test_torchinductor.py -k test_linalg_eig_stride_consistency_cuda -v
========================================================= test session starts ==========================================================
platform linux -- Python 3.13.12, pytest-7.3.2, pluggy-1.6.0 -- /opt/venv/bin/python
cachedir: .pytest_cache
hypothesis profile 'dev' -> database=None, max_examples=10, suppress_health_check=[HealthCheck.too_slow]
rootdir: /var/lib/jenkins/pytorch
configfile: pytest.ini
plugins: flakefinder-1.1.0, xdoctest-1.3.0, hypothesis-6.56.4, subtests-0.13.1, rerunfailures-14.0, cpp-2.3.0, xdist-3.3.1
collected 1 item
Running 1 items in this shard

../var/lib/jenkins/pytorch/test/functorch/test_vmap.py::TestVmapOperatorsOpInfoCUDA::test_torch_return_types_returns_cuda SKIPPED [0.0011s] [100%]

========================================================== 1 skipped in 3.61s ==========================================================
========================================================= test session starts ==========================================================
platform linux -- Python 3.13.12, pytest-7.3.2, pluggy-1.6.0 -- /opt/venv/bin/python
cachedir: .pytest_cache
hypothesis profile 'dev' -> database=None, max_examples=10, suppress_health_check=[HealthCheck.too_slow]
rootdir: /var/lib/jenkins/pytorch
configfile: pytest.ini
plugins: flakefinder-1.1.0, xdoctest-1.3.0, hypothesis-6.56.4, subtests-0.13.1, rerunfailures-14.0, cpp-2.3.0, xdist-3.3.1
collected 1967 items / 1966 deselected / 1 selected
Running 1 items in this shard

../var/lib/jenkins/pytorch/test/inductor/test_torchinductor.py::GPUTests::test_linalg_eig_stride_consistency_cuda SKIPPED [0.0010s] [100%]

================================================= 1 skipped, 1966 deselected in 6.74s ==================================================
```

Tests skip. PR https://github.com/ROCm/pytorch/pull/3070 incorrectly pulled in skipCUDAIfNoMagma without importing first. 