### PR TITLE
[CI][release/2.11]Pin all Python dependency versions in requirements files

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -15,13 +15,13 @@ build==1.3.0
 #Pinned versions: 1.3.0
 #test that import:
 
-click
+click==8.3.1
 #Description: Command Line Interface Creation Kit
-#Pinned versions:
+#Pinned versions: 8.3.1
 #test that import:
 
 coremltools==5.0b5 ; python_version < "3.12"
-coremltools==8.3 ; python_version == "3.12"
+coremltools==8.3.0 ; python_version == "3.12"
 #Description: Apple framework for ML integration
 #Pinned versions: 5.0b5
 #test that import:
@@ -68,7 +68,7 @@ lark==0.12.0
 #Pinned versions: 0.12.0
 #test that import:
 
-librosa>=0.6.2 ; python_version < "3.11" and platform_machine != "s390x"
+librosa==0.10.2 ; python_version < "3.11" and platform_machine != "s390x"
 librosa==0.10.2 ; python_version == "3.12" and platform_machine != "s390x"
 #Description: A python package for music and audio analysis
 #Pinned versions: >=0.6.2
@@ -149,9 +149,9 @@ pandas==2.3.3; python_version >= "3.14"
 #Pinned versions: 1.9.0
 #test that import:
 
-opt-einsum==3.3
+opt-einsum==3.3.0
 #Description: Python library to optimize tensor contraction order, used in einsum
-#Pinned versions: 3.3
+#Pinned versions: 3.3.0
 #test that import: test_linalg.py
 
 optree==0.13.0 ; python_version < "3.14"
@@ -178,9 +178,9 @@ protobuf==6.33.5
 #Pinned versions: 6.33.2
 #test that import: test_tensorboard.py, test/onnx/*
 
-psutil
+psutil==7.2.2
 #Description: information on running processes and system utilization
-#Pinned versions:
+#Pinned versions: 7.2.2
 #test that import: test_profiler.py, test_openmp.py, test_dataloader.py
 
 pytest==7.3.2
@@ -198,9 +198,9 @@ pytest-flakefinder==1.1.0
 #Pinned versions: 1.1.0
 #test that import:
 
-pytest-rerunfailures>=10.3
+pytest-rerunfailures==14.0
 #Description: plugin for rerunning failure tests in pytest
-#Pinned versions:
+#Pinned versions: 14.0
 #test that import:
 
 pytest-subtests==0.13.1
@@ -270,8 +270,7 @@ scipy==1.16.2 ; python_version >= "3.14"
 #test that import:
 
 # needed by torchgen utils
-typing-extensions==4.12.2 ; python_version < "3.14"
-typing-extensions==4.15.0 ; python_version >= "3.14"
+typing-extensions==4.15.0
 #Description: type hints for python
 #Pinned versions:
 #test that import:
@@ -281,7 +280,7 @@ typing-extensions==4.15.0 ; python_version >= "3.14"
 #Pinned versions:
 #test that import:
 
-unittest-xml-reporting<=3.2.0,>=2.0.0
+unittest-xml-reporting==3.2.0
 #Description: saves unit test results to xml
 #Pinned versions:
 #test that import:
@@ -292,7 +291,7 @@ lintrunner==0.12.11
 #Pinned versions: 0.12.11
 #test that import:
 
-redis>=4.0.0
+redis==7.4.0
 #Description: redis database
 #test that import: anything that tests OSS caching/mocking (inductor/test_codecache.py, inductor/test_max_autotune.py)
 
@@ -370,10 +369,10 @@ pwlf==2.2.1
 
 # To build PyTorch itself
 pyyaml==6.0.3
-pyzstd
-setuptools==78.1.1
-packaging==24.0
-six
+pyzstd==0.16.2
+setuptools==79.0.1
+packaging==25.0
+six==1.17.0
 
 scons==4.5.2 ; platform_machine == "aarch64"
 
@@ -387,7 +386,7 @@ dataclasses_json==0.6.7
 #Pinned versions: 0.6.7
 #test that import:
 
-cmake==3.31.6
+cmake==4.0.0
 #Description: required for building
 
 tlparse==0.4.0
@@ -396,7 +395,7 @@ tlparse==0.4.0
 filelock==3.20.3
 #Description: required for inductor testing
 
-cuda-bindings>=12.0,<13.0 ; platform_machine != "s390x" and platform_system != "Darwin"
+cuda-bindings==12.9.6 ; platform_machine != "s390x" and platform_system != "Darwin"
 #Description: required for testing CUDAGraph::raw_cuda_graph(). See https://nvidia.github.io/cuda-python/cuda-bindings/latest/support.html for how this version was chosen. Note "Any fix in the latest bindings would be backported to the prior major version" means that only the newest version of cuda-bindings will get fixes. Depending on the latest version of 12.x is okay because all 12.y versions will be supported via "CUDA minor version compatibility". Pytorch builds against 13.z versions of cuda toolkit work with 12.x versions of cuda-bindings as well because newer drivers work with old toolkits.
 #test that import: test_cuda.py
 
