### PR TITLE
[release/2.10] Fix numpy compatibility for Python 3.14 for 2.10

### DIFF
--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -3,7 +3,7 @@ setuptools==79.0.1
 cmake==4.0.0
 ninja==1.11.1.4
 numpy==2.1.2 ; python_version < "3.14"
-numpy>=2.3 ; python_version >= "3.14"
+numpy==2.4.3 ; python_version >= "3.14"
 packaging==25.0
 pyyaml==6.0.3
 requests==2.32.5

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -2,7 +2,8 @@
 setuptools==79.0.1
 cmake==4.0.0
 ninja==1.11.1.4
-numpy==2.1.2
+numpy==2.1.2 ; python_version < "3.14"
+numpy>=2.3 ; python_version >= "3.14"
 packaging==25.0
 pyyaml==6.0.3
 requests==2.32.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,8 @@ lintrunner==0.12.7 ; platform_machine != "s390x" and platform_machine != "riscv6
 networkx==2.8.8
 ninja==1.11.1.4
 numpy==2.0.2 ; python_version == "3.9"
-numpy==2.1.2 ; python_version > "3.9"
+numpy==2.1.2 ; python_version > "3.9" and python_version < "3.14"
+numpy==2.4.3 ; python_version >= "3.14"
 optree==0.13.0 ; python_version < "3.14"
 optree==0.17.0 ; python_version >= "3.14"
 psutil==7.2.2


### PR DESCRIPTION
## Summary
- `numpy==2.1.2` has no cp314 wheels on PyPI, causing Python 3.14 builds in TheRock CI to fail with a meson/sccache error when pip falls back to building numpy from source
- Add `python_version` markers to use `numpy==2.4.3` for Python 3.14+, while keeping the existing `numpy==2.1.2` pin for older Python versions

## Motivation

- Failing: https://github.com/ROCm/TheRock/actions/runs/23488558012/job/68350335718

## Test Result

- https://github.com/ROCm/TheRock/actions/runs/23511528510
- https://github.com/ROCm/TheRock/actions/runs/23516828149 ( latest )

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
