### PR TITLE
[release/2.11] Align Radeon targets for supported and preferred hipBLASLt backend with release/2.10

### DIFF
--- a/aten/src/ATen/cuda/detail/CUDAHooks.cpp
+++ b/aten/src/ATen/cuda/detail/CUDAHooks.cpp
@@ -554,8 +554,11 @@ bool CUDAHooks::isGPUArch(const std::vector<std::string>& archs, DeviceIndex dev
 const std::vector<std::string>& CUDAHooks::getHipblasltPreferredArchs() const {
   static const std::vector<std::string> archs = {
     "gfx90a", "gfx942",
-#if ROCM_VERSION >= 60400
-    "gfx1200", "gfx1201",
+#if ROCM_VERSION >= 60300
+    "gfx1100", "gfx1101", "gfx1102", "gfx1200", "gfx1201",
+#endif
+#if ROCM_VERSION >= 60402
+    "gfx1150", "gfx1151",
 #endif
 #if ROCM_VERSION >= 70000
     "gfx950"
@@ -570,8 +573,11 @@ const std::vector<std::string>& CUDAHooks::getHipblasltSupportedArchs() const {
 #if ROCM_VERSION >= 60300
     "gfx1100", "gfx1101", "gfx1103", "gfx1200", "gfx1201", "gfx908",
 #endif
+#if ROCM_VERSION >= 60402
+    "gfx1150", "gfx1151",
+#endif
 #if ROCM_VERSION >= 70000
-    "gfx950", "gfx1150", "gfx1151",
+    "gfx950",
 #endif
 #if ROCM_VERSION >= 70200
     "gfx1250"

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -629,7 +629,12 @@ print(t.is_pinned())
                 gcn_arch = str(
                     torch.cuda.get_device_properties(0).gcnArchName.split(":", 1)[0]
                 )
-                if gcn_arch in ["gfx90a", "gfx942", "gfx950", "gfx1200", "gfx1201"]:
+                if gcn_arch in [
+                    "gfx90a", "gfx942", "gfx950",
+                    "gfx1100", "gfx1101", "gfx1102",
+                    "gfx1150", "gfx1151",
+                    "gfx1200", "gfx1201",
+                ]:
                     self.assertTrue(default == torch._C._BlasBackend.Cublaslt)
                 else:
                     self.assertTrue(default == torch._C._BlasBackend.Cublas)


### PR DESCRIPTION
## Motivation

Align list of supported and preferred hipBLASLt targets (for Radeon GPU) with release/2.10 branch. Also, update the ROCm versions where target should be added to supported or preferred hipBLASLt list.