### PR TITLE
[release/2.9] Fix numpy compatibility for Python 3.14 for 2.9

### DIFF
--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -2,7 +2,8 @@
 setuptools==79.0.1
 cmake==4.0.0
 ninja==1.11.1.3
-numpy==2.1.2
+numpy==2.1.2 ; python_version < "3.14"
+numpy>=2.3 ; python_version >= "3.14"
 packaging==25.0
 pyyaml==6.0.3
 requests==2.32.5

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -3,7 +3,7 @@ setuptools==79.0.1
 cmake==4.0.0
 ninja==1.11.1.3
 numpy==2.1.2 ; python_version < "3.14"
-numpy>=2.3 ; python_version >= "3.14"
+numpy==2.4.3 ; python_version >= "3.14"
 packaging==25.0
 pyyaml==6.0.3
 requests==2.32.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,8 @@ lintrunner==0.12.7 ; platform_machine != "s390x" and platform_machine != "riscv6
 networkx==2.8.8
 ninja==1.11.1.3
 numpy==2.0.2 ; python_version == "3.9"
-numpy==2.1.2 ; python_version > "3.9"
+numpy==2.1.2 ; python_version > "3.9" and python_version < "3.14"
+numpy>=2.3 ; python_version >= "3.14"
 optree==0.13.0
 psutil==7.1.0
 sympy==1.13.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ lintrunner==0.12.7 ; platform_machine != "s390x" and platform_machine != "riscv6
 networkx==2.8.8
 ninja==1.11.1.3
 numpy==2.0.2 ; python_version == "3.9"
-numpy==2.1.2 ; python_version > "3.9" and python_version < "3.14" and python_version < "3.14"
+numpy==2.1.2 ; python_version > "3.9" and python_version < "3.14"
 numpy==2.4.3 ; python_version >= "3.14"
 optree==0.13.0
 psutil==7.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,8 +14,8 @@ lintrunner==0.12.7 ; platform_machine != "s390x" and platform_machine != "riscv6
 networkx==2.8.8
 ninja==1.11.1.3
 numpy==2.0.2 ; python_version == "3.9"
-numpy==2.1.2 ; python_version > "3.9" and python_version < "3.14"
-numpy>=2.3 ; python_version >= "3.14"
+numpy==2.1.2 ; python_version > "3.9" and python_version < "3.14" and python_version < "3.14"
+numpy==2.4.3 ; python_version >= "3.14"
 optree==0.13.0
 psutil==7.1.0
 sympy==1.13.3


### PR DESCRIPTION
## Summary
- `numpy==2.1.2` has no cp314 wheels on PyPI, causing Python 3.14 builds in TheRock CI to fail with a meson/sccache error when pip falls back to building numpy from source
- Add `python_version` markers to use `numpy==2.4.3` for Python 3.14+, while keeping the existing `numpy==2.1.2` pin for older Python versions

## Motivation

- Failing: https://github.com/ROCm/TheRock/actions/runs/23488558012/job/68350335414

## Test Result

- https://github.com/ROCm/TheRock/actions/runs/23510885250/job/68431224030
- https://github.com/ROCm/TheRock/actions/runs/23516862647/job/68451235656 (latest)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
