### PR TITLE
[release/2.10] Skip test_rms_norm_sharing_weights tests

### DIFF
--- a/test/inductor/test_mix_order_reduction.py
+++ b/test/inductor/test_mix_order_reduction.py
@@ -9,6 +9,8 @@ from torch._inductor.test_case import run_tests, TestCase
 from torch.testing import FileCheck
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
+    isRocmArchAnyOf,
+    MI200_ARCH,
     parametrize,
 )
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
@@ -499,6 +501,9 @@ class MixOrderReductionTest(TestBase):
     def test_rms_norm_sharing_weights(self, split_reductions, dtype):
         if not inductor_config.triton.mix_order_reduction:
             self.skipTest("Mix order reduction not enabled")
+
+        if dtype is torch.bfloat16 and isRocmArchAnyOf(MI200_ARCH):
+            self.skipTest("Currently failing on rocm mi200")
 
         def f(xs, w, eps):
             ys = []

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -103,7 +103,7 @@ except ImportError:
 SEED = 1234
 MI350_ARCH = ("gfx950",)
 MI300_ARCH = ("gfx942",)
-MI200_ARCH = ("gfx90a")
+MI200_ARCH = ("gfx90a",)
 NAVI_ARCH = ("gfx1030", "gfx1100", "gfx1101", "gfx1200", "gfx1201")
 NAVI3_ARCH = ("gfx1100", "gfx1101")
 NAVI4_ARCH = ("gfx1200", "gfx1201")


### PR DESCRIPTION
Ported only test/inductor/test_mix_order_reduction.py changes from https://github.com/pytorch/pytorch/pull/170205/changes

