### PR TITLE
[release/2.11] Update Numba version constraints to support Python 3.14

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -120,7 +120,7 @@ ninja==1.11.1.4
 numba==0.49.0 ; python_version < "3.9" and platform_machine != "s390x"
 numba==0.60.0 ; python_version == "3.9" and platform_machine != "s390x"
 numba==0.61.2 ; python_version >= "3.10" and python_version < "3.14" and platform_machine != "s390x"
-numba==0.63.0 ; python_version >= "3.14" 
+numba==0.64.0 ; python_version >= "3.14" and platform_machine != "s390x"
 #Description: Just-In-Time Compiler for Numerical Functions
 #Pinned versions: 0.55.2, 0.60.0
 #test that import: test_numba_integration.py

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -120,7 +120,7 @@ ninja==1.11.1.4
 numba==0.49.0 ; python_version < "3.9" and platform_machine != "s390x"
 numba==0.60.0 ; python_version == "3.9" and platform_machine != "s390x"
 numba==0.61.2 ; python_version >= "3.10" and python_version < "3.14" and platform_machine != "s390x"
-numba>=0.63.0 ; python_version >= "3.14" 
+numba==0.63.0 ; python_version >= "3.14" 
 #Description: Just-In-Time Compiler for Numerical Functions
 #Pinned versions: 0.55.2, 0.60.0
 #test that import: test_numba_integration.py

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -119,8 +119,8 @@ ninja==1.11.1.4
 
 numba==0.49.0 ; python_version < "3.9" and platform_machine != "s390x"
 numba==0.60.0 ; python_version == "3.9" and platform_machine != "s390x"
-numba==0.61.2 ; python_version > "3.9" and platform_machine != "s390x"
-
+numba==0.61.2 ; python_version >= "3.10" and python_version < "3.14" and platform_machine != "s390x"
+numba>=0.63.0 ; python_version >= "3.14" 
 #Description: Just-In-Time Compiler for Numerical Functions
 #Pinned versions: 0.55.2, 0.60.0
 #test that import: test_numba_integration.py


### PR DESCRIPTION
- This PR updates the Numba version constraints to correctly handle Python 3.14 and aligns the platform conditions with Numba’s current support matrix.
- Add a new rule selecting numba==0.64.0 for Python ≥ 3.14