@@ -406,7 +405,7 @@ pyre-extensions==0.0.32
 tabulate==0.9.0
 #Description: These package are needed to build FBGEMM and torchrec on PyTorch CI
 
-tqdm>=4.66.0
+tqdm==4.67.3
 #Description: progress bar library required for dynamo benchmarks
 #test that import: benchmarks/dynamo/*
 

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,11 +1,14 @@
 # Build System requirements
-setuptools>=70.1.0,<82
-cmake>=3.27
-ninja
-numpy
-packaging
-pyyaml
-requests
-six  # dependency chain: NNPACK -> PeachPy -> six
-typing-extensions>=4.15.0
-pip  # not technically needed, but this makes setup.py invocation work
+# setuptools and cmake pinned to match rocm/pytorch release/2.10:
+# https://github.com/ROCm/pytorch/blob/0b21eac93ff682d862b257770fff5f9fc069b30a/requirements-build.txt
+setuptools==79.0.1
+cmake==4.0.0
+ninja==1.11.1.4
+numpy==2.0.2 ; python_version == "3.9"
+numpy==2.1.2 ; python_version > "3.9"
+packaging==25.0
+pyyaml==6.0.3
+requests==2.32.5
+six==1.17.0  # dependency chain: NNPACK -> PeachPy -> six
+typing_extensions==4.15.0
+pip==26.0.1  # not technically needed, but this makes setup.py invocation work

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,19 +4,20 @@
 --requirement requirements-build.txt
 
 # Install / Development extra requirements
-build[uv]  # for building sdist and wheel
-expecttest>=0.3.0
-filelock
-fsspec>=0.8.5
-hypothesis
-jinja2
-lintrunner ; platform_machine != "s390x"
-networkx>=2.5.1
-ninja
+build[uv]==1.3.0  # for building sdist and wheel
+expecttest==0.3.0
+filelock==3.20.3
+fsspec==2026.2.0
+hypothesis==6.56.4
+jinja2==3.1.6
+lintrunner==0.12.11 ; platform_machine != "s390x"
+networkx==2.8.8
+ninja==1.11.1.4
 numpy==2.0.2 ; python_version == "3.9"
 numpy==2.1.2 ; python_version > "3.9"
-optree>=0.13.0
-psutil
-spin
-sympy>=1.13.3
-wheel
+optree==0.13.0 ; python_version < "3.14"
+optree==0.17.0 ; python_version >= "3.14"
+psutil==7.2.2
+spin==0.17
+sympy==1.13.3
+wheel==0.46.3


### PR DESCRIPTION
Pin dependencies in release/2.11. Tested and installed with python 3.10, 3.11, 3.12, 3.13. 

Build failed because triton requires cmake less than 4 which we fixed in release/2.10 with https://github.com/ROCm/triton/commit/8edc6c4f11ac73ec145e9a0dbe311b83d58d54d7

```
 #63 35.94 writing manifest file 'python/triton.egg-info/SOURCES.txt'
 #63 35.98 
 #63 35.98 ERROR Missing dependencies:
 #63 35.98 	cmake<4.0,>=3.20
 #63 35.98 ERROR conda.cli.main_run:execute(142): `conda run python -m build --wheel --no-isolation` failed. (See above for error)
 #63 ERROR: process "/bin/sh -c if [ -n \"${TRITON}\" ]; then bash ./install_triton.sh; fi" did not complete successfully: exit code: 1
 ------
  > [stage-0 55/62] RUN if [ -n "yes" ]; then bash ./install_triton.sh; fi:
 35.92 writing top-level names to python/triton.egg-info/top_level.txt
 35.92 writing manifest file 'python/triton.egg-info/SOURCES.txt'
 35.93 reading manifest file 'python/triton.egg-info/SOURCES.txt'
 35.93 reading manifest template 'MANIFEST.in'
 35.94 adding license file 'LICENSE'
 35.94 writing manifest file 'python/triton.egg-info/SOURCES.txt'
 35.98 
 35.98 ERROR Missing dependencies:
 35.98 	cmake<4.0,>=3.20
 35.98 ERROR conda.cli.main_run:execute(142): `conda run python -m build --wheel --no-isolation` failed. (See above for error)
 ------
 Dockerfile:122
 --------------------
  120 |     COPY ci_commit_pins/triton.txt triton.txt
  121 |     COPY triton_version.txt triton_version.txt
  122 | >>> RUN if [ -n "${TRITON}" ]; then bash ./install_triton.sh; fi
  123 |     RUN rm install_triton.sh common_utils.sh triton.txt triton_version.txt
```