### PR TITLE
Fix preffered blas backend test

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -625,7 +625,7 @@ print(t.is_pinned())
                 gcn_arch = str(
                     torch.cuda.get_device_properties(0).gcnArchName.split(":", 1)[0]
                 )
-                if gcn_arch in ["gfx90a", "gfx942", "gfx950", "gfx1200", "gfx1201"]:
+                if gcn_arch in ["gfx90a", "gfx942", "gfx950", "gfx1100", "gfx1101", "gfx1102", "gfx1150", "gfx1151", "gfx1200", "gfx1201"]:
                     self.assertTrue(default == torch._C._BlasBackend.Cublaslt)
                 else:
                     self.assertTrue(default == torch._C._BlasBackend.Cublas)


### PR DESCRIPTION
## Motivation

After adding the following targets: gfx1100, gfx1101, gfx1150 and gfx1151 to preffered hipBLASLt backend list, the test hasn't been properly updated, resulting in failure on these achitectures. This PR only updates the test.


## Test Plan

Running python test/test_cuda.py TestCuda.test_preferred_blas_library_settings
