### PR TITLE
[CI] Improve summary output and add log based failure detection for parity workflow

### DIFF
--- a/.automation_scripts/parse_xml_results.py
+++ b/.automation_scripts/parse_xml_results.py
@@ -61,7 +61,7 @@ def parse_xml_report(
     report: Path,
     workflow_id: int,
     workflow_run_attempt: int,
-    test_config: str
+    work_flow_name: str
 ) -> Dict[Tuple[str], Dict[str, Any]]:
     """Convert a test report xml file into a JSON-serializable list of test cases."""
     print(f"Parsing {tag}s for test report: {report}")
@@ -87,7 +87,7 @@ def parse_xml_report(
             case["workflow_id"] = workflow_id
             case["workflow_run_attempt"] = workflow_run_attempt
             case["job_id"] = job_id
-            case["test_config"] = test_config
+            case["work_flow_name"] = work_flow_name
 
             # [invoking file]
             # The name of the file that the test is located in is not necessarily
@@ -105,9 +105,9 @@ def parse_xml_report(
                     case_name = case_name + "_" + BACKENDS_LIST[ind]
                     break
             case["invoking_file"] = case_name
-            test_cases[ ( case["invoking_file"], case["classname"], case["name"], case["test_config"] ) ] = case
+            test_cases[ ( case["invoking_file"], case["classname"], case["name"], case["work_flow_name"] ) ] = case
         elif tag == 'testsuite':
-            case["test_config"] = test_config
+            case["work_flow_name"] = work_flow_name
             case["invoking_xml"] = report.name
             case["running_time_xml"] = case["time"]
             case_name = report.parent.name
@@ -117,7 +117,7 @@ def parse_xml_report(
                     break
             case["invoking_file"] = case_name
 
-            test_cases[ ( case["invoking_file"], case["invoking_xml"], case["test_config"] ) ] = case
+            test_cases[ ( case["invoking_file"], case["invoking_xml"], case["work_flow_name"] ) ] = case
 
     return test_cases
 

--- a/.automation_scripts/parse_xml_results.py
+++ b/.automation_scripts/parse_xml_results.py
@@ -61,7 +61,7 @@ def parse_xml_report(
     report: Path,
     workflow_id: int,
     workflow_run_attempt: int,
-    work_flow_name: str
+    test_config: str
 ) -> Dict[Tuple[str], Dict[str, Any]]:
     """Convert a test report xml file into a JSON-serializable list of test cases."""
     print(f"Parsing {tag}s for test report: {report}")
@@ -87,7 +87,7 @@ def parse_xml_report(
             case["workflow_id"] = workflow_id
             case["workflow_run_attempt"] = workflow_run_attempt
             case["job_id"] = job_id
-            case["work_flow_name"] = work_flow_name
+            case["test_config"] = test_config
 
             # [invoking file]
             # The name of the file that the test is located in is not necessarily
@@ -105,9 +105,9 @@ def parse_xml_report(
                     case_name = case_name + "_" + BACKENDS_LIST[ind]
                     break
             case["invoking_file"] = case_name
-            test_cases[ ( case["invoking_file"], case["classname"], case["name"], case["work_flow_name"] ) ] = case
+            test_cases[ ( case["invoking_file"], case["classname"], case["name"], case["test_config"] ) ] = case
         elif tag == 'testsuite':
-            case["work_flow_name"] = work_flow_name
+            case["test_config"] = test_config
             case["invoking_xml"] = report.name
             case["running_time_xml"] = case["time"]
             case_name = report.parent.name
@@ -117,7 +117,7 @@ def parse_xml_report(
                     break
             case["invoking_file"] = case_name
 
-            test_cases[ ( case["invoking_file"], case["invoking_xml"], case["work_flow_name"] ) ] = case
+            test_cases[ ( case["invoking_file"], case["invoking_xml"], case["test_config"] ) ] = case
 
     return test_cases
 

--- a/.automation_scripts/pytorch-unit-test-scripts/auto_classify_skip_reasons.py
+++ b/.automation_scripts/pytorch-unit-test-scripts/auto_classify_skip_reasons.py
@@ -917,7 +917,7 @@ def main():
         test_file = row.get('test_file', '')
         test_class = row.get('test_class', '')
         test_name = row.get('test_name', '')
-        workflow = row.get('work_flow_name', '')
+        workflow = row.get('test_config', '')
 
         if existing_reason and not args.reclassify_all:
             already_had_count += 1

--- a/.automation_scripts/pytorch-unit-test-scripts/detect_log_failures.py
+++ b/.automation_scripts/pytorch-unit-test-scripts/detect_log_failures.py
@@ -32,6 +32,12 @@ RE_TIMEOUT = re.compile(r"Command took >(\d+)min, returning 124")
 RE_FAILED_CONSISTENTLY = re.compile(
     r"FAILED CONSISTENTLY: (?P<test_path>\S+)"
 )
+RE_STEPCURRENT = re.compile(
+    r"stepcurrent:.*Running only (?:test/)?(?P<test_path>\S+)"
+)
+RE_INDIVIDUAL_TEST = re.compile(
+    r"(?P<test_path>\S+\.py::(?P<cls>\w+)::(?P<method>\w+))"
+)
 
 CRASH_PATTERNS = [
     (re.compile(r"Segmentation fault", re.IGNORECASE), "SEGFAULT"),
@@ -80,6 +86,20 @@ def parse_log_file(filepath):
 
     with open(filepath, "r", errors="replace") as f:
         for line in f:
+            # Lightweight tracking of individual pytest test lines.
+            # These are very frequent (~37% of lines) so we extract the
+            # test name directly without timestamp stripping.
+            if ".py::" in line:
+                m_ind = RE_INDIVIDUAL_TEST.search(line)
+                if m_ind:
+                    active = current_test or last_failed_test
+                    if active and active in results:
+                        # Only update if the pytest path belongs to this shard's test file,
+                        # otherwise rerun output from earlier shards contaminates later ones.
+                        shard_file = results[active]["test_file"]
+                        if shard_file + ".py" in m_ind.group("test_path"):
+                            results[active]["last_test"] = f"{m_ind.group('cls')}::{m_ind.group('method')}"
+
             if " ... [" not in line and "was successful" not in line \
                and "failed!" not in line and "Got exit code" not in line \
                and "returning 124" not in line and "FAILED CONSISTENTLY" not in line \
@@ -90,7 +110,8 @@ def parse_log_file(filepath):
                and "Fatal Python error" not in line and "core dumped" not in line \
                and "Aborted (core dumped)" not in line \
                and "OutOfMemoryError" not in line \
-               and "bad_alloc" not in line:
+               and "bad_alloc" not in line \
+               and "stepcurrent" not in line:
                 continue
 
             stripped = RE_TIMESTAMP.sub("", line).rstrip()
@@ -108,6 +129,8 @@ def parse_log_file(filepath):
                         "reason": "",
                         "exit_codes": [],
                         "crashes": [],
+                        "crash_tests": [],
+                        "last_test": "",
                     }
                 continue
 
@@ -132,8 +155,32 @@ def parse_log_file(filepath):
                 current_test = key
                 continue
 
-            # For exit codes and timeouts, attach to current or last failed test
             active = current_test or last_failed_test
+
+            # Track stepcurrent rerun lines — identifies crash-causing test
+            m = RE_STEPCURRENT.search(stripped)
+            if m:
+                test_path = m.group("test_path")
+                parts = test_path.split("::")
+                if len(parts) >= 3:
+                    crash_id = f"{parts[1]}::{parts[2]}"
+                elif len(parts) == 2:
+                    crash_id = parts[1]
+                else:
+                    crash_id = None
+                if crash_id and active and active in results:
+                    shard_file = results[active]["test_file"]
+                    if shard_file in test_path:
+                        if crash_id not in results[active]["crash_tests"]:
+                            results[active]["crash_tests"].append(crash_id)
+                continue
+
+            # Track individual pytest test lines for last-running-test context
+            m_ind = RE_INDIVIDUAL_TEST.search(stripped)
+            if m_ind and active and active in results:
+                cls = m_ind.group("cls")
+                method = m_ind.group("method")
+                results[active]["last_test"] = f"{cls}::{method}"
 
             m = RE_EXIT_CODE.search(stripped)
             if m:
@@ -197,6 +244,22 @@ def scan_logs(logs_dir):
             if info["status"] == "RUNNING" and categories == ["INCOMPLETE"]:
                 continue
 
+            reason = info["reason"]
+            # Populate reason with identified crash/timeout test name
+            crash_tests = info.get("crash_tests", [])
+            last_test = info.get("last_test", "")
+            identified_test = ""
+            if crash_tests:
+                identified_test = crash_tests[0]
+            elif last_test:
+                identified_test = last_test
+
+            if identified_test and "::" in identified_test:
+                if not reason:
+                    reason = identified_test
+                elif "::" not in reason:
+                    reason = f"{identified_test} | {reason}"
+
             all_failures.append({
                 "log_file": fname,
                 "platform": platform,
@@ -205,7 +268,7 @@ def scan_logs(logs_dir):
                 "shard": f"{info['shard']}/{info['total']}",
                 "status": info["status"],
                 "category": "+".join(categories),
-                "reason": info["reason"],
+                "reason": reason,
                 "exit_codes": ",".join(str(c) for c in info["exit_codes"]),
             })
 

--- a/.automation_scripts/pytorch-unit-test-scripts/detect_log_failures.py
+++ b/.automation_scripts/pytorch-unit-test-scripts/detect_log_failures.py
@@ -64,13 +64,13 @@ LOG_FILE_MAP = {
 
 
 def classify_log_file(filename):
-    """Return (platform, workflow, shard_num) from a log filename like rocm3.txt."""
+    """Return (platform, test_config, shard_num) from a log filename like rocm3.txt."""
     stem = Path(filename).stem
-    for prefix, (platform, workflow) in sorted(LOG_FILE_MAP.items(), key=lambda x: -len(x[0])):
+    for prefix, (platform, test_config) in sorted(LOG_FILE_MAP.items(), key=lambda x: -len(x[0])):
         if stem.startswith(prefix):
             remainder = stem[len(prefix):]
             if remainder.isdigit():
-                return platform, workflow, int(remainder)
+                return platform, test_config, int(remainder)
     return None, None, None
 
 
@@ -214,7 +214,7 @@ def scan_logs(logs_dir):
         if not fname.endswith(".txt"):
             continue
 
-        platform, workflow, shard_num = classify_log_file(fname)
+        platform, test_config, shard_num = classify_log_file(fname)
         if platform is None:
             continue
 
@@ -263,7 +263,7 @@ def scan_logs(logs_dir):
             all_failures.append({
                 "log_file": fname,
                 "platform": platform,
-                "workflow": workflow,
+                "test_config": test_config,
                 "test_file": info["test_file"],
                 "shard": f"{info['shard']}/{info['total']}",
                 "status": info["status"],
@@ -281,7 +281,7 @@ def scan_logs(logs_dir):
             all_failures.append({
                 "log_file": fname,
                 "platform": platform,
-                "workflow": workflow,
+                "test_config": test_config,
                 "test_file": file_part,
                 "shard": "",
                 "status": "FAILED_CONSISTENTLY",
@@ -295,7 +295,7 @@ def scan_logs(logs_dir):
 
 def write_csv_report(failures, output_path):
     fieldnames = [
-        "log_file", "platform", "workflow", "test_file", "shard",
+        "log_file", "platform", "test_config", "test_file", "shard",
         "status", "category", "reason", "exit_codes",
     ]
     with open(output_path, "w", newline="") as f:
@@ -323,7 +323,7 @@ def print_summary(failures):
     for cat, items in sorted(by_category.items()):
         print(f"  {cat}: {len(items)}")
         for item in items:
-            print(f"    - {item['test_file']} ({item['platform']}/{item['workflow']}) [{item['log_file']}]")
+            print(f"    - {item['test_file']} ({item['platform']}/{item['test_config']}) [{item['log_file']}]")
             if item["reason"]:
                 print(f"      Reason: {item['reason'][:120]}")
     print()

--- a/.automation_scripts/pytorch-unit-test-scripts/detect_log_failures.py
+++ b/.automation_scripts/pytorch-unit-test-scripts/detect_log_failures.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""Scan CI log files (.txt) for test failures not captured in XML reports.
+
+Tests that timeout (exit code 124), crash (SIGIOT, SIGSEGV, Fatal Python error),
+or are killed (SIGKILL, OOM) never produce JUnit XML output. This script detects
+those failures from the raw log files and outputs a CSV/summary.
+
+Usage:
+    python detect_log_failures.py --logs-dir <folder> [--output <path.csv>]
+"""
+
+import argparse
+import csv
+import os
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+
+RE_RUNNING = re.compile(
+    r"Running (?P<test_file>\S+) (?P<shard>\d+)/(?P<total>\d+) \.\.\."
+)
+RE_SUCCESS = re.compile(
+    r"(?P<test_file>\S+) (?P<shard>\d+)/(?P<total>\d+) was successful"
+)
+RE_FAILED = re.compile(
+    r"(?P<test_file>\S+) (?P<shard>\d+)/(?P<total>\d+) failed!(?P<reason>.*)"
+)
+RE_EXIT_CODE = re.compile(r"Got exit code (?P<code>\d+)")
+RE_TIMEOUT = re.compile(r"Command took >(\d+)min, returning 124")
+RE_FAILED_CONSISTENTLY = re.compile(
+    r"FAILED CONSISTENTLY: (?P<test_path>\S+)"
+)
+
+CRASH_PATTERNS = [
+    (re.compile(r"Segmentation fault", re.IGNORECASE), "SEGFAULT"),
+    (re.compile(r"SIGSEGV"), "SIGSEGV"),
+    (re.compile(r"SIGIOT"), "SIGIOT"),
+    (re.compile(r"SIGABRT"), "SIGABRT"),
+    (re.compile(r"SIGKILL"), "SIGKILL"),
+    (re.compile(r"Fatal Python error", re.IGNORECASE), "FATAL_PYTHON"),
+    (re.compile(r"core dumped", re.IGNORECASE), "CORE_DUMP"),
+    (re.compile(r"Aborted \(core dumped\)", re.IGNORECASE), "ABORTED"),
+    (re.compile(r"torch\.cuda\.OutOfMemoryError"), "CUDA_OOM"),
+    (re.compile(r"std::bad_alloc"), "BAD_ALLOC"),
+]
+
+LOG_FILE_MAP = {
+    "rocm": ("rocm", "default"),
+    "rocm_dist": ("rocm", "distributed"),
+    "rocm_inductor": ("rocm", "inductor"),
+    "cuda": ("cuda", "default"),
+    "cuda_dist": ("cuda", "distributed"),
+    "cuda_inductor": ("cuda", "inductor"),
+    "baseline": ("baseline", "default"),
+}
+
+
+def classify_log_file(filename):
+    """Return (platform, workflow, shard_num) from a log filename like rocm3.txt."""
+    stem = Path(filename).stem
+    for prefix, (platform, workflow) in sorted(LOG_FILE_MAP.items(), key=lambda x: -len(x[0])):
+        if stem.startswith(prefix):
+            remainder = stem[len(prefix):]
+            if remainder.isdigit():
+                return platform, workflow, int(remainder)
+    return None, None, None
+
+
+RE_TIMESTAMP = re.compile(r"^\d{4}-\d{2}-\d{2}T[\d:.]+Z\s*")
+
+
+def parse_log_file(filepath):
+    """Parse a single log file and return test file results and consistent failures."""
+    results = {}
+    current_test = None
+    last_failed_test = None
+    consistent_failures = []
+
+    with open(filepath, "r", errors="replace") as f:
+        for line in f:
+            if " ... [" not in line and "was successful" not in line \
+               and "failed!" not in line and "Got exit code" not in line \
+               and "returning 124" not in line and "FAILED CONSISTENTLY" not in line \
+               and "Retrying" not in line \
+               and "Segmentation fault" not in line and "SIGIOT" not in line \
+               and "SIGSEGV" not in line and "SIGABRT" not in line \
+               and "SIGKILL" not in line \
+               and "Fatal Python error" not in line and "core dumped" not in line \
+               and "Aborted (core dumped)" not in line \
+               and "OutOfMemoryError" not in line \
+               and "bad_alloc" not in line:
+                continue
+
+            stripped = RE_TIMESTAMP.sub("", line).rstrip()
+
+            m = RE_RUNNING.search(stripped)
+            if m:
+                key = f"{m.group('test_file')} {m.group('shard')}/{m.group('total')}"
+                current_test = key
+                if key not in results:
+                    results[key] = {
+                        "test_file": m.group("test_file"),
+                        "shard": int(m.group("shard")),
+                        "total": int(m.group("total")),
+                        "status": "RUNNING",
+                        "reason": "",
+                        "exit_codes": [],
+                        "crashes": [],
+                    }
+                continue
+
+            m = RE_SUCCESS.search(stripped)
+            if m:
+                key = f"{m.group('test_file')} {m.group('shard')}/{m.group('total')}"
+                if key in results:
+                    results[key]["status"] = "PASSED"
+                current_test = None
+                last_failed_test = None
+                continue
+
+            m = RE_FAILED.search(stripped)
+            if m:
+                key = f"{m.group('test_file')} {m.group('shard')}/{m.group('total')}"
+                reason = m.group("reason").strip()
+                if key in results:
+                    results[key]["status"] = "FAILED"
+                    if reason:
+                        results[key]["reason"] = reason
+                last_failed_test = key
+                current_test = key
+                continue
+
+            # For exit codes and timeouts, attach to current or last failed test
+            active = current_test or last_failed_test
+
+            m = RE_EXIT_CODE.search(stripped)
+            if m:
+                code = int(m.group("code"))
+                if active and active in results:
+                    results[active]["exit_codes"].append(code)
+
+            m = RE_TIMEOUT.search(stripped)
+            if m and active and active in results:
+                if "TIMEOUT" not in results[active]["crashes"]:
+                    results[active]["crashes"].append("TIMEOUT")
+
+            m = RE_FAILED_CONSISTENTLY.search(stripped)
+            if m:
+                consistent_failures.append(m.group("test_path"))
+
+            if active and active in results:
+                for pattern, label in CRASH_PATTERNS:
+                    if pattern.search(stripped):
+                        if label not in results[active]["crashes"]:
+                            results[active]["crashes"].append(label)
+
+    return results, consistent_failures
+
+
+def scan_logs(logs_dir):
+    """Scan all log files and return all non-passing test file results."""
+    all_failures = []
+
+    for fname in sorted(os.listdir(logs_dir)):
+        if not fname.endswith(".txt"):
+            continue
+
+        platform, workflow, shard_num = classify_log_file(fname)
+        if platform is None:
+            continue
+
+        filepath = os.path.join(logs_dir, fname)
+        results, consistent_failures = parse_log_file(filepath)
+
+        for key, info in results.items():
+            if info["status"] == "PASSED":
+                continue
+
+            categories = []
+            if 124 in info["exit_codes"] or "TIMEOUT" in info["crashes"]:
+                categories.append("TIMEOUT")
+            for c in info["crashes"]:
+                if c != "TIMEOUT":
+                    categories.append(c)
+            if info["status"] == "FAILED" and not categories:
+                categories.append("FAILED")
+            if info["status"] == "RUNNING" and not categories:
+                categories.append("INCOMPLETE")
+
+            if not categories:
+                continue
+            # Skip tests stuck in RUNNING with no evidence of failure —
+            # these are typically from multi-shard logs where a different
+            # shard's "Running ..." line appeared but the result was elsewhere.
+            if info["status"] == "RUNNING" and categories == ["INCOMPLETE"]:
+                continue
+
+            all_failures.append({
+                "log_file": fname,
+                "platform": platform,
+                "workflow": workflow,
+                "test_file": info["test_file"],
+                "shard": f"{info['shard']}/{info['total']}",
+                "test_class": "",
+                "test_name": "",
+                "status": info["status"],
+                "category": "+".join(categories),
+                "reason": info["reason"],
+                "exit_codes": ",".join(str(c) for c in info["exit_codes"]),
+            })
+
+        for test_path in consistent_failures:
+            parts = test_path.split("::")
+            file_part = parts[0].replace("test/", "").replace(".py", "")
+            test_class = parts[1] if len(parts) > 1 else ""
+            test_name = parts[2] if len(parts) > 2 else ""
+
+            all_failures.append({
+                "log_file": fname,
+                "platform": platform,
+                "workflow": workflow,
+                "test_file": file_part,
+                "shard": "",
+                "test_class": test_class,
+                "test_name": test_name,
+                "status": "FAILED_CONSISTENTLY",
+                "category": "CONSISTENT_FAILURE",
+                "reason": f"{test_class}::{test_name}" if test_class else "",
+                "exit_codes": "",
+            })
+
+    return all_failures
+
+
+def write_csv_report(failures, output_path):
+    fieldnames = [
+        "log_file", "platform", "workflow", "test_file", "shard",
+        "test_class", "test_name",
+        "status", "category", "reason", "exit_codes",
+    ]
+    with open(output_path, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(failures)
+    print(f"Log failure report: {output_path} ({len(failures)} entries)")
+
+
+def print_summary(failures):
+    if not failures:
+        print("No log-based failures detected.")
+        return
+
+    by_category = defaultdict(list)
+    for f in failures:
+        by_category[f["category"]].append(f)
+
+    print(f"\n{'='*60}")
+    print("LOG FAILURE DETECTION SUMMARY")
+    print(f"{'='*60}")
+    print(f"Total failures detected: {len(failures)}")
+    print()
+
+    for cat, items in sorted(by_category.items()):
+        print(f"  {cat}: {len(items)}")
+        for item in items:
+            print(f"    - {item['test_file']} ({item['platform']}/{item['workflow']}) [{item['log_file']}]")
+            if item["reason"]:
+                print(f"      Reason: {item['reason'][:120]}")
+    print()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Detect test failures from CI log files not captured in XML reports"
+    )
+    parser.add_argument(
+        "--logs-dir", required=True,
+        help="Directory containing .txt log files"
+    )
+    parser.add_argument(
+        "--output", default="log_failures.csv",
+        help="Output CSV path (default: log_failures.csv)"
+    )
+    args = parser.parse_args()
+
+    failures = scan_logs(args.logs_dir)
+    print_summary(failures)
+    write_csv_report(failures, args.output)
+    return 0 if not failures else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.automation_scripts/pytorch-unit-test-scripts/detect_log_failures.py
+++ b/.automation_scripts/pytorch-unit-test-scripts/detect_log_failures.py
@@ -203,8 +203,6 @@ def scan_logs(logs_dir):
                 "workflow": workflow,
                 "test_file": info["test_file"],
                 "shard": f"{info['shard']}/{info['total']}",
-                "test_class": "",
-                "test_name": "",
                 "status": info["status"],
                 "category": "+".join(categories),
                 "reason": info["reason"],
@@ -223,8 +221,6 @@ def scan_logs(logs_dir):
                 "workflow": workflow,
                 "test_file": file_part,
                 "shard": "",
-                "test_class": test_class,
-                "test_name": test_name,
                 "status": "FAILED_CONSISTENTLY",
                 "category": "CONSISTENT_FAILURE",
                 "reason": f"{test_class}::{test_name}" if test_class else "",
@@ -237,7 +233,6 @@ def scan_logs(logs_dir):
 def write_csv_report(failures, output_path):
     fieldnames = [
         "log_file", "platform", "workflow", "test_file", "shard",
-        "test_class", "test_name",
         "status", "category", "reason", "exit_codes",
     ]
     with open(output_path, "w", newline="") as f:

--- a/.automation_scripts/pytorch-unit-test-scripts/download_testlogs
+++ b/.automation_scripts/pytorch-unit-test-scripts/download_testlogs
@@ -312,16 +312,17 @@ def download_workflow_run(created=None, max_pages=10, workflow=None, sha=None, i
         workflow_runs = None
         try:
             workflow_runs = response.json()['workflow_runs']
-            #print(workflow_runs)
         except:
             raise Exception(response.text)
+        if not workflow_runs:
+            continue
+        # Prefer completed runs over in-progress ones. When multiple
+        # runs exist for the same SHA, the most recent may still be
+        # running and have no artifacts yet.
+        completed = [wf for wf in workflow_runs if wf.get('status') == 'completed']
+        if completed:
+            return completed[0]
         return workflow_runs[0]
-        for wf in workflow_runs:
-            wf_name = wf["name"]
-            if not sha and (wf_name == workflow):
-                return wf
-            if sha and (wf_name == workflow) and (wf["head_sha"] == sha):
-                return wf
 
     # Should not reach here ideally
     raise Exception(error_msg)

--- a/.automation_scripts/pytorch-unit-test-scripts/download_testlogs
+++ b/.automation_scripts/pytorch-unit-test-scripts/download_testlogs
@@ -406,7 +406,7 @@ def main():
     elif arch == 'mi355':
         ROCmWorkflowNames = {
             "default": "trunk",
-            "distributed": "trunk",
+            "distributed": "periodic-rocm-mi355",
             "inductor": "inductor-rocm-mi355"
         }
     elif arch == 'mi200':
@@ -443,7 +443,7 @@ def main():
         },
         "mi355": {
             "default": "linux-jammy-rocm-py3.10-mi355",
-            "distributed": "linux-jammy-rocm-py3.10-mi355",
+            "distributed": "linux-noble-rocm-py3.12-mi355",
             "inductor": "linux-noble-rocm-py3.12-mi355"
         },
         "navi31": {
@@ -520,7 +520,7 @@ def main():
         except (IndexError, Exception):
             periodic_wf = None
         periodic_fallbacks = {
-            "mi355": ("periodic-rocm-mi355", "linux-noble-rocm-py3.12-mi355"),
+            "mi355": ("trunk", "linux-jammy-rocm-py3.10-mi355"),
             "mi200": ("periodic-rocm-mi200", "linux-jammy-rocm-py3.10"),
         }
         if periodic_wf is None and arch in periodic_fallbacks:

--- a/.automation_scripts/pytorch-unit-test-scripts/download_testlogs
+++ b/.automation_scripts/pytorch-unit-test-scripts/download_testlogs
@@ -477,7 +477,8 @@ def main():
 
     print(f"Using ROCm architecture: {arch}")
     print(f"Using ROCm workflows: {ROCmWorkflowNames}")
-    print(f"Using CUDA workflows: {CUDAWorkflowNames}") if not args.no_cuda
+    if not args.no_cuda:
+        print(f"Using CUDA workflows: {CUDAWorkflowNames}")
     print(f"Using ROCm job prefixes: {rocm_job_prefix}")
     print(f"Using ROCm shard counts: {rocm_shards}")
 

--- a/.automation_scripts/pytorch-unit-test-scripts/download_testlogs
+++ b/.automation_scripts/pytorch-unit-test-scripts/download_testlogs
@@ -659,20 +659,67 @@ def main():
         print("==========================================")
         print(f"Finding CUDA tests in trunk workflow by sha: {sha}")
         print("==========================================")
-        error_msg="Error: Trunk workflow not found in scanned workflow runs. Try increasing max_pages."
-        trunk_wf = download_workflow_run(created=args.created, max_pages=args.max_pages, workflow=CUDAWorkflowNames["default"], sha=sha, ignore_status=args.ignore_status, status=status, error_msg=error_msg)
-        print(f"Using workflow with id:{trunk_wf['id']} as trunk_wf")
 
-        # Get job IDs for the target CUDA version to filter S3 artifacts.
-        # The jobs API may not return test jobs from reusable workflows,
-        # so fall back to the check-runs API which includes all jobs.
-        all_cuda_jobs = get_workflow_jobs(trunk_wf)
-        cuda_test_jobs = [j for j in all_cuda_jobs if cuda_job_prefix in j['name'] and '/ test' in j['name']]
-        if not cuda_test_jobs:
-            print("No CUDA test jobs found via jobs API, trying check-runs API...")
+        # There can be multiple trunk runs for the same SHA. Find the one
+        # that actually contains CUDA test jobs by checking each run's jobs
+        # list, falling back to check-runs API to resolve the correct run.
+        trunk_wf = None
+        all_cuda_jobs = []
+        cuda_test_jobs = []
+
+        trunk_runs = []
+        params = {'per_page': 10}
+        if not args.ignore_status:
+            params['status'] = status
+        params['head_sha'] = sha
+        resp = requests.get(
+            f"https://api.github.com/repos/pytorch/pytorch/actions/workflows/{CUDAWorkflowNames['default']}.yml/runs",
+            headers=authentication_headers, params=params,
+        )
+        trunk_runs = resp.json().get('workflow_runs', [])
+
+        for run in trunk_runs:
+            jobs = get_workflow_jobs(run)
+            test_jobs = [j for j in jobs if cuda_job_prefix in j['name'] and '/ test' in j['name']]
+            if test_jobs:
+                trunk_wf = run
+                all_cuda_jobs = jobs
+                cuda_test_jobs = test_jobs
+                print(f"Found CUDA test jobs in trunk run {run['id']}")
+                break
+
+        if not cuda_test_jobs and trunk_runs:
+            # CUDA test jobs may be in a different run than the one returned
+            # by the jobs API. Use check-runs API to find the actual run.
+            print("No CUDA test jobs in any trunk run's jobs API, trying check-runs API...")
             check_runs = get_check_runs_for_commit(sha, cuda_job_prefix)
             cuda_test_jobs = [cr for cr in check_runs if '/ test' in cr['name']]
-            all_cuda_jobs.extend(cuda_test_jobs)
+            if cuda_test_jobs:
+                # Extract the actual workflow run ID from the check-run details URL
+                import re as _re
+                run_match = _re.search(r'/runs/(\d+)/', cuda_test_jobs[0].get('details_url', ''))
+                if run_match:
+                    actual_run_id = int(run_match.group(1))
+                    # Find or fetch the correct workflow run
+                    for run in trunk_runs:
+                        if run['id'] == actual_run_id:
+                            trunk_wf = run
+                            break
+                    if trunk_wf is None:
+                        resp = requests.get(
+                            f"https://api.github.com/repos/pytorch/pytorch/actions/runs/{actual_run_id}",
+                            headers=authentication_headers,
+                        )
+                        trunk_wf = resp.json()
+                    print(f"CUDA test jobs are in trunk run {trunk_wf['id']} (found via check-runs)")
+                all_cuda_jobs = list(cuda_test_jobs)
+
+        if trunk_wf is None:
+            trunk_wf = trunk_runs[0] if trunk_runs else None
+        if trunk_wf is None:
+            raise Exception("Error: No trunk workflow run found for CUDA tests")
+
+        print(f"Using trunk workflow run {trunk_wf['id']} for CUDA")
 
         cuda_job_ids = [str(j['id']) for j in cuda_test_jobs]
         cuda_artifact_substrings = [f"_{jid}" for jid in cuda_job_ids] if cuda_job_ids else ["nvidia.gpu"]

--- a/.automation_scripts/pytorch-unit-test-scripts/download_testlogs
+++ b/.automation_scripts/pytorch-unit-test-scripts/download_testlogs
@@ -476,6 +476,8 @@ def main():
         args.no_cuda = True
 
     print(f"Using ROCm architecture: {arch}")
+    print(f"Using ROCm workflows: {ROCmWorkflowNames}")
+    print(f"Using CUDA workflows: {CUDAWorkflowNames}") if not args.no_cuda
     print(f"Using ROCm job prefixes: {rocm_job_prefix}")
     print(f"Using ROCm shard counts: {rocm_shards}")
 
@@ -506,7 +508,7 @@ def main():
     if not args.exclude_distributed and not args.no_rocm:
         periodic_sha = sha
         print("==============================================")
-        print(f"Finding ROCm tests in periodic workflow by sha: {sha}")
+        print(f"Finding ROCm tests in {ROCmWorkflowNames["distributed"]} workflow by sha: {sha}")
         print("==============================================")
         # find distributed test in periodic workflow with success status
         error_msg="Error: Periodic workflow not found in scanned workflow runs."
@@ -567,7 +569,7 @@ def main():
     if not args.no_rocm and not args.exclude_default:
         rocm_sha = sha
         print("===========================================")
-        print(f"Finding ROCm tests in rocm workflow by sha: {rocm_sha}")
+        print(f"Finding ROCm tests in ROCmWorkflowNames["default"] workflow by sha: {rocm_sha}")
         print("===========================================")
         # find tests in rocm workflow with given sha and success status
         #https://docs.github.com/en/rest/actions/workflow-runs#list-workflow-runs-for-a-repository
@@ -624,7 +626,7 @@ def main():
         # find tests in inductor workflow with given sha and success status
         #https://docs.github.com/en/rest/actions/workflow-runs#list-workflow-runs-for-a-repository
         print("===========================================")
-        print(f"Finding ROCm tests in inductor-rocm workflow by sha: {inductor_rocm_sha}")
+        print(f"Finding ROCm tests in ROCmWorkflowNames["inductor"] workflow by sha: {inductor_rocm_sha}")
         print("===========================================")
         error_msg="Error: inductor workflow not found in scanned workflow runs. Try increasing max_pages."
         inductor_wf_rocm = download_workflow_run(created=args.created, max_pages=args.max_pages, workflow=ROCmWorkflowNames["inductor"], sha=inductor_rocm_sha, ignore_status=args.ignore_status, status=status, error_msg=error_msg)

--- a/.automation_scripts/pytorch-unit-test-scripts/download_testlogs
+++ b/.automation_scripts/pytorch-unit-test-scripts/download_testlogs
@@ -106,16 +106,40 @@ def get_workflow_jobs(wf):
             jobs += response.json()["jobs"]
     return jobs
 
+def get_check_runs_for_commit(sha, prefix):
+    """Get check runs for a commit filtered by name prefix.
+
+    The workflow jobs API does not return jobs from reusable workflows
+    (workflow_call). The check-runs API returns all jobs regardless of
+    workflow nesting, so we use it as a fallback.
+    """
+    check_runs = []
+    page = 1
+    while True:
+        response = requests.get(
+            f"https://api.github.com/repos/pytorch/pytorch/commits/{sha}/check-runs",
+            headers=authentication_headers,
+            params={'per_page': 100, 'page': page},
+        )
+        data = response.json()
+        runs = data.get('check_runs', [])
+        check_runs.extend([cr for cr in runs if prefix in cr.get('name', '')])
+        if len(runs) < 100:
+            break
+        page += 1
+    return check_runs
+
 def get_job_ids_by_prefix(wf, prefix):
     """Get job IDs (as strings) for jobs whose name contains the given prefix."""
     jobs = get_workflow_jobs(wf)
     return [str(j['id']) for j in jobs if prefix in j['name']]
 
-def download_logs(wf, test_log_list, test_folder):
+def download_logs(wf, test_log_list, test_folder, jobs=None):
     if wf is None: 
         raise Exception("wf is None!")
     
-    jobs = get_workflow_jobs(wf)
+    if jobs is None:
+        jobs = get_workflow_jobs(wf)
 
     for test_log in test_log_list:
         write_out_file = test_folder + "/" + test_log[0]
@@ -632,27 +656,32 @@ def main():
 
     if not args.no_cuda:
         cuda_job_prefix = "linux-jammy-cuda13.0-py3.10-gcc11"
-        pull_sha = sha
         print("==========================================")
-        print(f"Finding CUDA tests in pull workflow by sha: {pull_sha}")
+        print(f"Finding CUDA tests in trunk workflow by sha: {sha}")
         print("==========================================")
-        # find tests in pull workflow with given sha and success status
-        #https://docs.github.com/en/rest/actions/workflow-runs#list-workflow-runs-for-a-repository
-        error_msg="Error: Pull workflow not found in scanned workflow runs. Try increasing max_pages."
-        pull_wf = download_workflow_run(created=args.created, max_pages=args.max_pages, workflow=CUDAWorkflowNames["default"], sha=pull_sha, ignore_status=args.ignore_status, status=status, error_msg=error_msg)
-        print(f"Using workflow with id:{pull_wf['id']} as pull_wf")
+        error_msg="Error: Trunk workflow not found in scanned workflow runs. Try increasing max_pages."
+        trunk_wf = download_workflow_run(created=args.created, max_pages=args.max_pages, workflow=CUDAWorkflowNames["default"], sha=sha, ignore_status=args.ignore_status, status=status, error_msg=error_msg)
+        print(f"Using workflow with id:{trunk_wf['id']} as trunk_wf")
 
-        # Get job IDs for the target CUDA version to filter S3 artifacts
-        cuda_job_ids = get_job_ids_by_prefix(pull_wf, cuda_job_prefix)
+        # Get job IDs for the target CUDA version to filter S3 artifacts.
+        # The jobs API may not return test jobs from reusable workflows,
+        # so fall back to the check-runs API which includes all jobs.
+        all_cuda_jobs = get_workflow_jobs(trunk_wf)
+        cuda_test_jobs = [j for j in all_cuda_jobs if cuda_job_prefix in j['name'] and '/ test' in j['name']]
+        if not cuda_test_jobs:
+            print("No CUDA test jobs found via jobs API, trying check-runs API...")
+            check_runs = get_check_runs_for_commit(sha, cuda_job_prefix)
+            cuda_test_jobs = [cr for cr in check_runs if '/ test' in cr['name']]
+            all_cuda_jobs.extend(cuda_test_jobs)
+
+        cuda_job_ids = [str(j['id']) for j in cuda_test_jobs]
         cuda_artifact_substrings = [f"_{jid}" for jid in cuda_job_ids] if cuda_job_ids else ["nvidia.gpu"]
         print(f"Using CUDA job prefix: {cuda_job_prefix}")
-        print(f"Found {len(cuda_job_ids)} CUDA jobs matching prefix")
+        print(f"Found {len(cuda_test_jobs)} CUDA test jobs matching prefix")
 
-        folder_list = get_or_create_test_folder(pull_wf)
+        folder_list = get_or_create_test_folder(trunk_wf)
 
         # Download logs
-        # If the cuda logs aren't found you might want to check the HUD for the correct tags
-        # Link to HUD: https://hud.pytorch.org/hud/pytorch/pytorch/main/1?per_page=50&name_filter=cuda
         if not args.artifacts_only:
             test_log_list_cuda_default = [
               ["cuda1.txt", f"{cuda_job_prefix} / test (default, 1, 5"],
@@ -670,7 +699,7 @@ def main():
                 ]
                 test_log_list_cuda += test_log_list_cuda_distributed
 
-            download_logs(pull_wf, test_log_list_cuda, folder_list[0])
+            download_logs(trunk_wf, test_log_list_cuda, folder_list[0], jobs=all_cuda_jobs)
 
         # Download artifacts
         test_artifacts_list_cuda_default = [
@@ -695,7 +724,7 @@ def main():
 
         if test_artifacts_list_cuda:
             download_artifacts(
-                pull_wf,
+                trunk_wf,
                 test_artifacts_list_cuda,
                 test_folder=folder_list[1],
                 allowed_substrings=cuda_artifact_substrings,

--- a/.automation_scripts/pytorch-unit-test-scripts/download_testlogs
+++ b/.automation_scripts/pytorch-unit-test-scripts/download_testlogs
@@ -509,7 +509,7 @@ def main():
     if not args.exclude_distributed and not args.no_rocm:
         periodic_sha = sha
         print("==============================================")
-        print(f"Finding ROCm tests in {ROCmWorkflowNames["distributed"]} workflow by sha: {sha}")
+        print(f"Finding ROCm distributed tests in workflow '{ROCmWorkflowNames['distributed']}' by sha: {sha}")
         print("==============================================")
         # find distributed test in periodic workflow with success status
         error_msg="Error: Periodic workflow not found in scanned workflow runs."
@@ -530,7 +530,8 @@ def main():
             periodic_fallback_used = True
         if periodic_wf is None:
             raise Exception(error_msg)
-        print(f"Using workflow with id:{periodic_wf['id']} as periodic_wf")
+        dist_wf_name = ROCmWorkflowNames['distributed'] if not periodic_fallback_used else periodic_fallbacks[arch][0]
+        print(f"Using workflow '{dist_wf_name}' with id:{periodic_wf['id']} for ROCm distributed")
 
         if periodic_fallback_used and arch in periodic_fallbacks:
             dist_job_prefix = periodic_fallbacks[arch][1]
@@ -570,7 +571,7 @@ def main():
     if not args.no_rocm and not args.exclude_default:
         rocm_sha = sha
         print("===========================================")
-        print(f"Finding ROCm tests in ROCmWorkflowNames["default"] workflow by sha: {rocm_sha}")
+        print(f"Finding ROCm default tests in workflow '{ROCmWorkflowNames['default']}' by sha: {rocm_sha}")
         print("===========================================")
         # find tests in rocm workflow with given sha and success status
         #https://docs.github.com/en/rest/actions/workflow-runs#list-workflow-runs-for-a-repository
@@ -591,7 +592,8 @@ def main():
             rocm_job_prefix['default'] = fallback_prefix
         if rocm_wf is None:
             raise Exception(error_msg)
-        print(f"Using workflow with id:{rocm_wf['id']} as rocm_wf{' (fallback)' if default_fallback_used else ''}")
+        default_wf_name = ROCmWorkflowNames['default'] if not default_fallback_used else default_fallbacks[arch][0]
+        print(f"Using workflow '{default_wf_name}' with id:{rocm_wf['id']} for ROCm default{' (fallback)' if default_fallback_used else ''}")
 
         folder_list = get_or_create_test_folder(rocm_wf)
 
@@ -627,11 +629,11 @@ def main():
         # find tests in inductor workflow with given sha and success status
         #https://docs.github.com/en/rest/actions/workflow-runs#list-workflow-runs-for-a-repository
         print("===========================================")
-        print(f"Finding ROCm tests in ROCmWorkflowNames["inductor"] workflow by sha: {inductor_rocm_sha}")
+        print(f"Finding ROCm inductor tests in workflow '{ROCmWorkflowNames['inductor']}' by sha: {inductor_rocm_sha}")
         print("===========================================")
         error_msg="Error: inductor workflow not found in scanned workflow runs. Try increasing max_pages."
         inductor_wf_rocm = download_workflow_run(created=args.created, max_pages=args.max_pages, workflow=ROCmWorkflowNames["inductor"], sha=inductor_rocm_sha, ignore_status=args.ignore_status, status=status, error_msg=error_msg)
-        print(f"Using workflow with id:{inductor_wf_rocm['id']} as inductor_wf_rocm")
+        print(f"Using workflow '{ROCmWorkflowNames['inductor']}' with id:{inductor_wf_rocm['id']} for ROCm inductor")
 
         folder_list = get_or_create_test_folder(inductor_wf_rocm)
 
@@ -661,7 +663,7 @@ def main():
     if not args.no_cuda:
         cuda_job_prefix = "linux-jammy-cuda13.0-py3.10-gcc11"
         print("==========================================")
-        print(f"Finding CUDA tests in trunk workflow by sha: {sha}")
+        print(f"Finding CUDA tests in workflow '{CUDAWorkflowNames['default']}' by sha: {sha}")
         print("==========================================")
 
         # There can be multiple trunk runs for the same SHA. Find the one
@@ -723,7 +725,7 @@ def main():
         if trunk_wf is None:
             raise Exception("Error: No trunk workflow run found for CUDA tests")
 
-        print(f"Using trunk workflow run {trunk_wf['id']} for CUDA")
+        print(f"Using workflow '{CUDAWorkflowNames['default']}' with id:{trunk_wf['id']} for CUDA default")
 
         cuda_job_ids = [str(j['id']) for j in cuda_test_jobs]
         cuda_artifact_substrings = [f"_{jid}" for jid in cuda_job_ids] if cuda_job_ids else ["nvidia.gpu"]
@@ -786,13 +788,13 @@ def main():
         if not args.exclude_inductor:
             inductor_sha = sha
             print("==========================================")
-            print(f"Finding CUDA tests in inductor workflow by sha: {inductor_sha}")
+            print(f"Finding CUDA inductor tests in workflow '{CUDAWorkflowNames['inductor']}' by sha: {inductor_sha}")
             print("==========================================")
             # find tests in inductor workflow with given sha and success status
             #https://docs.github.com/en/rest/actions/workflow-runs#list-workflow-runs-for-a-repository
             error_msg="Error: inductor workflow not found in scanned workflow runs. Try increasing max_pages."
             inductor_wf_cuda = download_workflow_run(created=args.created, max_pages=args.max_pages, workflow=CUDAWorkflowNames["inductor"], sha=inductor_sha, ignore_status=args.ignore_status, status=status, error_msg=error_msg)
-            print(f"Using workflow with id:{inductor_wf_cuda['id']} as inductor_wf_cuda")
+            print(f"Using workflow '{CUDAWorkflowNames['inductor']}' with id:{inductor_wf_cuda['id']} for CUDA inductor")
 
             folder_list = get_or_create_test_folder(inductor_wf_cuda)
 
@@ -842,7 +844,7 @@ def main():
                     ignore_status=args.ignore_status, status=status,
                     error_msg=f"Baseline default workflow not found for {baseline_sha}",
                 )
-                print(f"Baseline default workflow id: {baseline_default_wf['id']}")
+                print(f"Baseline default workflow '{ROCmWorkflowNames['default']}' id: {baseline_default_wf['id']}")
                 default_shards = rocm_shards["default"]
 
                 if not args.artifacts_only:
@@ -874,7 +876,7 @@ def main():
                     ignore_status=args.ignore_status, status=status,
                     error_msg=f"Baseline distributed workflow not found for {baseline_sha}",
                 )
-                print(f"Baseline distributed workflow id: {baseline_dist_wf['id']}")
+                print(f"Baseline distributed workflow '{ROCmWorkflowNames['distributed']}' id: {baseline_dist_wf['id']}")
                 dist_shards = rocm_shards["distributed"]
 
                 if not args.artifacts_only:
@@ -906,7 +908,7 @@ def main():
                     ignore_status=args.ignore_status, status=status,
                     error_msg=f"Baseline inductor workflow not found for {baseline_sha}",
                 )
-                print(f"Baseline inductor workflow id: {baseline_inductor_wf['id']}")
+                print(f"Baseline inductor workflow '{ROCmWorkflowNames['inductor']}' id: {baseline_inductor_wf['id']}")
                 inductor_shards = rocm_shards["inductor"]
 
                 if not args.artifacts_only:
@@ -935,7 +937,7 @@ def main():
     # Download inductor-periodic benchmark artifacts (separate from parity CSV)
     if args.include_inductor_periodic:
         print("==============================================")
-        print(f"Finding inductor-periodic workflow by sha: {sha}")
+        print(f"Finding inductor-periodic tests in workflow 'inductor-periodic' by sha: {sha}")
         print("==============================================")
         error_msg = "Error: inductor-periodic workflow not found for this SHA. It may not have run on this commit."
         try:
@@ -950,7 +952,7 @@ def main():
             inductor_periodic_wf = None
 
         if inductor_periodic_wf:
-            print(f"Using workflow with id:{inductor_periodic_wf['id']} as inductor_periodic_wf")
+            print(f"Using workflow 'inductor-periodic' with id:{inductor_periodic_wf['id']} for inductor-periodic")
 
             folder_list = get_or_create_test_folder(inductor_periodic_wf)
             test_folder = folder_list[0]

--- a/.automation_scripts/pytorch-unit-test-scripts/generate_summary.py
+++ b/.automation_scripts/pytorch-unit-test-scripts/generate_summary.py
@@ -360,13 +360,13 @@ def write_csv(rows, archs, output_path, failed_tests=None, s1_name='set1', s2_na
 
     if log_failures:
         csv_rows.append(['LOG-BASED FAILURES (not in XML)'])
-        csv_rows.append(['Platform', 'Workflow', 'Test File', 'Test Class', 'Test Name', 'Category', 'Reason', 'Log File'])
+        csv_rows.append(['Platform', 'Workflow', 'Test File', 'Test Class', 'Test Name', 'Category', 'Log File'])
         for lf in log_failures:
             test_class, test_name = _parse_log_failure_names(lf)
             csv_rows.append([
                 lf.get('platform', ''), lf.get('workflow', ''),
                 lf.get('test_file', ''), test_class, test_name,
-                lf.get('category', ''), lf.get('reason', ''),
+                lf.get('category', ''),
                 lf.get('log_file', ''),
             ])
         csv_rows.append([])
@@ -437,16 +437,14 @@ def write_markdown(rows, archs, output_path, failed_tests=None, s1_name='set1', 
         lines.append('These test failures were detected from CI log files but have no XML report')
         lines.append('(typically due to timeouts, crashes, or process kills).')
         lines.append('')
-        lines.append('| Platform | Workflow | Test File | Test Class | Test Name | Category | Reason |')
-        lines.append('| --- | --- | --- | --- | --- | --- | --- |')
+        lines.append('| Platform | Workflow | Test File | Test Class | Test Name | Category |')
+        lines.append('| --- | --- | --- | --- | --- | --- |')
         for lf in log_failures:
             test_class, test_name = _parse_log_failure_names(lf)
-            reason = lf.get('reason', '')[:80]
             lines.append(
                 f"| {lf.get('platform', '')} | {lf.get('workflow', '')} "
                 f"| {lf.get('test_file', '')} | {test_class} "
-                f"| {test_name} | {lf.get('category', '')} "
-                f"| {reason} |"
+                f"| {test_name} | {lf.get('category', '')} |"
             )
         lines.append('')
 

--- a/.automation_scripts/pytorch-unit-test-scripts/generate_summary.py
+++ b/.automation_scripts/pytorch-unit-test-scripts/generate_summary.py
@@ -6,8 +6,8 @@ import os
 import sys
 
 
-WORKFLOWS = ['default', 'distributed', 'inductor']
-WORKFLOW_DISPLAY = {
+TEST_CONFIGS = ['default', 'distributed', 'inductor']
+TEST_CONFIG_DISPLAY = {
     'default': 'TEST DEFAULT',
     'distributed': 'TEST DISTRIBUTED',
     'inductor': 'TEST INDUCTOR',
@@ -65,7 +65,7 @@ def detect_columns(headers, set1_name, set2_name):
     return s1_status, s2_status, s1_time, s2_time
 
 
-def workflow_stats_keys(s1_name, s2_name, has_set2=True):
+def test_config_stats_keys(s1_name, s2_name, has_set2=True):
     s1 = s1_name.upper()
     s2 = s2_name.upper()
     if not has_set2:
@@ -90,13 +90,13 @@ def workflow_stats_keys(s1_name, s2_name, has_set2=True):
     ]
 
 
-def compute_workflow_stats(rows, s1_col, s2_col, s1_name, s2_name, has_set2=True):
+def compute_test_config_stats(rows, s1_col, s2_col, s1_name, s2_name, has_set2=True):
     s1 = s1_name.upper()
     s2 = s2_name.upper()
 
     if not has_set2:
         vals = {}
-        keys = workflow_stats_keys(s1_name, s2_name, has_set2=False)
+        keys = test_config_stats_keys(s1_name, s2_name, has_set2=False)
         vals[keys[0]] = sum(1 for r in rows if r[s1_col] == 'PASSED')
         vals[keys[1]] = sum(1 for r in rows if r[s1_col] == 'SKIPPED')
         vals[keys[2]] = sum(1 for r in rows if r[s1_col] == 'FAILED')
@@ -126,7 +126,7 @@ def compute_workflow_stats(rows, s1_col, s2_col, s1_name, s2_name, has_set2=True
     pct = (skip_miss / total_s2 * 100) if total_s2 else 0
 
     vals = {}
-    keys = workflow_stats_keys(s1_name, s2_name)
+    keys = test_config_stats_keys(s1_name, s2_name)
     vals[keys[0]] = s1_skip_not_s2
     vals[keys[1]] = s1_skip
     vals[keys[2]] = s2_skip
@@ -192,7 +192,7 @@ def compute_overall_stats(rows, s1_col, s2_col, s1_time_col, s2_time_col, s1_nam
 
     total_disagree = 0
     total_s2 = 0
-    for wf in WORKFLOWS:
+    for wf in TEST_CONFIGS:
         wf_rows = [r for r in rows if r['work_flow_name'] == wf]
         s1_skip_not_s2 = sum(
             1 for r in wf_rows
@@ -247,7 +247,7 @@ def collect_failed_tests(arch_data, archs, s1_name, s2_name):
                     'test_file': r.get('test_file', ''),
                     'test_class': r.get('test_class', ''),
                     'test_name': r.get('test_name', ''),
-                    'workflow': r.get('work_flow_name', ''),
+                    'test_config': r.get('work_flow_name', ''),
                     'shard': shard,
                     f'status_{s1_name}': s1,
                 }
@@ -285,16 +285,16 @@ def build_rows(args, archs, arch_data):
     if args.pr_id:
         out.append(('__header__', f'PR ID: {args.pr_id}'))
 
-    wf_keys = workflow_stats_keys(args.set1_name, args.set2_name, has_set2=any_has_set2)
-    for wf in WORKFLOWS:
-        out.append(('__section__', WORKFLOW_DISPLAY[wf]))
+    wf_keys = test_config_stats_keys(args.set1_name, args.set2_name, has_set2=any_has_set2)
+    for wf in TEST_CONFIGS:
+        out.append(('__section__', TEST_CONFIG_DISPLAY[wf]))
         arch_stats = {}
         for arch in archs:
             d = arch_data[arch]
             s1_col, s2_col, _, _ = d['cols']
             has_set2 = d.get('has_set2', True)
             wf_rows = [r for r in d['rows'] if r['work_flow_name'] == wf]
-            arch_stats[arch] = compute_workflow_stats(
+            arch_stats[arch] = compute_test_config_stats(
                 wf_rows, s1_col, s2_col, args.set1_name, args.set2_name,
                 has_set2=has_set2,
             )
@@ -352,7 +352,7 @@ def write_csv(rows, archs, output_path, failed_tests=None, s1_name='set1', s2_na
             header.append(f'Status ({s2_name})')
         csv_rows.append(header)
         for t in failed_tests:
-            row = [t['arch'], t['workflow'], t['test_file'],
+            row = [t['arch'], t['test_config'], t['test_file'],
                    t['test_class'], t['test_name'], t.get('shard', ''),
                    t[f'status_{s1_name}']]
             if has_set2:
@@ -366,7 +366,7 @@ def write_csv(rows, archs, output_path, failed_tests=None, s1_name='set1', s2_na
         for lf in log_failures:
             test_class, test_name = _parse_log_failure_names(lf)
             csv_rows.append([
-                lf.get('platform', ''), lf.get('workflow', ''),
+                lf.get('platform', ''), lf.get('test_config', ''),
                 lf.get('test_file', ''), test_class, test_name,
                 lf.get('shard', ''), lf.get('category', ''),
                 lf.get('log_file', ''),
@@ -419,7 +419,7 @@ def write_markdown(rows, archs, output_path, failed_tests=None, s1_name='set1', 
         lines.append('| ' + ' | '.join(cols) + ' |')
         lines.append('| ' + ' | '.join(['---'] * len(cols)) + ' |')
         for t in failed_tests:
-            line = (f"| {t['arch']} | {t['workflow']} | {t['test_file']} "
+            line = (f"| {t['arch']} | {t['test_config']} | {t['test_file']} "
                     f"| {t['test_class']} | {t['test_name']} "
                     f"| {t.get('shard', '')} | {t[f'status_{s1_name}']}")
             if has_set2:
@@ -444,7 +444,7 @@ def write_markdown(rows, archs, output_path, failed_tests=None, s1_name='set1', 
         for lf in log_failures:
             test_class, test_name = _parse_log_failure_names(lf)
             lines.append(
-                f"| {lf.get('platform', '')} | {lf.get('workflow', '')} "
+                f"| {lf.get('platform', '')} | {lf.get('test_config', '')} "
                 f"| {lf.get('test_file', '')} | {test_class} "
                 f"| {test_name} | {lf.get('shard', '')} "
                 f"| {lf.get('category', '')} |"

--- a/.automation_scripts/pytorch-unit-test-scripts/generate_summary.py
+++ b/.automation_scripts/pytorch-unit-test-scripts/generate_summary.py
@@ -315,6 +315,15 @@ def build_rows(args, archs, arch_data):
     return out
 
 
+def _parse_log_failure_names(lf):
+    """Extract test_class and test_name from a log failure's reason field."""
+    reason = lf.get('reason', '')
+    if '::' in reason:
+        parts = reason.split('::', 1)
+        return parts[0], parts[1]
+    return '', ''
+
+
 def write_csv(rows, archs, output_path, failed_tests=None, s1_name='set1', s2_name='set2', has_set2=True, log_failures=None):
     csv_rows = []
     csv_rows.append([''] + list(archs))
@@ -348,11 +357,12 @@ def write_csv(rows, archs, output_path, failed_tests=None, s1_name='set1', s2_na
         csv_rows.append(['LOG-BASED FAILURES (not in XML)'])
         csv_rows.append(['Platform', 'Workflow', 'Test File', 'Test Class', 'Test Name', 'Category', 'Reason', 'Log File'])
         for lf in log_failures:
+            test_class, test_name = _parse_log_failure_names(lf)
             csv_rows.append([
                 lf.get('platform', ''), lf.get('workflow', ''),
-                lf.get('test_file', ''), lf.get('test_class', ''),
-                lf.get('test_name', ''), lf.get('category', ''),
-                lf.get('reason', ''), lf.get('log_file', ''),
+                lf.get('test_file', ''), test_class, test_name,
+                lf.get('category', ''), lf.get('reason', ''),
+                lf.get('log_file', ''),
             ])
         csv_rows.append([])
 
@@ -425,11 +435,12 @@ def write_markdown(rows, archs, output_path, failed_tests=None, s1_name='set1', 
         lines.append('| Platform | Workflow | Test File | Test Class | Test Name | Category | Reason |')
         lines.append('| --- | --- | --- | --- | --- | --- | --- |')
         for lf in log_failures:
+            test_class, test_name = _parse_log_failure_names(lf)
             reason = lf.get('reason', '')[:80]
             lines.append(
                 f"| {lf.get('platform', '')} | {lf.get('workflow', '')} "
-                f"| {lf.get('test_file', '')} | {lf.get('test_class', '')} "
-                f"| {lf.get('test_name', '')} | {lf.get('category', '')} "
+                f"| {lf.get('test_file', '')} | {test_class} "
+                f"| {test_name} | {lf.get('category', '')} "
                 f"| {reason} |"
             )
         lines.append('')

--- a/.automation_scripts/pytorch-unit-test-scripts/generate_summary.py
+++ b/.automation_scripts/pytorch-unit-test-scripts/generate_summary.py
@@ -316,12 +316,17 @@ def build_rows(args, archs, arch_data):
 
 
 def _parse_log_failure_names(lf):
-    """Extract test_class and test_name from a log failure's reason field."""
+    """Extract test_class and test_name from a log failure's reason field.
+
+    Handles formats like 'TestClass::test_method' and
+    'TestClass::test_method | extra reason text'.
+    """
     reason = lf.get('reason', '')
-    if '::' in reason:
-        parts = reason.split('::', 1)
-        return parts[0], parts[1]
-    return '', ''
+    if '::' not in reason:
+        return '', ''
+    test_part = reason.split(' | ', 1)[0] if ' | ' in reason else reason
+    parts = test_part.split('::', 1)
+    return parts[0], parts[1]
 
 
 def write_csv(rows, archs, output_path, failed_tests=None, s1_name='set1', s2_name='set2', has_set2=True, log_failures=None):

--- a/.automation_scripts/pytorch-unit-test-scripts/generate_summary.py
+++ b/.automation_scripts/pytorch-unit-test-scripts/generate_summary.py
@@ -346,7 +346,7 @@ def write_csv(rows, archs, output_path, failed_tests=None, s1_name='set1', s2_na
 
     if failed_tests:
         csv_rows.append(['FAILED TESTS'])
-        header = ['Arch', 'Workflow', 'Test File', 'Test Class',
+        header = ['Arch', 'Test Config', 'Test File', 'Test Class',
                   'Test Name', 'Shard', f'Status ({s1_name})']
         if has_set2:
             header.append(f'Status ({s2_name})')
@@ -362,7 +362,7 @@ def write_csv(rows, archs, output_path, failed_tests=None, s1_name='set1', s2_na
 
     if log_failures:
         csv_rows.append(['LOG-BASED FAILURES (not in XML)'])
-        csv_rows.append(['Platform', 'Workflow', 'Test File', 'Test Class', 'Test Name', 'Shard', 'Category', 'Log File'])
+        csv_rows.append(['Platform', 'Test Config', 'Test File', 'Test Class', 'Test Name', 'Shard', 'Category', 'Log File'])
         for lf in log_failures:
             test_class, test_name = _parse_log_failure_names(lf)
             csv_rows.append([
@@ -412,7 +412,7 @@ def write_markdown(rows, archs, output_path, failed_tests=None, s1_name='set1', 
     if failed_tests:
         lines.append('### FAILED TESTS')
         lines.append('')
-        cols = ['Arch', 'Workflow', 'Test File', 'Test Class', 'Test Name',
+        cols = ['Arch', 'Test Config', 'Test File', 'Test Class', 'Test Name',
                 'Shard', f'Status ({s1_name})']
         if has_set2:
             cols.append(f'Status ({s2_name})')
@@ -439,7 +439,7 @@ def write_markdown(rows, archs, output_path, failed_tests=None, s1_name='set1', 
         lines.append('These test failures were detected from CI log files but have no XML report')
         lines.append('(typically due to timeouts, crashes, or process kills).')
         lines.append('')
-        lines.append('| Platform | Workflow | Test File | Test Class | Test Name | Shard | Category |')
+        lines.append('| Platform | Test Config | Test File | Test Class | Test Name | Shard | Category |')
         lines.append('| --- | --- | --- | --- | --- | --- | --- |')
         for lf in log_failures:
             test_class, test_name = _parse_log_failure_names(lf)

--- a/.automation_scripts/pytorch-unit-test-scripts/generate_summary.py
+++ b/.automation_scripts/pytorch-unit-test-scripts/generate_summary.py
@@ -2,6 +2,7 @@
 
 import argparse
 import csv
+import os
 import sys
 
 
@@ -38,6 +39,10 @@ def parse_args():
     parser.add_argument(
         '--output', type=str, default='parity_summary',
         help='Output path prefix (produces .csv and .md)'
+    )
+    parser.add_argument(
+        '--log-failures', nargs='*', default=[],
+        help='CSV file(s) from detect_log_failures.py to include in summary'
     )
     return parser.parse_args()
 
@@ -250,6 +255,18 @@ def collect_failed_tests(arch_data, archs, s1_name, s2_name):
     return failed
 
 
+def load_log_failures(filepaths):
+    """Load log failure CSVs from detect_log_failures.py."""
+    entries = []
+    for fp in filepaths:
+        if not os.path.isfile(fp):
+            continue
+        with open(fp, newline='') as f:
+            for row in csv.DictReader(f):
+                entries.append(row)
+    return entries
+
+
 def fmt_val(v):
     if isinstance(v, int):
         return f'{v:,}'
@@ -298,7 +315,7 @@ def build_rows(args, archs, arch_data):
     return out
 
 
-def write_csv(rows, archs, output_path, failed_tests=None, s1_name='set1', s2_name='set2', has_set2=True):
+def write_csv(rows, archs, output_path, failed_tests=None, s1_name='set1', s2_name='set2', has_set2=True, log_failures=None):
     csv_rows = []
     csv_rows.append([''] + list(archs))
     for label, vals in rows:
@@ -327,12 +344,24 @@ def write_csv(rows, archs, output_path, failed_tests=None, s1_name='set1', s2_na
             csv_rows.append(row)
         csv_rows.append([])
 
+    if log_failures:
+        csv_rows.append(['LOG-BASED FAILURES (not in XML)'])
+        csv_rows.append(['Platform', 'Workflow', 'Test File', 'Test Class', 'Test Name', 'Category', 'Reason', 'Log File'])
+        for lf in log_failures:
+            csv_rows.append([
+                lf.get('platform', ''), lf.get('workflow', ''),
+                lf.get('test_file', ''), lf.get('test_class', ''),
+                lf.get('test_name', ''), lf.get('category', ''),
+                lf.get('reason', ''), lf.get('log_file', ''),
+            ])
+        csv_rows.append([])
+
     with open(output_path, 'w', newline='') as f:
         csv.writer(f).writerows(csv_rows)
     print(f'CSV written to {output_path}')
 
 
-def write_markdown(rows, archs, output_path, failed_tests=None, s1_name='set1', s2_name='set2', has_set2=True):
+def write_markdown(rows, archs, output_path, failed_tests=None, s1_name='set1', s2_name='set2', has_set2=True, log_failures=None):
     lines = []
     current_section = []
 
@@ -387,6 +416,24 @@ def write_markdown(rows, archs, output_path, failed_tests=None, s1_name='set1', 
         lines.append('No failed tests found.')
         lines.append('')
 
+    if log_failures:
+        lines.append('### LOG-BASED FAILURES (not in XML)')
+        lines.append('')
+        lines.append('These test failures were detected from CI log files but have no XML report')
+        lines.append('(typically due to timeouts, crashes, or process kills).')
+        lines.append('')
+        lines.append('| Platform | Workflow | Test File | Test Class | Test Name | Category | Reason |')
+        lines.append('| --- | --- | --- | --- | --- | --- | --- |')
+        for lf in log_failures:
+            reason = lf.get('reason', '')[:80]
+            lines.append(
+                f"| {lf.get('platform', '')} | {lf.get('workflow', '')} "
+                f"| {lf.get('test_file', '')} | {lf.get('test_class', '')} "
+                f"| {lf.get('test_name', '')} | {lf.get('category', '')} "
+                f"| {reason} |"
+            )
+        lines.append('')
+
     md = '\n'.join(lines)
     with open(output_path, 'w') as f:
         f.write(md)
@@ -414,13 +461,14 @@ def main():
     data_rows = build_rows(args, archs, arch_data)
     failed = collect_failed_tests(arch_data, archs, args.set1_name, args.set2_name)
     any_has_set2 = any(d.get('has_set2', True) for d in arch_data.values())
+    log_failures = load_log_failures(args.log_failures) if args.log_failures else []
 
     output_base = args.output
     if output_base.endswith('.csv') or output_base.endswith('.md'):
         output_base = output_base.rsplit('.', 1)[0]
 
-    write_csv(data_rows, archs, f'{output_base}.csv', failed, args.set1_name, args.set2_name, has_set2=any_has_set2)
-    write_markdown(data_rows, archs, f'{output_base}.md', failed, args.set1_name, args.set2_name, has_set2=any_has_set2)
+    write_csv(data_rows, archs, f'{output_base}.csv', failed, args.set1_name, args.set2_name, has_set2=any_has_set2, log_failures=log_failures)
+    write_markdown(data_rows, archs, f'{output_base}.md', failed, args.set1_name, args.set2_name, has_set2=any_has_set2, log_failures=log_failures)
 
 
 if __name__ == '__main__':

--- a/.automation_scripts/pytorch-unit-test-scripts/generate_summary.py
+++ b/.automation_scripts/pytorch-unit-test-scripts/generate_summary.py
@@ -193,7 +193,7 @@ def compute_overall_stats(rows, s1_col, s2_col, s1_time_col, s2_time_col, s1_nam
     total_disagree = 0
     total_s2 = 0
     for wf in TEST_CONFIGS:
-        wf_rows = [r for r in rows if r['work_flow_name'] == wf]
+        wf_rows = [r for r in rows if r['test_config'] == wf]
         s1_skip_not_s2 = sum(
             1 for r in wf_rows
             if r[s1_col] == 'SKIPPED' and r[s2_col] != 'SKIPPED'
@@ -247,7 +247,7 @@ def collect_failed_tests(arch_data, archs, s1_name, s2_name):
                     'test_file': r.get('test_file', ''),
                     'test_class': r.get('test_class', ''),
                     'test_name': r.get('test_name', ''),
-                    'test_config': r.get('work_flow_name', ''),
+                    'test_config': r.get('test_config', ''),
                     'shard': shard,
                     f'status_{s1_name}': s1,
                 }
@@ -293,7 +293,7 @@ def build_rows(args, archs, arch_data):
             d = arch_data[arch]
             s1_col, s2_col, _, _ = d['cols']
             has_set2 = d.get('has_set2', True)
-            wf_rows = [r for r in d['rows'] if r['work_flow_name'] == wf]
+            wf_rows = [r for r in d['rows'] if r['test_config'] == wf]
             arch_stats[arch] = compute_test_config_stats(
                 wf_rows, s1_col, s2_col, args.set1_name, args.set2_name,
                 has_set2=has_set2,

--- a/.automation_scripts/pytorch-unit-test-scripts/generate_summary.py
+++ b/.automation_scripts/pytorch-unit-test-scripts/generate_summary.py
@@ -241,12 +241,14 @@ def collect_failed_tests(arch_data, archs, s1_name, s2_name):
             s1 = r[s1_col].strip()
             s2 = r[s2_col].strip() if has_set2 else ''
             if s1 == 'FAILED' or s2 == 'FAILED':
+                shard = r.get(f'shard_{s1_name}', '') if s1 == 'FAILED' else r.get(f'shard_{s2_name}', '')
                 entry = {
                     'arch': arch,
                     'test_file': r.get('test_file', ''),
                     'test_class': r.get('test_class', ''),
                     'test_name': r.get('test_name', ''),
                     'workflow': r.get('work_flow_name', ''),
+                    'shard': shard,
                     f'status_{s1_name}': s1,
                 }
                 if has_set2:
@@ -345,13 +347,13 @@ def write_csv(rows, archs, output_path, failed_tests=None, s1_name='set1', s2_na
     if failed_tests:
         csv_rows.append(['FAILED TESTS'])
         header = ['Arch', 'Workflow', 'Test File', 'Test Class',
-                  'Test Name', f'Status ({s1_name})']
+                  'Test Name', 'Shard', f'Status ({s1_name})']
         if has_set2:
             header.append(f'Status ({s2_name})')
         csv_rows.append(header)
         for t in failed_tests:
             row = [t['arch'], t['workflow'], t['test_file'],
-                   t['test_class'], t['test_name'],
+                   t['test_class'], t['test_name'], t.get('shard', ''),
                    t[f'status_{s1_name}']]
             if has_set2:
                 row.append(t.get(f'status_{s2_name}', ''))
@@ -360,13 +362,13 @@ def write_csv(rows, archs, output_path, failed_tests=None, s1_name='set1', s2_na
 
     if log_failures:
         csv_rows.append(['LOG-BASED FAILURES (not in XML)'])
-        csv_rows.append(['Platform', 'Workflow', 'Test File', 'Test Class', 'Test Name', 'Category', 'Log File'])
+        csv_rows.append(['Platform', 'Workflow', 'Test File', 'Test Class', 'Test Name', 'Shard', 'Category', 'Log File'])
         for lf in log_failures:
             test_class, test_name = _parse_log_failure_names(lf)
             csv_rows.append([
                 lf.get('platform', ''), lf.get('workflow', ''),
                 lf.get('test_file', ''), test_class, test_name,
-                lf.get('category', ''),
+                lf.get('shard', ''), lf.get('category', ''),
                 lf.get('log_file', ''),
             ])
         csv_rows.append([])
@@ -411,7 +413,7 @@ def write_markdown(rows, archs, output_path, failed_tests=None, s1_name='set1', 
         lines.append('### FAILED TESTS')
         lines.append('')
         cols = ['Arch', 'Workflow', 'Test File', 'Test Class', 'Test Name',
-                f'Status ({s1_name})']
+                'Shard', f'Status ({s1_name})']
         if has_set2:
             cols.append(f'Status ({s2_name})')
         lines.append('| ' + ' | '.join(cols) + ' |')
@@ -419,7 +421,7 @@ def write_markdown(rows, archs, output_path, failed_tests=None, s1_name='set1', 
         for t in failed_tests:
             line = (f"| {t['arch']} | {t['workflow']} | {t['test_file']} "
                     f"| {t['test_class']} | {t['test_name']} "
-                    f"| {t[f'status_{s1_name}']}")
+                    f"| {t.get('shard', '')} | {t[f'status_{s1_name}']}")
             if has_set2:
                 line += f" | {t.get(f'status_{s2_name}', '')}"
             line += ' |'
@@ -437,14 +439,15 @@ def write_markdown(rows, archs, output_path, failed_tests=None, s1_name='set1', 
         lines.append('These test failures were detected from CI log files but have no XML report')
         lines.append('(typically due to timeouts, crashes, or process kills).')
         lines.append('')
-        lines.append('| Platform | Workflow | Test File | Test Class | Test Name | Category |')
-        lines.append('| --- | --- | --- | --- | --- | --- |')
+        lines.append('| Platform | Workflow | Test File | Test Class | Test Name | Shard | Category |')
+        lines.append('| --- | --- | --- | --- | --- | --- | --- |')
         for lf in log_failures:
             test_class, test_name = _parse_log_failure_names(lf)
             lines.append(
                 f"| {lf.get('platform', '')} | {lf.get('workflow', '')} "
                 f"| {lf.get('test_file', '')} | {test_class} "
-                f"| {test_name} | {lf.get('category', '')} |"
+                f"| {test_name} | {lf.get('shard', '')} "
+                f"| {lf.get('category', '')} |"
             )
         lines.append('')
 

--- a/.automation_scripts/pytorch-unit-test-scripts/generate_summary.py
+++ b/.automation_scripts/pytorch-unit-test-scripts/generate_summary.py
@@ -258,13 +258,21 @@ def collect_failed_tests(arch_data, archs, s1_name, s2_name):
 
 
 def load_log_failures(filepaths):
-    """Load log failure CSVs from detect_log_failures.py."""
+    """Load log failure CSVs from detect_log_failures.py.
+
+    Extracts the architecture from the filename (e.g. log_failures_mi355.csv -> mi355).
+    """
     entries = []
     for fp in filepaths:
         if not os.path.isfile(fp):
             continue
+        basename = os.path.basename(fp)
+        arch = ''
+        if basename.startswith('log_failures_') and basename.endswith('.csv'):
+            arch = basename[len('log_failures_'):-len('.csv')]
         with open(fp, newline='') as f:
             for row in csv.DictReader(f):
+                row['arch'] = arch
                 entries.append(row)
     return entries
 
@@ -362,11 +370,11 @@ def write_csv(rows, archs, output_path, failed_tests=None, s1_name='set1', s2_na
 
     if log_failures:
         csv_rows.append(['LOG-BASED FAILURES (not in XML)'])
-        csv_rows.append(['Platform', 'Test Config', 'Test File', 'Test Class', 'Test Name', 'Shard', 'Category', 'Log File'])
+        csv_rows.append(['Arch', 'Platform', 'Test Config', 'Test File', 'Test Class', 'Test Name', 'Shard', 'Category', 'Log File'])
         for lf in log_failures:
             test_class, test_name = _parse_log_failure_names(lf)
             csv_rows.append([
-                lf.get('platform', ''), lf.get('test_config', ''),
+                lf.get('arch', ''), lf.get('platform', ''), lf.get('test_config', ''),
                 lf.get('test_file', ''), test_class, test_name,
                 lf.get('shard', ''), lf.get('category', ''),
                 lf.get('log_file', ''),
@@ -439,12 +447,12 @@ def write_markdown(rows, archs, output_path, failed_tests=None, s1_name='set1', 
         lines.append('These test failures were detected from CI log files but have no XML report')
         lines.append('(typically due to timeouts, crashes, or process kills).')
         lines.append('')
-        lines.append('| Platform | Test Config | Test File | Test Class | Test Name | Shard | Category |')
-        lines.append('| --- | --- | --- | --- | --- | --- | --- |')
+        lines.append('| Arch | Platform | Test Config | Test File | Test Class | Test Name | Shard | Category |')
+        lines.append('| --- | --- | --- | --- | --- | --- | --- | --- |')
         for lf in log_failures:
             test_class, test_name = _parse_log_failure_names(lf)
             lines.append(
-                f"| {lf.get('platform', '')} | {lf.get('test_config', '')} "
+                f"| {lf.get('arch', '')} | {lf.get('platform', '')} | {lf.get('test_config', '')} "
                 f"| {lf.get('test_file', '')} | {test_class} "
                 f"| {test_name} | {lf.get('shard', '')} "
                 f"| {lf.get('category', '')} |"

--- a/.automation_scripts/pytorch-unit-test-scripts/summarize_xml_testreports.py
+++ b/.automation_scripts/pytorch-unit-test-scripts/summarize_xml_testreports.py
@@ -49,7 +49,7 @@ EXCLUDED_TESTS = [
 ]
 
 
-# Workflow names
+# Test config names
 TestConfigName = Enum('TestConfigName', ['default', 'distributed', 'inductor'])
 
 def _status_priority(test_case):
@@ -219,7 +219,7 @@ def summarize_xml_files(args):
     #parse the xml files
     test_cases_set1_running_time = parse_xml_reports_as_dict(-1, -1, 'testsuite', set1_path)
     # TODO: Does it matter what the workflow_run_attempt is set to below??
-    # test_cases is dict of dicts, with keys as tuple of test_file, test_class, test_name and test workflow
+    # test_cases is dict of dicts, with keys as tuple of test_file, test_class, test_name and test_config
     test_cases_set1 = parse_xml_reports_as_dict(-1, -1, 'testcase', set1_path)
     for (k,v) in list(test_cases_set1.items()):
         if v['test_config'] == TestConfigName.default.name:
@@ -299,28 +299,28 @@ def summarize_xml_files(args):
     test_file_level_CUDA: Dict[Tuple[str], float] = {}
     for (k,v) in list(test_cases_set1_running_time.items()):
           test_file_name = k[0]
-          test_workflow_name = k[2]
-          tar_tup_rocm = (test_file_name, test_workflow_name,)
+          test_config_name = k[2]
+          tar_tup_rocm = (test_file_name, test_config_name,)
           if test_file_level_ROCm.get(tar_tup_rocm) == None:
-              test_file_level_ROCm[ ( test_file_name, test_workflow_name ) ] = v["running_time_xml"]
+              test_file_level_ROCm[ ( test_file_name, test_config_name ) ] = v["running_time_xml"]
           else:
-              test_file_level_ROCm[ ( test_file_name, test_workflow_name ) ] += v["running_time_xml"]
+              test_file_level_ROCm[ ( test_file_name, test_config_name ) ] += v["running_time_xml"]
     for (k,v) in list(test_cases_set2_running_time.items()):
           test_file_name = k[0]
-          test_workflow_name = k[2]
-          tar_tup_cuda = (test_file_name, test_workflow_name)
+          test_config_name = k[2]
+          tar_tup_cuda = (test_file_name, test_config_name)
           if test_file_level_CUDA.get(tar_tup_cuda) == None:
-              test_file_level_CUDA[ ( test_file_name, test_workflow_name ) ] = v["running_time_xml"]
+              test_file_level_CUDA[ ( test_file_name, test_config_name ) ] = v["running_time_xml"]
           else:
-              test_file_level_CUDA[ ( test_file_name, test_workflow_name ) ] += v["running_time_xml"]
+              test_file_level_CUDA[ ( test_file_name, test_config_name ) ] += v["running_time_xml"]
 
     # test file level counts: ROCm tests run, passed, skipped, missed; CUDA tests run
     test_file_counts_ROCm: Dict[Tuple[str], Dict[str, int]] = {}
     test_file_counts_CUDA: Dict[Tuple[str], int] = {}
     for (k,v) in list(test_cases_set1.items()):
         test_file_name = k[0]
-        test_workflow_name = v['test_config']
-        tar_tup = (test_file_name, test_workflow_name)
+        test_config_name = v['test_config']
+        tar_tup = (test_file_name, test_config_name)
         if tar_tup not in test_file_counts_ROCm:
             test_file_counts_ROCm[tar_tup] = {'tests_run': 0, 'passed': 0, 'skipped': 0, 'missed': 0}
         test_file_counts_ROCm[tar_tup]['tests_run'] += 1
@@ -333,8 +333,8 @@ def summarize_xml_files(args):
             test_file_counts_ROCm[tar_tup]['missed'] += 1
     for (k,v) in list(test_cases_set2.items()) if set2_path else []:
         test_file_name = k[0]
-        test_workflow_name = v['test_config']
-        tar_tup = (test_file_name, test_workflow_name)
+        test_config_name = v['test_config']
+        tar_tup = (test_file_name, test_config_name)
         if tar_tup not in test_file_counts_CUDA:
             test_file_counts_CUDA[tar_tup] = 0
         test_file_counts_CUDA[tar_tup] += 1
@@ -460,16 +460,16 @@ def summarize_xml_files(args):
         item_values["test_name"] = k[2]
         item_values[f"status_{set1_name}"] = get_test_status(v[0])
         item_values[f"status_{set2_name}"] = get_test_status(v[1]) if set2_path else ""
-        # get workflow info
+        # get test config info
         v_values = v[0]
         v1_values = v[1] if set2_path else []
-        workflow_name = ""
+        config_name = ""
         item_values["test_config"] = ""
         if item_values[f"status_{set1_name}"] != "MISSED":
-            workflow_name = v_values['test_config']
+            config_name = v_values['test_config']
         elif item_values[f"status_{set2_name}"] != "MISSED" and item_values[f"status_{set2_name}"] != "":
-            workflow_name = v1_values['test_config']
-        item_values["test_config"] = workflow_name
+            config_name = v1_values['test_config']
+        item_values["test_config"] = config_name
         item_values[f"shard_{set1_name}"] = v_values.get('shard', '') if v_values else ''
         item_values[f"shard_{set2_name}"] = v1_values.get('shard', '') if v1_values else ''
         # get test related info
@@ -591,7 +591,7 @@ def summarize_xml_files(args):
     for key_rocm in test_file_level_ROCm.keys():
         item_values = {}
         item_values["test_file"] = key_rocm[0]
-        item_values["test_workflow"] = key_rocm[1]
+        item_values["test_config"] = key_rocm[1]
         item_values["rocm_running_time"] = test_file_level_ROCm[key_rocm]
         item_values["cuda_running_time"] = 0.0
         if key_rocm in test_file_level_CUDA.keys():
@@ -612,7 +612,7 @@ def summarize_xml_files(args):
         if not key_cuda in test_file_level_ROCm.keys():
             item_values = {}
             item_values["test_file"] = key_cuda[0]
-            item_values["test_workflow"] = key_cuda[1]
+            item_values["test_config"] = key_cuda[1]
             item_values["rocm_running_time"] = 0.0
             item_values["cuda_running_time"] = test_file_level_CUDA[key_cuda]
             item_values["abs_time_diff"] = item_values["rocm_running_time"] - item_values["cuda_running_time"]
@@ -632,7 +632,7 @@ def summarize_xml_files(args):
     def sorting_key_running_time(e):
         if e == "test_file":
           return 0
-        elif e == "test_workflow":
+        elif e == "test_config":
           return 1
         elif e == "rocm_running_time":
           return 2

--- a/.automation_scripts/pytorch-unit-test-scripts/summarize_xml_testreports.py
+++ b/.automation_scripts/pytorch-unit-test-scripts/summarize_xml_testreports.py
@@ -3,6 +3,7 @@
 import argparse
 import csv
 import os
+import re
 import pandas as pd
 from enum import Enum
 from itertools import chain
@@ -58,6 +59,13 @@ def _status_priority(test_case):
     status = get_test_status(test_case)
     return {"PASSED": 4, "XFAILED": 3, "SKIPPED": 2, "FAILED": 1, "ERROR": 1, "MISSED": 0}.get(status, 0)
 
+def _extract_shard(dirname):
+    """Extract shard number from directory names like 'test-default-3-6'."""
+    m = re.match(r'test-\w+-(\d+)-(\d+)', dirname)
+    if m:
+        return f"{m.group(1)}/{m.group(2)}"
+    return ""
+
 def parse_xml_reports_as_dict(workflow_run_id, workflow_run_attempt, tag, path="."):
     work_flow_name = ""
     test_cases = {}
@@ -71,6 +79,7 @@ def parse_xml_reports_as_dict(workflow_run_id, workflow_run_attempt, tag, path="
                 work_flow_name = WorkflowName.distributed.name
             elif "test-inductor" in new_dir:
                 work_flow_name = WorkflowName.inductor.name
+            shard = _extract_shard(dir)
             for xml_report in Path(new_dir).glob("**/*.xml"):
                 try:
                     new_cases = parse_xml_report(
@@ -84,6 +93,7 @@ def parse_xml_reports_as_dict(workflow_run_id, workflow_run_attempt, tag, path="
                     print(f"WARNING: Skipping malformed XML {xml_report}: {e}")
                     continue
                 for key, case in new_cases.items():
+                    case["shard"] = shard
                     existing = test_cases.get(key)
                     if existing is None or _status_priority(case) > _status_priority(existing):
                         test_cases[key] = case
@@ -460,6 +470,8 @@ def summarize_xml_files(args):
         elif item_values[f"status_{set2_name}"] != "MISSED" and item_values[f"status_{set2_name}"] != "":
             workflow_name = v1_values['work_flow_name']
         item_values["work_flow_name"] = workflow_name
+        item_values[f"shard_{set1_name}"] = v_values.get('shard', '') if v_values else ''
+        item_values[f"shard_{set2_name}"] = v1_values.get('shard', '') if v1_values else ''
         # get test related info
         item_values[f"message_{set1_name}"] = get_test_message(v[0])
         item_values[f"message_{set2_name}"] = get_test_message(v[1]) if set2_path else ""
@@ -548,6 +560,10 @@ def summarize_xml_files(args):
           return 19
         elif e == "existed_last_week":
           return 20
+        elif e == f"shard_{set1_name}":
+          return 21
+        elif e == f"shard_{set2_name}":
+          return 22
         elif e == "workflow_run_attempt" or e == "job_id":
           return 1000
         else:

--- a/.automation_scripts/pytorch-unit-test-scripts/summarize_xml_testreports.py
+++ b/.automation_scripts/pytorch-unit-test-scripts/summarize_xml_testreports.py
@@ -50,7 +50,7 @@ EXCLUDED_TESTS = [
 
 
 # Workflow names
-WorkflowName = Enum('WorkflowName', ['default', 'distributed', 'inductor'])
+TestConfigName = Enum('TestConfigName', ['default', 'distributed', 'inductor'])
 
 def _status_priority(test_case):
     """Return a numeric priority for deduplication of retried tests.
@@ -67,18 +67,18 @@ def _extract_shard(dirname):
     return ""
 
 def parse_xml_reports_as_dict(workflow_run_id, workflow_run_attempt, tag, path="."):
-    work_flow_name = ""
+    test_config = ""
     test_cases = {}
     items_list = os.listdir(path)
     for dir in items_list:
         new_dir = path + '/' + dir + '/'
         if os.path.isdir(new_dir):
             if "test-default" in new_dir:
-                work_flow_name = WorkflowName.default.name
+                test_config = TestConfigName.default.name
             elif "test-distributed" in new_dir:
-                work_flow_name = WorkflowName.distributed.name
+                test_config = TestConfigName.distributed.name
             elif "test-inductor" in new_dir:
-                work_flow_name = WorkflowName.inductor.name
+                test_config = TestConfigName.inductor.name
             shard = _extract_shard(dir)
             for xml_report in Path(new_dir).glob("**/*.xml"):
                 try:
@@ -87,7 +87,7 @@ def parse_xml_reports_as_dict(workflow_run_id, workflow_run_attempt, tag, path="
                         xml_report,
                         workflow_run_id,
                         workflow_run_attempt,
-                        work_flow_name
+                        test_config
                     )
                 except Exception as e:
                     print(f"WARNING: Skipping malformed XML {xml_report}: {e}")
@@ -222,11 +222,11 @@ def summarize_xml_files(args):
     # test_cases is dict of dicts, with keys as tuple of test_file, test_class, test_name and test workflow
     test_cases_set1 = parse_xml_reports_as_dict(-1, -1, 'testcase', set1_path)
     for (k,v) in list(test_cases_set1.items()):
-        if v['work_flow_name'] == WorkflowName.default.name:
+        if v['test_config'] == TestConfigName.default.name:
             ROCM_DEFAULT += 1
-        elif v['work_flow_name'] == WorkflowName.distributed.name:
+        elif v['test_config'] == TestConfigName.distributed.name:
             ROCM_DISTRIBUTED += 1
-        elif v['work_flow_name'] == WorkflowName.inductor.name:
+        elif v['test_config'] == TestConfigName.inductor.name:
             ROCM_INDUCTOR += 1
 
     # start with creating empty dicts for set2 for each test tuple
@@ -255,11 +255,11 @@ def summarize_xml_files(args):
       test_cases_set2_running_time = parse_xml_reports_as_dict(-1, -1, 'testsuite', set2_path)
       test_cases_set2 = parse_xml_reports_as_dict(-1, -1, 'testcase', set2_path)
       for (k,v) in list(test_cases_set2.items()):
-          if v['work_flow_name'] == WorkflowName.default.name:
+          if v['test_config'] == TestConfigName.default.name:
               CUDA_DEFAULT += 1
-          elif v['work_flow_name'] == WorkflowName.distributed.name:
+          elif v['test_config'] == TestConfigName.distributed.name:
               CUDA_DISTRIBUTED += 1
-          elif v['work_flow_name'] == WorkflowName.inductor.name:
+          elif v['test_config'] == TestConfigName.inductor.name:
               CUDA_INDUCTOR += 1
 
       # for rocm/cuda comparison, sometimes parity sheet has inaccurate resutls due to different function string but with same test names,
@@ -319,7 +319,7 @@ def summarize_xml_files(args):
     test_file_counts_CUDA: Dict[Tuple[str], int] = {}
     for (k,v) in list(test_cases_set1.items()):
         test_file_name = k[0]
-        test_workflow_name = v['work_flow_name']
+        test_workflow_name = v['test_config']
         tar_tup = (test_file_name, test_workflow_name)
         if tar_tup not in test_file_counts_ROCm:
             test_file_counts_ROCm[tar_tup] = {'tests_run': 0, 'passed': 0, 'skipped': 0, 'missed': 0}
@@ -333,7 +333,7 @@ def summarize_xml_files(args):
             test_file_counts_ROCm[tar_tup]['missed'] += 1
     for (k,v) in list(test_cases_set2.items()) if set2_path else []:
         test_file_name = k[0]
-        test_workflow_name = v['work_flow_name']
+        test_workflow_name = v['test_config']
         tar_tup = (test_file_name, test_workflow_name)
         if tar_tup not in test_file_counts_CUDA:
             test_file_counts_CUDA[tar_tup] = 0
@@ -396,20 +396,20 @@ def summarize_xml_files(args):
         test_info = v[0]
         test_info_set2 = []
         if status_set_1 == "SKIPPED" and status_set_2 != "SKIPPED":
-            if test_info['work_flow_name'] == WorkflowName.default.name:
+            if test_info['test_config'] == TestConfigName.default.name:
                 SKIPPED_DEFAULT += 1
-            elif test_info['work_flow_name'] == WorkflowName.distributed.name:
+            elif test_info['test_config'] == TestConfigName.distributed.name:
                 SKIPPED_DISTRIBUTED += 1
-            elif test_info['work_flow_name'] == WorkflowName.inductor.name:
+            elif test_info['test_config'] == TestConfigName.inductor.name:
                 SKIPPED_INDUCTOR += 1
         elif set2_path:
             test_info_set2 = v[1]
             if status_set_1 == "MISSED" and status_set_2 != "MISSED":
-              if test_info_set2['work_flow_name'] == WorkflowName.default.name:
+              if test_info_set2['test_config'] == TestConfigName.default.name:
                 MISSED_DEFAULT += 1
-              elif test_info_set2['work_flow_name'] == WorkflowName.distributed.name:
+              elif test_info_set2['test_config'] == TestConfigName.distributed.name:
                 MISSED_DISTRIBUTED += 1
-              elif test_info_set2['work_flow_name'] == WorkflowName.inductor.name:
+              elif test_info_set2['test_config'] == TestConfigName.inductor.name:
                 MISSED_INDUCTOR += 1
 
 
@@ -418,17 +418,17 @@ def summarize_xml_files(args):
               for known_skip in known_skips:
                   if test_file_name == known_skip['test_file'] and k[1] == known_skip['test_class'] and k[2] == known_skip['test_name']:
                       v[2] = known_skip['skip_reason'] if known_skip.__contains__('skip_reason') and not pd.isna(known_skip['skip_reason']) else ' '
-                      if (test_info.__contains__('work_flow_name') and test_info['work_flow_name'] == WorkflowName.default.name) or (test_info_set2.__contains__('work_flow_name') and test_info_set2['work_flow_name'] == WorkflowName.default.name):
+                      if (test_info.__contains__('test_config') and test_info['test_config'] == TestConfigName.default.name) or (test_info_set2.__contains__('test_config') and test_info_set2['test_config'] == TestConfigName.default.name):
                           if not skip_reasons_stat_default.__contains__(v[2]):
                               skip_reasons_stat_default[v[2]] = 1
                           else:
                               skip_reasons_stat_default[v[2]] += 1
-                      elif (test_info.__contains__('work_flow_name') and test_info['work_flow_name'] == WorkflowName.distributed.name) or (test_info_set2.__contains__('work_flow_name') and test_info_set2['work_flow_name'] == WorkflowName.distributed.name):
+                      elif (test_info.__contains__('test_config') and test_info['test_config'] == TestConfigName.distributed.name) or (test_info_set2.__contains__('test_config') and test_info_set2['test_config'] == TestConfigName.distributed.name):
                           if not skip_reasons_stat_distributed.__contains__(v[2]):
                               skip_reasons_stat_distributed[v[2]] = 1
                           else:
                               skip_reasons_stat_distributed[v[2]] += 1
-                      elif (test_info.__contains__('work_flow_name') and test_info['work_flow_name'] == WorkflowName.inductor.name) or (test_info_set2.__contains__('work_flow_name') and test_info_set2['work_flow_name'] == WorkflowName.inductor.name):
+                      elif (test_info.__contains__('test_config') and test_info['test_config'] == TestConfigName.inductor.name) or (test_info_set2.__contains__('test_config') and test_info_set2['test_config'] == TestConfigName.inductor.name):
                           if not skip_reasons_stat_inductor.__contains__(v[2]):
                               skip_reasons_stat_inductor[v[2]] = 1
                           else:
@@ -438,11 +438,11 @@ def summarize_xml_files(args):
                       break
 
         if status_set_1 == "PASSED" and status_set_2 != "PASSED" and set2_path:
-            if test_info['work_flow_name'] == WorkflowName.default.name:
+            if test_info['test_config'] == TestConfigName.default.name:
                 ROCMONLY_DEFAULT += 1
-            elif test_info['work_flow_name'] == WorkflowName.distributed.name:
+            elif test_info['test_config'] == TestConfigName.distributed.name:
                 ROCMONLY_DISTRIBUTED += 1
-            elif test_info['work_flow_name'] == WorkflowName.inductor.name:
+            elif test_info['test_config'] == TestConfigName.inductor.name:
                 ROCMONLY_INDUCTOR += 1
 
     skip_reasons_stat_default.pop(' ', None)
@@ -464,12 +464,12 @@ def summarize_xml_files(args):
         v_values = v[0]
         v1_values = v[1] if set2_path else []
         workflow_name = ""
-        item_values["work_flow_name"] = ""
+        item_values["test_config"] = ""
         if item_values[f"status_{set1_name}"] != "MISSED":
-            workflow_name = v_values['work_flow_name']
+            workflow_name = v_values['test_config']
         elif item_values[f"status_{set2_name}"] != "MISSED" and item_values[f"status_{set2_name}"] != "":
-            workflow_name = v1_values['work_flow_name']
-        item_values["work_flow_name"] = workflow_name
+            workflow_name = v1_values['test_config']
+        item_values["test_config"] = workflow_name
         item_values[f"shard_{set1_name}"] = v_values.get('shard', '') if v_values else ''
         item_values[f"shard_{set2_name}"] = v1_values.get('shard', '') if v1_values else ''
         # get test related info
@@ -526,7 +526,7 @@ def summarize_xml_files(args):
           return 2
         elif e == "test_name":
           return 3
-        elif e == "work_flow_name":
+        elif e == "test_config":
           return 4
         elif e == "skip_reason":
           return 5

--- a/.automation_scripts/pytorch-unit-test-scripts/upload_test_stats.py
+++ b/.automation_scripts/pytorch-unit-test-scripts/upload_test_stats.py
@@ -38,7 +38,7 @@ def parse_xml_report(
     report: Path,
     workflow_id: int,
     workflow_run_attempt: int,
-    work_flow_name: str
+    test_config: str
 ) -> Dict[Tuple[str], Dict[str, Any]]:
     """Convert a test report xml file into a JSON-serializable list of test cases."""
     #print(f"Parsing {tag}s for test report: {report}")
@@ -65,7 +65,7 @@ def parse_xml_report(
             case["workflow_id"] = workflow_id
             case["workflow_run_attempt"] = workflow_run_attempt
             case["job_id"] = job_id
-            case["work_flow_name"] = work_flow_name
+            case["test_config"] = test_config
 
             # [invoking file]
             # The name of the file that the test is located in is not necessarily
@@ -87,9 +87,9 @@ def parse_xml_report(
                     continue
                 break
             case["invoking_file"] = case_name
-            test_cases[ ( case["invoking_file"], case["classname"], case["name"], case["work_flow_name"] ) ] = case
+            test_cases[ ( case["invoking_file"], case["classname"], case["name"], case["test_config"] ) ] = case
         elif tag == 'testsuite':
-            case["work_flow_name"] = work_flow_name
+            case["test_config"] = test_config
             case["invoking_xml"] = report.name
             case["running_time_xml"] = case["time"]
             case_name = report.parent.name
@@ -102,7 +102,7 @@ def parse_xml_report(
                     continue
                 break
             case["invoking_file"] = case_name
-            test_cases[ ( case["invoking_file"], case["invoking_xml"], case["work_flow_name"] ) ] = case
+            test_cases[ ( case["invoking_file"], case["invoking_xml"], case["test_config"] ) ] = case
 
     return test_cases
 

--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -245,6 +245,17 @@ jobs:
             echo "No parity CSV found in $FOLDER, skipping auto-classify"
           fi
 
+      - name: Detect log-based failures (timeouts, crashes)
+        if: ${{ inputs.include_logs }}
+        working-directory: .automation_scripts/pytorch-unit-test-scripts
+        run: |
+          FOLDER="${{ steps.folder.outputs.folder }}"
+          if ls "$FOLDER"/*.txt 1>/dev/null 2>&1; then
+            python3 detect_log_failures.py --logs-dir "$FOLDER" --output "$FOLDER/log_failures_${{ matrix.arch }}.csv" 2>&1 || true
+          else
+            echo "No log files found in $FOLDER, skipping log failure detection"
+          fi
+
       - name: Collect upload paths
         id: upload-paths
         run: |
@@ -310,7 +321,7 @@ jobs:
           CSV_ARGS=()
           ARCH_ARGS=()
           for ARCH in $ARCHS; do
-            ARTIFACT_DIR="../artifacts/${PREFIX}-results-${ARCH}"
+            ARTIFACT_DIR="../../artifacts/${PREFIX}-results-${ARCH}"
             CSV=$(find "$ARTIFACT_DIR"/ -maxdepth 2 -name "*.csv" ! -name "*_running_time*" ! -name "*_summary*" 2>/dev/null | head -1)
             if [ -z "$CSV" ]; then
               echo "WARNING: No CSV found for $ARCH, skipping"
@@ -334,13 +345,27 @@ jobs:
           if [ -n "$SHA" ]; then
             ARGS+=(--sha "$SHA")
           else
-            DETECTED_SHA=$(basename "$(find ../artifacts/ -name '*.csv' | head -1)" | grep -oP '[0-9a-f]{40}' || true)
+            DETECTED_SHA=$(basename "$(find ../../artifacts/ -name '*.csv' | head -1)" | grep -oP '[0-9a-f]{40}' || true)
             if [ -n "$DETECTED_SHA" ]; then
               ARGS+=(--sha "$DETECTED_SHA")
             fi
           fi
           if [ -n "$PR_ID" ]; then
             ARGS+=(--pr_id "$PR_ID")
+          fi
+
+          # Collect log failure CSVs if they exist
+          LOG_FAIL_ARGS=()
+          for ARCH in $ARCHS; do
+            LF="../../artifacts/${PREFIX}-results-${ARCH}"
+            LF_CSV=$(find "$LF"/ -maxdepth 2 -name "log_failures_*.csv" 2>/dev/null | head -1)
+            if [ -n "$LF_CSV" ]; then
+              LOG_FAIL_ARGS+=("$LF_CSV")
+              echo "Found log failures for $ARCH: $LF_CSV"
+            fi
+          done
+          if [ ${#LOG_FAIL_ARGS[@]} -gt 0 ]; then
+            ARGS+=(--log-failures "${LOG_FAIL_ARGS[@]}")
           fi
 
           OUTPUT="${PREFIX}_summary"

--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -322,7 +322,7 @@ jobs:
           ARCH_ARGS=()
           for ARCH in $ARCHS; do
             ARTIFACT_DIR="../../artifacts/${PREFIX}-results-${ARCH}"
-            CSV=$(find "$ARTIFACT_DIR"/ -maxdepth 2 -name "*.csv" ! -name "*_running_time*" ! -name "*_summary*" 2>/dev/null | head -1)
+            CSV=$(find "$ARTIFACT_DIR"/ -maxdepth 2 -name "*.csv" ! -name "*_running_time*" ! -name "*_summary*" ! -name "log_failures_*" 2>/dev/null | head -1)
             if [ -z "$CSV" ]; then
               echo "WARNING: No CSV found for $ARCH, skipping"
               continue


### PR DESCRIPTION
## Summary

Adds log-based failure detection to the parity workflow. Tests that timeout (exit code 124), crash (SIGIOT, SIGSEGV), hit Fatal Python errors, or OOM never produce JUnit XML output, so they are invisible to the existing XML-based parity report. This PR closes that gap.

### Changes

- **New script: `detect_log_failures.py`** — Parses raw CI `.txt` log files to detect test failures not captured in XML reports. Classifies failures as TIMEOUT, CRASH, CONSISTENT_FAILURE, or NON_ZERO_EXIT. Outputs a CSV with platform, workflow, test file, category, and reason.
- **`generate_summary.py`** — Adds `--log-failures` argument to accept CSV(s) from `detect_log_failures.py`. Appends a "LOG-BASED FAILURES (not in XML)" section to both CSV and markdown output.
- **`parity.yml`** — Adds a "Detect log-based failures" step after XML processing (runs when `include_logs` is enabled). Wires the resulting CSV into the summarize job via `--log-failures`.
- Adding in shard information 
- Also adding in which workflow we are downloading for in download testlogs

### How it works

1. `detect_log_failures.py` scans `.txt` log files for patterns like:
   - `Got exit code 124` (timeout)
   - `Segmentation fault`, `SIGSEGV`, `SIGIOT`, `Fatal Python error` (crash)
   - `FAILED CONSISTENTLY` 
   - `OutOfMemoryError`, `bad_alloc` (OOM)
2. Results are saved as `log_failures_<arch>.csv` and uploaded as part of the per-arch artifact
3. The summarize job collects all log failure CSVs and passes them to `generate_summary.py`
4. The final parity report includes a dedicated section listing these failures

## Test plan

- [x] Syntax-checked both Python files (`py_compile`)
- [x] Validated `parity.yml` YAML syntax
- [x] Tested `detect_log_failures.py` against actual CI log files from parity runs
- [x] Verified all files match fork/main (with correct `.automation_scripts/` paths)
- [x] Run parity workflow with `include_logs: true` to verify end-to-end
Validation: https://github.com/ethanwee1/pytorch/actions/runs/24352395766
