### PR TITLE
[release/2.10] Fix: python 3.14 numba and onnx versions

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -119,7 +119,8 @@ ninja==1.11.1.4
 
 numba==0.49.0 ; python_version < "3.9" and platform_machine != "s390x"
 numba==0.60.0 ; python_version == "3.9" and platform_machine != "s390x"
-numba==0.61.2 ; python_version > "3.9" and platform_machine != "s390x"
+numba==0.61.2 ; python_version > "3.9" and python_version < "3.14" and platform_machine != "s390x"
+numba==0.64.0 ; python_version >= "3.14" and platform_machine != "s390x"
 
 #Description: Just-In-Time Compiler for Numerical Functions
 #Pinned versions: 0.55.2, 0.60.0

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -339,8 +339,9 @@ sympy==1.13.3
 #test that import:
 
 onnx==1.19.1 ; python_version < "3.14"
-# Unpin once Python 3.14 is supported. See  onnxruntime issue 26309.
-onnx==1.18.0 ; python_version == "3.14"
+# onnx 1.20.1 uses abi3 stable ABI wheels (compatible with Python 3.12+).
+# onnx 1.18.0 fails to build on 3.14 due to CMake ABI tag mismatch (onnx#7226).
+onnx==1.20.1 ; python_version >= "3.14"
 #Description: Required by onnx tests, and mypy and test_public_bindings.py when checking torch.onnx._internal
 #Pinned versions:
 #test that import:


### PR DESCRIPTION
## Motivation

The CI Docker build for Python 3.14 (`pyt_whl_docker_rel-7.2`) fails during `pip install -r requirements-ci.txt` due to two packages that don't support Python 3.14:

1. **numba==0.61.2** — explicitly rejects Python 3.14 (`>=3.10,<3.14`)
2. **onnx==1.18.0** — CMake ABI tag mismatch: builds `.cpython-312` extension but Python 3.14 expects `.cpython-314` (onnx#7226)

This blocks all Python 3.14 PyTorch wheel and Docker image builds on ROCm 7.2.

## Technical Details

### Fix 1: numba

`numba==0.61.2` has a version guard in its `setup.py` that restricts installation to `Python >=3.10,<3.14`. Python 3.14 support was added in numba 0.63.0 (released Dec 8, 2025).

```diff
 numba==0.49.0 ; python_version < "3.9" and platform_machine != "s390x"
 numba==0.60.0 ; python_version == "3.9" and platform_machine != "s390x"
-numba==0.61.2 ; python_version > "3.9" and platform_machine != "s390x"
+numba==0.61.2 ; python_version > "3.9" and python_version < "3.14" and platform_machine != "s390x"
+numba==0.64.0 ; python_version >= "3.14" and platform_machine != "s390x"
```

- Restricted the existing `numba==0.61.2` entry to `python_version < "3.14"` so Python 3.10/3.11/3.12/3.13 builds are completely unaffected.
- Added `numba==0.64.0` for `python_version >= "3.14"`. This is the latest stable release (Feb 18, 2026) and supports Python 3.14.
- Dependency compatibility: the pinned `numpy==2.1.2` is within range for both numba 0.61.2 (`<2.3`) and 0.64.0 (`<2.5`). `llvmlite` is not pinned and will be auto-resolved by pip (0.44.x for 0.61.2, 0.46.x for 0.64.0).

### Fix 2: onnx

`onnx==1.18.0` was pinned for Python 3.14 but its CMake build system picks up the wrong Python ABI tag — it compiles `onnx_cpp2py_export.cpython-312-x86_64-linux-gnu.so` instead of `cpython-314`, causing a build failure.

```diff
 onnx==1.19.1 ; python_version < "3.14"
-# Unpin once Python 3.14 is supported. See  onnxruntime issue 26309.
-onnx==1.18.0 ; python_version == "3.14"
+# onnx 1.20.1 uses abi3 stable ABI wheels (compatible with Python 3.12+).
+# onnx 1.18.0 fails to build on 3.14 due to CMake ABI tag mismatch (onnx#7226).
+onnx==1.20.1 ; python_version >= "3.14"
```

- `onnx==1.20.1` provides **abi3 stable ABI** pre-built wheels that work across Python 3.12+, completely avoiding the source build issue.
- All other Python 3.14-sensitive packages (`optree`, `scipy`, `lxml`) already have working 3.14 entries in the file.

## Test Plan

- [x] Trigger Python 3.14 Docker build (`pyt_whl_docker_rel-7.2`) and confirm both numba and onnx install successfully: `registry-sc-harbor.amd.com/framework/compute-rocm-rel-7.2:78_ubuntu24.04_py3.14_pytorch_users-kithumma-numba-py314-fix_`
- [x] Trigger Python 3.12 Docker build and confirm no regression (original package versions still used) - Not needed since changes only impact 3.14 explicitly
- [x] Verify `test_numba_integration.py` passes on Python 3.14: In `registry-sc-harbor.amd.com/framework/compute-rocm-rel-7.2:78_ubuntu24.04_py3.14_pytorch_users-kithumma-numba-py314-fix_` on MI355:
```
test_numba_integration 1/1 was successful, full logs can be found in artifacts with path test/test-reports/test_numba_integration_1.1_e8a4690ac23086da_.log
Running 8 items in this shard: test/test_numba_integration.py::TestNumbaIntegration::test_active_device, test/test_numba_integration.py::TestNumbaIntegration::test_array_adaptor, test/test_numba_integration.py::TestNumbaIntegration::test_conversion_errors, test/test_numba_integration.py::TestNumbaIntegration::test_cuda_array_interface, test/test_numba_integration.py::TestNumbaIntegration::test_from_cuda_array_interface, test/test_numba_integration.py::TestNumbaIntegration::test_from_cuda_array_interface_active_device, test/test_numba_integration.py::TestNumbaIntegration::test_from_cuda_array_interface_inferred_strides, test/test_numba_integration.py::TestNumbaIntegration::test_from_cuda_array_interface_lifetime
```

## Test Result

Pre-fix (build 1): Python 3.14 build fails at numba install — `RuntimeError: Cannot install on Python version 3.14.3; only versions >=3.10,<3.14 are supported.`

Pre-fix (build 2, after numba fix): Python 3.14 build fails at onnx install — `error: can't copy 'onnx_cpp2py_export.cpython-314-x86_64-linux-gnu.so': doesn't exist`

Post-fix: docker built successfully, microbenchmark ran successfully on MI355, some UT failures but generally okay.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
