### PR TITLE
[CI] Show only ROCm failures in parity summary and add cross-arch column

### DIFF
--- a/.automation_scripts/pytorch-unit-test-scripts/detect_log_failures.py
+++ b/.automation_scripts/pytorch-unit-test-scripts/detect_log_failures.py
@@ -214,6 +214,19 @@ def scan_logs(logs_dir):
     """Scan all log files and return all non-passing test file results."""
     all_failures = []
 
+    # Pre-compute job-level shard totals per (platform, test_config) by
+    # counting how many log files belong to each group. Log files are
+    # 1-indexed (e.g. rocm1.txt..rocm6.txt for a 6-way sharded job), so
+    # the count == total shards for that CI job.
+    shard_totals = defaultdict(int)
+    for fname in os.listdir(logs_dir):
+        if not fname.endswith(".txt"):
+            continue
+        platform, test_config, shard_num = classify_log_file(fname)
+        if platform is None:
+            continue
+        shard_totals[(platform, test_config)] += 1
+
     for fname in sorted(os.listdir(logs_dir)):
         if not fname.endswith(".txt"):
             continue
@@ -221,6 +234,9 @@ def scan_logs(logs_dir):
         platform, test_config, shard_num = classify_log_file(fname)
         if platform is None:
             continue
+
+        job_total = shard_totals.get((platform, test_config), 0)
+        job_shard_str = f"{shard_num}/{job_total}" if job_total else str(shard_num)
 
         filepath = os.path.join(logs_dir, fname)
         results, consistent_failures = parse_log_file(filepath)
@@ -269,7 +285,8 @@ def scan_logs(logs_dir):
                 "platform": platform,
                 "test_config": test_config,
                 "test_file": info["test_file"],
-                "shard": f"{info['shard']}/{info['total']}",
+                "job_shard": job_shard_str,
+                "test_shard": f"{info['shard']}/{info['total']}",
                 "status": info["status"],
                 "category": "+".join(categories),
                 "reason": reason,
@@ -287,7 +304,8 @@ def scan_logs(logs_dir):
                 "platform": platform,
                 "test_config": test_config,
                 "test_file": file_part,
-                "shard": shard_str,
+                "job_shard": job_shard_str,
+                "test_shard": shard_str,
                 "status": "FAILED_CONSISTENTLY",
                 "category": "CONSISTENT_FAILURE",
                 "reason": f"{test_class}::{test_name}" if test_class else "",
@@ -299,7 +317,8 @@ def scan_logs(logs_dir):
 
 def write_csv_report(failures, output_path):
     fieldnames = [
-        "log_file", "platform", "test_config", "test_file", "shard",
+        "log_file", "platform", "test_config", "test_file",
+        "job_shard", "test_shard",
         "status", "category", "reason", "exit_codes",
     ]
     with open(output_path, "w", newline="") as f:

--- a/.automation_scripts/pytorch-unit-test-scripts/detect_log_failures.py
+++ b/.automation_scripts/pytorch-unit-test-scripts/detect_log_failures.py
@@ -56,6 +56,10 @@ LOG_FILE_MAP = {
     "rocm": ("rocm", "default"),
     "rocm_dist": ("rocm", "distributed"),
     "rocm_inductor": ("rocm", "inductor"),
+    "cuda": ("cuda", "default"),
+    "cuda_dist": ("cuda", "distributed"),
+    "cuda_inductor": ("cuda", "inductor"),
+    "baseline": ("baseline", "default"),
 }
 
 
@@ -191,7 +195,11 @@ def parse_log_file(filepath):
 
             m = RE_FAILED_CONSISTENTLY.search(stripped)
             if m:
-                consistent_failures.append(m.group("test_path"))
+                shard_str = ""
+                if active and active in results:
+                    info = results[active]
+                    shard_str = f"{info['shard']}/{info['total']}"
+                consistent_failures.append((m.group("test_path"), shard_str))
 
             if active and active in results:
                 for pattern, label in CRASH_PATTERNS:
@@ -268,7 +276,7 @@ def scan_logs(logs_dir):
                 "exit_codes": ",".join(str(c) for c in info["exit_codes"]),
             })
 
-        for test_path in consistent_failures:
+        for test_path, shard_str in consistent_failures:
             parts = test_path.split("::")
             file_part = parts[0].replace("test/", "").replace(".py", "")
             test_class = parts[1] if len(parts) > 1 else ""
@@ -279,7 +287,7 @@ def scan_logs(logs_dir):
                 "platform": platform,
                 "test_config": test_config,
                 "test_file": file_part,
-                "shard": "",
+                "shard": shard_str,
                 "status": "FAILED_CONSISTENTLY",
                 "category": "CONSISTENT_FAILURE",
                 "reason": f"{test_class}::{test_name}" if test_class else "",

--- a/.automation_scripts/pytorch-unit-test-scripts/detect_log_failures.py
+++ b/.automation_scripts/pytorch-unit-test-scripts/detect_log_failures.py
@@ -211,8 +211,17 @@ def parse_log_file(filepath):
 
 
 def scan_logs(logs_dir):
-    """Scan all log files and return all non-passing test file results."""
+    """Scan all log files and return non-passing test file results plus a
+    test-level shard inventory.
+
+    Returns (all_failures, shard_inventory) where shard_inventory is a list
+    of dicts with one entry per (platform, test_config, job_shard, test_file)
+    combination seen in the logs, plus a sorted comma-separated list of the
+    test-level shards observed (e.g. "1/1" or "1/15,2/15,...,15/15"). This
+    lets downstream consumers look up the test-level shard for any XML-based
+    failure whose only shard info is the job-level shard."""
     all_failures = []
+    shard_map = defaultdict(set)
 
     # Pre-compute job-level shard totals per (platform, test_config) by
     # counting how many log files belong to each group. Log files are
@@ -240,6 +249,13 @@ def scan_logs(logs_dir):
 
         filepath = os.path.join(logs_dir, fname)
         results, consistent_failures = parse_log_file(filepath)
+
+        # Record every (test_file, test_shard) observed in this log file,
+        # including PASSED ones, so the inventory covers the full run.
+        for info in results.values():
+            shard_map[(platform, test_config, job_shard_str, info["test_file"])].add(
+                f"{info['shard']}/{info['total']}"
+            )
 
         for key, info in results.items():
             if info["status"] == "PASSED":
@@ -312,7 +328,29 @@ def scan_logs(logs_dir):
                 "exit_codes": "",
             })
 
-    return all_failures
+    def _sort_shards(vals):
+        def key(v):
+            try:
+                a, b = v.split("/", 1)
+                return (int(b), int(a))
+            except (ValueError, AttributeError):
+                return (0, 0)
+        return sorted(vals, key=key)
+
+    shard_inventory = [
+        {
+            "platform": platform,
+            "test_config": test_config,
+            "job_shard": job_shard_str,
+            "test_file": test_file,
+            "test_shards": ",".join(_sort_shards(shards)),
+        }
+        for (platform, test_config, job_shard_str, test_file), shards in shard_map.items()
+    ]
+    shard_inventory.sort(key=lambda r: (r["platform"], r["test_config"],
+                                        r["job_shard"], r["test_file"]))
+
+    return all_failures, shard_inventory
 
 
 def write_csv_report(failures, output_path):
@@ -326,6 +364,26 @@ def write_csv_report(failures, output_path):
         writer.writeheader()
         writer.writerows(failures)
     print(f"Log failure report: {output_path} ({len(failures)} entries)")
+
+
+def write_shards_report(inventory, output_path):
+    fieldnames = ["platform", "test_config", "job_shard", "test_file", "test_shards"]
+    with open(output_path, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(inventory)
+    print(f"Log shard inventory: {output_path} ({len(inventory)} entries)")
+
+
+def _derive_shards_path(output_path):
+    """Given an output path like '.../log_failures_mi355.csv', return
+    '.../log_shards_mi355.csv'. Falls back to appending '.shards.csv' if
+    the expected prefix isn't present."""
+    d, base = os.path.split(output_path)
+    if base.startswith("log_failures"):
+        return os.path.join(d, "log_shards" + base[len("log_failures"):])
+    stem, ext = os.path.splitext(base)
+    return os.path.join(d, f"{stem}.shards{ext or '.csv'}")
 
 
 def print_summary(failures):
@@ -366,9 +424,10 @@ def main():
     )
     args = parser.parse_args()
 
-    failures = scan_logs(args.logs_dir)
+    failures, shard_inventory = scan_logs(args.logs_dir)
     print_summary(failures)
     write_csv_report(failures, args.output)
+    write_shards_report(shard_inventory, _derive_shards_path(args.output))
     return 0 if not failures else 1
 
 

--- a/.automation_scripts/pytorch-unit-test-scripts/detect_log_failures.py
+++ b/.automation_scripts/pytorch-unit-test-scripts/detect_log_failures.py
@@ -38,6 +38,10 @@ RE_STEPCURRENT = re.compile(
 RE_INDIVIDUAL_TEST = re.compile(
     r"(?P<test_path>\S+\.py::(?P<cls>\w+)::(?P<method>\w+))"
 )
+RE_INDIV_PASSED = re.compile(
+    r"(?:test/)?(?P<file>\S+\.py)::(?P<cls>\w+)::(?P<method>\S+?)\s+PASSED"
+)
+RE_NEW_PROCESS_SUCCESS = re.compile(r"Test succeeded in new process")
 
 CRASH_PATTERNS = [
     (re.compile(r"Segmentation fault", re.IGNORECASE), "SEGFAULT"),
@@ -78,11 +82,20 @@ RE_TIMESTAMP = re.compile(r"^\d{4}-\d{2}-\d{2}T[\d:.]+Z\s*")
 
 
 def parse_log_file(filepath):
-    """Parse a single log file and return test file results and consistent failures."""
+    """Parse a single log file and return test file results, consistent failures,
+    and flaky tests.
+
+    A flaky test is one that failed in its normal-process run but PASSED when the
+    CI harness re-ran it alone in a new subprocess (indicated by a PASSED line
+    for the specific test::class::method, followed by 'Test succeeded in new
+    process, continuing with the rest of the tests').
+    """
     results = {}
     current_test = None
     last_failed_test = None
     consistent_failures = []
+    flaky_tests = []
+    last_passed_individual = None
 
     with open(filepath, "r", errors="replace") as f:
         for line in f:
@@ -111,7 +124,9 @@ def parse_log_file(filepath):
                and "Aborted (core dumped)" not in line \
                and "OutOfMemoryError" not in line \
                and "bad_alloc" not in line \
-               and "stepcurrent" not in line:
+               and "stepcurrent" not in line \
+               and "PASSED" not in line \
+               and "new process" not in line:
                 continue
 
             stripped = RE_TIMESTAMP.sub("", line).rstrip()
@@ -201,13 +216,42 @@ def parse_log_file(filepath):
                     shard_str = f"{info['shard']}/{info['total']}"
                 consistent_failures.append((m.group("test_path"), shard_str))
 
+            # Detect individual PASSED lines for flaky-rerun tracking.
+            m = RE_INDIV_PASSED.search(stripped)
+            if m:
+                last_passed_individual = {
+                    "file": m.group("file"),
+                    "cls": m.group("cls"),
+                    "method": m.group("method"),
+                    "active": active,
+                }
+
+            # When we see 'Test succeeded in new process' after a PASSED
+            # individual test, that test was originally failing in the main
+            # process (CI only falls back to rerun-in-new-process for tests
+            # that crashed or failed) but passed on retry -> flaky.
+            if RE_NEW_PROCESS_SUCCESS.search(stripped) and last_passed_individual:
+                lp = last_passed_individual
+                lp_active = lp.get("active")
+                test_shard = ""
+                if lp_active and lp_active in results:
+                    info = results[lp_active]
+                    test_shard = f"{info['shard']}/{info['total']}"
+                flaky_tests.append({
+                    "file": lp["file"],
+                    "cls": lp["cls"],
+                    "method": lp["method"],
+                    "test_shard": test_shard,
+                })
+                last_passed_individual = None
+
             if active and active in results:
                 for pattern, label in CRASH_PATTERNS:
                     if pattern.search(stripped):
                         if label not in results[active]["crashes"]:
                             results[active]["crashes"].append(label)
 
-    return results, consistent_failures
+    return results, consistent_failures, flaky_tests
 
 
 def scan_logs(logs_dir):
@@ -221,6 +265,7 @@ def scan_logs(logs_dir):
     lets downstream consumers look up the test-level shard for any XML-based
     failure whose only shard info is the job-level shard."""
     all_failures = []
+    all_flaky = []
     shard_map = defaultdict(set)
 
     # Pre-compute job-level shard totals per (platform, test_config) by
@@ -248,7 +293,20 @@ def scan_logs(logs_dir):
         job_shard_str = f"{shard_num}/{job_total}" if job_total else str(shard_num)
 
         filepath = os.path.join(logs_dir, fname)
-        results, consistent_failures = parse_log_file(filepath)
+        results, consistent_failures, flaky_tests = parse_log_file(filepath)
+
+        for ft in flaky_tests:
+            file_part = ft["file"].replace("test/", "").replace(".py", "")
+            all_flaky.append({
+                "log_file": fname,
+                "platform": platform,
+                "test_config": test_config,
+                "test_file": file_part,
+                "test_class": ft["cls"],
+                "test_name": ft["method"],
+                "job_shard": job_shard_str,
+                "test_shard": ft["test_shard"],
+            })
 
         # Record every (test_file, test_shard) observed in this log file,
         # including PASSED ones, so the inventory covers the full run.
@@ -350,7 +408,11 @@ def scan_logs(logs_dir):
     shard_inventory.sort(key=lambda r: (r["platform"], r["test_config"],
                                         r["job_shard"], r["test_file"]))
 
-    return all_failures, shard_inventory
+    all_flaky.sort(key=lambda r: (r["platform"], r["test_config"],
+                                  r["job_shard"], r["test_file"],
+                                  r["test_class"], r["test_name"]))
+
+    return all_failures, shard_inventory, all_flaky
 
 
 def write_csv_report(failures, output_path):
@@ -375,15 +437,35 @@ def write_shards_report(inventory, output_path):
     print(f"Log shard inventory: {output_path} ({len(inventory)} entries)")
 
 
-def _derive_shards_path(output_path):
-    """Given an output path like '.../log_failures_mi355.csv', return
-    '.../log_shards_mi355.csv'. Falls back to appending '.shards.csv' if
-    the expected prefix isn't present."""
+def write_flaky_report(flaky, output_path):
+    fieldnames = [
+        "log_file", "platform", "test_config", "test_file",
+        "test_class", "test_name", "job_shard", "test_shard",
+    ]
+    with open(output_path, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(flaky)
+    print(f"Flaky test report: {output_path} ({len(flaky)} entries)")
+
+
+def _derive_sibling_path(output_path, new_prefix):
+    """Given an output path like '.../log_failures_mi355.csv' and
+    new_prefix='log_shards', return '.../log_shards_mi355.csv'. Falls back to
+    appending '.{new_prefix}.csv' if the expected prefix isn't present."""
     d, base = os.path.split(output_path)
     if base.startswith("log_failures"):
-        return os.path.join(d, "log_shards" + base[len("log_failures"):])
+        return os.path.join(d, new_prefix + base[len("log_failures"):])
     stem, ext = os.path.splitext(base)
-    return os.path.join(d, f"{stem}.shards{ext or '.csv'}")
+    return os.path.join(d, f"{stem}.{new_prefix}{ext or '.csv'}")
+
+
+def _derive_shards_path(output_path):
+    return _derive_sibling_path(output_path, "log_shards")
+
+
+def _derive_flaky_path(output_path):
+    return _derive_sibling_path(output_path, "flaky_tests")
 
 
 def print_summary(failures):
@@ -424,10 +506,11 @@ def main():
     )
     args = parser.parse_args()
 
-    failures, shard_inventory = scan_logs(args.logs_dir)
+    failures, shard_inventory, flaky_tests = scan_logs(args.logs_dir)
     print_summary(failures)
     write_csv_report(failures, args.output)
     write_shards_report(shard_inventory, _derive_shards_path(args.output))
+    write_flaky_report(flaky_tests, _derive_flaky_path(args.output))
     return 0 if not failures else 1
 
 

--- a/.automation_scripts/pytorch-unit-test-scripts/detect_log_failures.py
+++ b/.automation_scripts/pytorch-unit-test-scripts/detect_log_failures.py
@@ -56,10 +56,6 @@ LOG_FILE_MAP = {
     "rocm": ("rocm", "default"),
     "rocm_dist": ("rocm", "distributed"),
     "rocm_inductor": ("rocm", "inductor"),
-    "cuda": ("cuda", "default"),
-    "cuda_dist": ("cuda", "distributed"),
-    "cuda_inductor": ("cuda", "inductor"),
-    "baseline": ("baseline", "default"),
 }
 
 

--- a/.automation_scripts/pytorch-unit-test-scripts/generate_summary.py
+++ b/.automation_scripts/pytorch-unit-test-scripts/generate_summary.py
@@ -231,7 +231,12 @@ def compute_overall_stats(rows, s1_col, s2_col, s1_time_col, s2_time_col, s1_nam
 
 
 def collect_failed_tests(arch_data, archs, s1_name, s2_name):
-    """Return a list of failed test rows across all architectures."""
+    """Return a list of failed test rows across all architectures.
+
+    Each entry includes an 'also_failing_in' field listing other architectures
+    where the same (test_file, test_class, test_name) tuple also fails on the
+    same platform (s1 or s2).
+    """
     failed = []
     for arch in archs:
         d = arch_data[arch]
@@ -240,21 +245,35 @@ def collect_failed_tests(arch_data, archs, s1_name, s2_name):
         for r in d['rows']:
             s1 = r[s1_col].strip()
             s2 = r[s2_col].strip() if has_set2 else ''
-            if s1 == 'FAILED' or s2 == 'FAILED':
-                shard = r.get(f'shard_{s1_name}', '') if s1 == 'FAILED' else r.get(f'shard_{s2_name}', '')
+            if s1 == 'FAILED':
                 entry = {
                     'arch': arch,
                     'test_file': r.get('test_file', ''),
                     'test_class': r.get('test_class', ''),
                     'test_name': r.get('test_name', ''),
                     'test_config': r.get('test_config', ''),
-                    'shard': shard,
+                    'shard': r.get(f'shard_{s1_name}', ''),
                     f'status_{s1_name}': s1,
                 }
                 if has_set2:
                     entry[f'status_{s2_name}'] = s2
                 failed.append(entry)
+
+    _add_cross_arch_info(failed)
     return failed
+
+
+def _add_cross_arch_info(failed_tests):
+    """Populate 'also_failing_in' for each entry based on matching test tuples."""
+    from collections import defaultdict
+    by_tuple = defaultdict(set)
+    for t in failed_tests:
+        key = (t['test_file'], t['test_class'], t['test_name'])
+        by_tuple[key].add(t['arch'])
+    for t in failed_tests:
+        key = (t['test_file'], t['test_class'], t['test_name'])
+        others = sorted(a for a in by_tuple[key] if a != t['arch'])
+        t['also_failing_in'] = ', '.join(others)
 
 
 def load_log_failures(filepaths):
@@ -352,19 +371,23 @@ def write_csv(rows, archs, output_path, failed_tests=None, s1_name='set1', s2_na
             csv_rows.append([label] + list(vals))
     csv_rows.append([])
 
-    if failed_tests:
+    s1_failed = [t for t in (failed_tests or []) if t.get(f'status_{s1_name}') == 'FAILED']
+
+    if s1_failed:
         csv_rows.append(['FAILED TESTS'])
         header = ['Arch', 'Test Config', 'Test File', 'Test Class',
                   'Test Name', 'Shard', f'Status ({s1_name})']
         if has_set2:
             header.append(f'Status ({s2_name})')
+        header.append('Also Failing In')
         csv_rows.append(header)
-        for t in failed_tests:
+        for t in s1_failed:
             row = [t['arch'], t['test_config'], t['test_file'],
                    t['test_class'], t['test_name'], t.get('shard', ''),
                    t[f'status_{s1_name}']]
             if has_set2:
                 row.append(t.get(f'status_{s2_name}', ''))
+            row.append(t.get('also_failing_in', ''))
             csv_rows.append(row)
         csv_rows.append([])
 
@@ -417,22 +440,26 @@ def write_markdown(rows, archs, output_path, failed_tests=None, s1_name='set1', 
 
     flush_table()
 
-    if failed_tests:
-        lines.append('### FAILED TESTS')
+    s1_failed = [t for t in (failed_tests or []) if t.get(f'status_{s1_name}') == 'FAILED']
+
+    cols = ['Arch', 'Test Config', 'Test File', 'Test Class', 'Test Name',
+            'Shard', f'Status ({s1_name})']
+    if has_set2:
+        cols.append(f'Status ({s2_name})')
+    cols.append('Also Failing In')
+
+    if s1_failed:
+        lines.append(f'### FAILED TESTS ({len(s1_failed)})')
         lines.append('')
-        cols = ['Arch', 'Test Config', 'Test File', 'Test Class', 'Test Name',
-                'Shard', f'Status ({s1_name})']
-        if has_set2:
-            cols.append(f'Status ({s2_name})')
         lines.append('| ' + ' | '.join(cols) + ' |')
         lines.append('| ' + ' | '.join(['---'] * len(cols)) + ' |')
-        for t in failed_tests:
+        for t in s1_failed:
             line = (f"| {t['arch']} | {t['test_config']} | {t['test_file']} "
                     f"| {t['test_class']} | {t['test_name']} "
                     f"| {t.get('shard', '')} | {t[f'status_{s1_name}']}")
             if has_set2:
                 line += f" | {t.get(f'status_{s2_name}', '')}"
-            line += ' |'
+            line += f" | {t.get('also_failing_in', '')} |"
             lines.append(line)
         lines.append('')
     else:

--- a/.automation_scripts/pytorch-unit-test-scripts/generate_summary.py
+++ b/.automation_scripts/pytorch-unit-test-scripts/generate_summary.py
@@ -345,6 +345,68 @@ def load_log_failures(filepaths):
     return entries
 
 
+def load_log_shards(filepaths):
+    """Load log shard inventory CSVs written alongside log_failures files.
+
+    For each log_failures_<arch>.csv, looks for a sibling log_shards_<arch>.csv
+    and returns a lookup dict:
+        (arch, platform, test_config, job_shard, normalized_test_file) -> test_shards_str
+
+    The CSV is produced by detect_log_failures.py and records every
+    (test_file, test_shard) pair observed per job-level shard. If an XML-based
+    failure's key matches, we can back-fill the test-level shard value.
+    """
+    lookup = {}
+    for fp in filepaths:
+        if not fp:
+            continue
+        basename = os.path.basename(fp)
+        arch = ''
+        if basename.startswith('log_failures_') and basename.endswith('.csv'):
+            arch = basename[len('log_failures_'):-len('.csv')]
+            shards_path = os.path.join(
+                os.path.dirname(fp),
+                'log_shards_' + basename[len('log_failures_'):],
+            )
+        else:
+            continue
+        if not os.path.isfile(shards_path):
+            continue
+        with open(shards_path, newline='') as f:
+            for row in csv.DictReader(f):
+                key = (arch, row.get('platform', ''), row.get('test_config', ''),
+                       row.get('job_shard', ''),
+                       _norm_test_file(row.get('test_file', '')))
+                lookup[key] = row.get('test_shards', '')
+    return lookup
+
+
+def _format_test_shards(shards_str):
+    """Collapse a test_shards inventory string into a compact display value.
+
+    - '' -> ''
+    - '1/1' -> '1/1'
+    - '3/14' -> '3/14'
+    - '1/14,6/14,12/14' -> '1,6,12/14' (multiple test-level shards observed)
+    - mixed totals fall back to the raw string."""
+    if not shards_str:
+        return ''
+    parts = [p for p in shards_str.split(',') if p]
+    if len(parts) == 1:
+        return parts[0]
+    totals = set()
+    nums = []
+    for p in parts:
+        if '/' not in p:
+            return shards_str
+        a, b = p.split('/', 1)
+        totals.add(b)
+        nums.append(a)
+    if len(totals) == 1:
+        return f"{','.join(nums)}/{totals.pop()}"
+    return shards_str
+
+
 def fmt_val(v):
     if isinstance(v, int):
         return f'{v:,}'
@@ -418,7 +480,7 @@ def _parse_log_failure_names(lf):
     return parts[0], parts[1]
 
 
-def write_csv(rows, archs, output_path, failed_tests=None, s1_name='set1', s2_name='set2', has_set2=True, log_failures=None):
+def write_csv(rows, archs, output_path, failed_tests=None, s1_name='set1', s2_name='set2', has_set2=True, log_failures=None, shard_lookup=None):
     csv_rows = []
     csv_rows.append([''] + list(archs))
     for label, vals in rows:
@@ -433,12 +495,23 @@ def write_csv(rows, archs, output_path, failed_tests=None, s1_name='set1', s2_na
 
     s1_failed = [t for t in (failed_tests or []) if t.get(f'status_{s1_name}') == 'FAILED']
 
+    shard_lookup = shard_lookup or {}
+
+    def _xml_test_shard(t, platform):
+        key = (t.get('arch', ''), platform, t.get('test_config', ''),
+               t.get(f'shard_{platform}', ''),
+               _norm_test_file(t.get('test_file', '')))
+        return _format_test_shards(shard_lookup.get(key, ''))
+
     if s1_failed:
         csv_rows.append(['FAILED TESTS'])
         header = ['Arch', 'Test Config', 'Test File', 'Test Class',
-                  'Test Name', f'Job-Level Shard ({s1_name})']
+                  'Test Name',
+                  f'Job-Level Shard ({s1_name})',
+                  f'Test-Level Shard ({s1_name})']
         if has_set2:
             header.append(f'Job-Level Shard ({s2_name})')
+            header.append(f'Test-Level Shard ({s2_name})')
         header.append(f'Status ({s1_name})')
         if has_set2:
             header.append(f'Status ({s2_name})')
@@ -447,9 +520,11 @@ def write_csv(rows, archs, output_path, failed_tests=None, s1_name='set1', s2_na
         for t in s1_failed:
             row = [t['arch'], t['test_config'], t['test_file'],
                    t['test_class'], t['test_name'],
-                   t.get(f'shard_{s1_name}', '')]
+                   t.get(f'shard_{s1_name}', ''),
+                   _xml_test_shard(t, s1_name)]
             if has_set2:
                 row.append(t.get(f'shard_{s2_name}', ''))
+                row.append(_xml_test_shard(t, s2_name))
             row.append(t[f'status_{s1_name}'])
             if has_set2:
                 row.append(t.get(f'status_{s2_name}', ''))
@@ -495,7 +570,7 @@ def write_csv(rows, archs, output_path, failed_tests=None, s1_name='set1', s2_na
     print(f'CSV written to {output_path}')
 
 
-def write_markdown(rows, archs, output_path, failed_tests=None, s1_name='set1', s2_name='set2', has_set2=True, log_failures=None):
+def write_markdown(rows, archs, output_path, failed_tests=None, s1_name='set1', s2_name='set2', has_set2=True, log_failures=None, shard_lookup=None):
     lines = []
     current_section = []
 
@@ -528,10 +603,20 @@ def write_markdown(rows, archs, output_path, failed_tests=None, s1_name='set1', 
 
     s1_failed = [t for t in (failed_tests or []) if t.get(f'status_{s1_name}') == 'FAILED']
 
+    shard_lookup = shard_lookup or {}
+
+    def _xml_test_shard(t, platform):
+        key = (t.get('arch', ''), platform, t.get('test_config', ''),
+               t.get(f'shard_{platform}', ''),
+               _norm_test_file(t.get('test_file', '')))
+        return _format_test_shards(shard_lookup.get(key, ''))
+
     cols = ['Arch', 'Test Config', 'Test File', 'Test Class', 'Test Name',
-            f'Job-Level Shard ({s1_name})']
+            f'Job-Level Shard ({s1_name})',
+            f'Test-Level Shard ({s1_name})']
     if has_set2:
         cols.append(f'Job-Level Shard ({s2_name})')
+        cols.append(f'Test-Level Shard ({s2_name})')
     cols.append(f'Status ({s1_name})')
     if has_set2:
         cols.append(f'Status ({s2_name})')
@@ -545,9 +630,11 @@ def write_markdown(rows, archs, output_path, failed_tests=None, s1_name='set1', 
         for t in s1_failed:
             line = (f"| {t['arch']} | {t['test_config']} | {t['test_file']} "
                     f"| {t['test_class']} | {t['test_name']} "
-                    f"| {t.get(f'shard_{s1_name}', '')}")
+                    f"| {t.get(f'shard_{s1_name}', '')} "
+                    f"| {_xml_test_shard(t, s1_name)}")
             if has_set2:
                 line += f" | {t.get(f'shard_{s2_name}', '')}"
+                line += f" | {_xml_test_shard(t, s2_name)}"
             line += f" | {t[f'status_{s1_name}']}"
             if has_set2:
                 line += f" | {t.get(f'status_{s2_name}', '')}"
@@ -624,6 +711,7 @@ def main():
     failed = collect_failed_tests(arch_data, archs, args.set1_name, args.set2_name)
     any_has_set2 = any(d.get('has_set2', True) for d in arch_data.values())
     log_failures = load_log_failures(args.log_failures) if args.log_failures else []
+    shard_lookup = load_log_shards(args.log_failures) if args.log_failures else {}
 
     _add_cross_arch_info(failed, log_failures, args.set2_name)
     _add_log_failure_cross_arch(log_failures, failed, args.set1_name, args.set2_name)
@@ -632,8 +720,8 @@ def main():
     if output_base.endswith('.csv') or output_base.endswith('.md'):
         output_base = output_base.rsplit('.', 1)[0]
 
-    write_csv(data_rows, archs, f'{output_base}.csv', failed, args.set1_name, args.set2_name, has_set2=any_has_set2, log_failures=log_failures)
-    write_markdown(data_rows, archs, f'{output_base}.md', failed, args.set1_name, args.set2_name, has_set2=any_has_set2, log_failures=log_failures)
+    write_csv(data_rows, archs, f'{output_base}.csv', failed, args.set1_name, args.set2_name, has_set2=any_has_set2, log_failures=log_failures, shard_lookup=shard_lookup)
+    write_markdown(data_rows, archs, f'{output_base}.md', failed, args.set1_name, args.set2_name, has_set2=any_has_set2, log_failures=log_failures, shard_lookup=shard_lookup)
 
 
 if __name__ == '__main__':

--- a/.automation_scripts/pytorch-unit-test-scripts/generate_summary.py
+++ b/.automation_scripts/pytorch-unit-test-scripts/generate_summary.py
@@ -393,6 +393,17 @@ def build_rows(args, archs, arch_data):
     return out
 
 
+def _norm_test_file(path):
+    """Normalize a test_file string so XML-sourced ('a.b.c') and log-sourced
+    ('a/b/c') forms compare equal. Also strips a trailing .py if present."""
+    if not path:
+        return ''
+    s = path.replace('/', '.')
+    if s.endswith('.py'):
+        s = s[:-3]
+    return s
+
+
 def _parse_log_failure_names(lf):
     """Extract test_class and test_name from a log failure's reason field.
 
@@ -447,7 +458,20 @@ def write_csv(rows, archs, output_path, failed_tests=None, s1_name='set1', s2_na
         csv_rows.append([])
 
     if log_failures:
-        rocm_log_failures = [lf for lf in log_failures if lf.get('platform', '') == s1_name]
+        xml_failed_keys = {
+            (t['arch'], _norm_test_file(t['test_file']), t['test_class'], t['test_name'])
+            for t in (failed_tests or [])
+        }
+        rocm_log_failures = []
+        for lf in log_failures:
+            if lf.get('platform', '') != s1_name:
+                continue
+            test_class, test_name = _parse_log_failure_names(lf)
+            key = (lf.get('arch', ''), _norm_test_file(lf.get('test_file', '')),
+                   test_class, test_name)
+            if key in xml_failed_keys:
+                continue
+            rocm_log_failures.append(lf)
         if rocm_log_failures:
             csv_rows.append(['LOG-BASED FAILURES (not in XML)'])
             csv_rows.append(['Arch', 'Platform', 'Test Config', 'Test File', 'Test Class',
@@ -537,7 +561,20 @@ def write_markdown(rows, archs, output_path, failed_tests=None, s1_name='set1', 
         lines.append('')
 
     if log_failures:
-        rocm_log_failures = [lf for lf in log_failures if lf.get('platform', '') == s1_name]
+        xml_failed_keys = {
+            (t['arch'], _norm_test_file(t['test_file']), t['test_class'], t['test_name'])
+            for t in (failed_tests or [])
+        }
+        rocm_log_failures = []
+        for lf in log_failures:
+            if lf.get('platform', '') != s1_name:
+                continue
+            test_class, test_name = _parse_log_failure_names(lf)
+            key = (lf.get('arch', ''), _norm_test_file(lf.get('test_file', '')),
+                   test_class, test_name)
+            if key in xml_failed_keys:
+                continue
+            rocm_log_failures.append(lf)
         if rocm_log_failures:
             lines.append(f'### LOG-BASED FAILURES (not in XML) ({len(rocm_log_failures)})')
             lines.append('')

--- a/.automation_scripts/pytorch-unit-test-scripts/generate_summary.py
+++ b/.automation_scripts/pytorch-unit-test-scripts/generate_summary.py
@@ -425,9 +425,9 @@ def write_csv(rows, archs, output_path, failed_tests=None, s1_name='set1', s2_na
     if s1_failed:
         csv_rows.append(['FAILED TESTS'])
         header = ['Arch', 'Test Config', 'Test File', 'Test Class',
-                  'Test Name', f'Shard ({s1_name})']
+                  'Test Name', f'Job-Level Shard ({s1_name})']
         if has_set2:
-            header.append(f'Shard ({s2_name})')
+            header.append(f'Job-Level Shard ({s2_name})')
         header.append(f'Status ({s1_name})')
         if has_set2:
             header.append(f'Status ({s2_name})')
@@ -451,13 +451,16 @@ def write_csv(rows, archs, output_path, failed_tests=None, s1_name='set1', s2_na
         if rocm_log_failures:
             csv_rows.append(['LOG-BASED FAILURES (not in XML)'])
             csv_rows.append(['Arch', 'Platform', 'Test Config', 'Test File', 'Test Class',
-                             'Test Name', 'Shard', 'Category', 'Also Failing In', 'Log File'])
+                             'Test Name', 'Job-Level Shard', 'Test-Level Shard',
+                             'Category', 'Also Failing In', 'Log File'])
             for lf in rocm_log_failures:
                 test_class, test_name = _parse_log_failure_names(lf)
                 csv_rows.append([
                     lf.get('arch', ''), lf.get('platform', ''), lf.get('test_config', ''),
                     lf.get('test_file', ''), test_class, test_name,
-                    lf.get('shard', ''), lf.get('category', ''),
+                    lf.get('job_shard', ''),
+                    lf.get('test_shard', lf.get('shard', '')),
+                    lf.get('category', ''),
                     lf.get('also_failing_in', ''),
                     lf.get('log_file', ''),
                 ])
@@ -502,9 +505,9 @@ def write_markdown(rows, archs, output_path, failed_tests=None, s1_name='set1', 
     s1_failed = [t for t in (failed_tests or []) if t.get(f'status_{s1_name}') == 'FAILED']
 
     cols = ['Arch', 'Test Config', 'Test File', 'Test Class', 'Test Name',
-            f'Shard ({s1_name})']
+            f'Job-Level Shard ({s1_name})']
     if has_set2:
-        cols.append(f'Shard ({s2_name})')
+        cols.append(f'Job-Level Shard ({s2_name})')
     cols.append(f'Status ({s1_name})')
     if has_set2:
         cols.append(f'Status ({s2_name})')
@@ -541,14 +544,16 @@ def write_markdown(rows, archs, output_path, failed_tests=None, s1_name='set1', 
             lines.append('These test failures were detected from CI log files but have no XML report')
             lines.append('(typically due to timeouts, crashes, or process kills).')
             lines.append('')
-            lines.append('| Arch | Platform | Test Config | Test File | Test Class | Test Name | Shard | Category | Also Failing In |')
-            lines.append('| --- | --- | --- | --- | --- | --- | --- | --- | --- |')
+            lines.append('| Arch | Platform | Test Config | Test File | Test Class | Test Name | Job-Level Shard | Test-Level Shard | Category | Also Failing In |')
+            lines.append('| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |')
             for lf in rocm_log_failures:
                 test_class, test_name = _parse_log_failure_names(lf)
                 lines.append(
                     f"| {lf.get('arch', '')} | {lf.get('platform', '')} | {lf.get('test_config', '')} "
                     f"| {lf.get('test_file', '')} | {test_class} "
-                    f"| {test_name} | {lf.get('shard', '')} "
+                    f"| {test_name} "
+                    f"| {lf.get('job_shard', '')} "
+                    f"| {lf.get('test_shard', lf.get('shard', ''))} "
                     f"| {lf.get('category', '')} "
                     f"| {lf.get('also_failing_in', '')} |"
                 )

--- a/.automation_scripts/pytorch-unit-test-scripts/generate_summary.py
+++ b/.automation_scripts/pytorch-unit-test-scripts/generate_summary.py
@@ -345,6 +345,48 @@ def load_log_failures(filepaths):
     return entries
 
 
+def load_flaky_tests_as_log_failures(filepaths):
+    """Load flaky_tests_<arch>.csv and return entries shaped like log-failure rows.
+
+    Each returned dict has the same schema as the entries produced by
+    load_log_failures, with category='FLAKY' and reason='<test_class>::<test_name>',
+    so they can be appended to the log_failures list and surfaced in the
+    LOG-BASED FAILURES table alongside crashes/timeouts/etc.
+    """
+    entries = []
+    for fp in filepaths or []:
+        if not fp:
+            continue
+        basename = os.path.basename(fp)
+        if not (basename.startswith('log_failures_') and basename.endswith('.csv')):
+            continue
+        arch = basename[len('log_failures_'):-len('.csv')]
+        flaky_path = os.path.join(
+            os.path.dirname(fp),
+            'flaky_tests_' + basename[len('log_failures_'):],
+        )
+        if not os.path.isfile(flaky_path):
+            continue
+        with open(flaky_path, newline='') as f:
+            for row in csv.DictReader(f):
+                test_class = row.get('test_class', '')
+                test_name = row.get('test_name', '')
+                entries.append({
+                    'arch': arch,
+                    'log_file': row.get('log_file', ''),
+                    'platform': row.get('platform', ''),
+                    'test_config': row.get('test_config', ''),
+                    'test_file': row.get('test_file', ''),
+                    'job_shard': row.get('job_shard', ''),
+                    'test_shard': row.get('test_shard', ''),
+                    'status': 'FLAKY',
+                    'category': 'FLAKY',
+                    'reason': f'{test_class}::{test_name}' if test_class else test_name,
+                    'exit_codes': '',
+                })
+    return entries
+
+
 def load_log_shards(filepaths):
     """Load log shard inventory CSVs written alongside log_failures files.
 
@@ -544,7 +586,10 @@ def write_csv(rows, archs, output_path, failed_tests=None, s1_name='set1', s2_na
             test_class, test_name = _parse_log_failure_names(lf)
             key = (lf.get('arch', ''), _norm_test_file(lf.get('test_file', '')),
                    test_class, test_name)
-            if key in xml_failed_keys:
+            # Skip entries already present in the XML-based FAILED TESTS table
+            # to avoid double-counting the same failure, except for FLAKY
+            # entries which represent an independent signal (a rerun passed).
+            if key in xml_failed_keys and lf.get('category', '') != 'FLAKY':
                 continue
             rocm_log_failures.append(lf)
         if rocm_log_failures:
@@ -659,7 +704,7 @@ def write_markdown(rows, archs, output_path, failed_tests=None, s1_name='set1', 
             test_class, test_name = _parse_log_failure_names(lf)
             key = (lf.get('arch', ''), _norm_test_file(lf.get('test_file', '')),
                    test_class, test_name)
-            if key in xml_failed_keys:
+            if key in xml_failed_keys and lf.get('category', '') != 'FLAKY':
                 continue
             rocm_log_failures.append(lf)
         if rocm_log_failures:
@@ -711,6 +756,8 @@ def main():
     failed = collect_failed_tests(arch_data, archs, args.set1_name, args.set2_name)
     any_has_set2 = any(d.get('has_set2', True) for d in arch_data.values())
     log_failures = load_log_failures(args.log_failures) if args.log_failures else []
+    if args.log_failures:
+        log_failures.extend(load_flaky_tests_as_log_failures(args.log_failures))
     shard_lookup = load_log_shards(args.log_failures) if args.log_failures else {}
 
     _add_cross_arch_info(failed, log_failures, args.set2_name)

--- a/.automation_scripts/pytorch-unit-test-scripts/generate_summary.py
+++ b/.automation_scripts/pytorch-unit-test-scripts/generate_summary.py
@@ -233,9 +233,10 @@ def compute_overall_stats(rows, s1_col, s2_col, s1_time_col, s2_time_col, s1_nam
 def collect_failed_tests(arch_data, archs, s1_name, s2_name):
     """Return a list of failed test rows across all architectures.
 
-    Each entry includes an 'also_failing_in' field listing other architectures
-    where the same (test_file, test_class, test_name) tuple also fails on the
-    same platform (s1 or s2).
+    Only collects tests where s1 (ROCm) is FAILED. Each entry records shards
+    for both s1 and s2 so the reviewer can look up the failure in either CI
+    job. 'also_failing_in' is populated later once log failures are known so
+    CUDA log-only failures can be included.
     """
     failed = []
     for arch in archs:
@@ -252,28 +253,76 @@ def collect_failed_tests(arch_data, archs, s1_name, s2_name):
                     'test_class': r.get('test_class', ''),
                     'test_name': r.get('test_name', ''),
                     'test_config': r.get('test_config', ''),
-                    'shard': r.get(f'shard_{s1_name}', ''),
+                    f'shard_{s1_name}': r.get(f'shard_{s1_name}', ''),
                     f'status_{s1_name}': s1,
                 }
                 if has_set2:
+                    entry[f'shard_{s2_name}'] = r.get(f'shard_{s2_name}', '')
                     entry[f'status_{s2_name}'] = s2
                 failed.append(entry)
 
-    _add_cross_arch_info(failed)
     return failed
 
 
-def _add_cross_arch_info(failed_tests):
-    """Populate 'also_failing_in' for each entry based on matching test tuples."""
+def _add_cross_arch_info(failed_tests, log_failures, s2_name):
+    """Populate 'also_failing_in' for each entry.
+
+    Matches across other ROCm architectures (from XML-based failures) and also
+    includes s2 (CUDA) if a log failure is recorded for the same test tuple.
+    """
     from collections import defaultdict
     by_tuple = defaultdict(set)
     for t in failed_tests:
         key = (t['test_file'], t['test_class'], t['test_name'])
         by_tuple[key].add(t['arch'])
+
+    cuda_log_tuples = set()
+    for lf in log_failures or []:
+        if lf.get('platform', '') == s2_name:
+            test_class, test_name = _parse_log_failure_names(lf)
+            cuda_log_tuples.add((lf.get('test_file', ''), test_class, test_name))
+
     for t in failed_tests:
         key = (t['test_file'], t['test_class'], t['test_name'])
         others = sorted(a for a in by_tuple[key] if a != t['arch'])
+        if key in cuda_log_tuples and s2_name not in others:
+            others.append(s2_name)
         t['also_failing_in'] = ', '.join(others)
+
+
+def _add_log_failure_cross_arch(log_failures, failed_tests, s1_name, s2_name):
+    """Populate 'also_failing_in' for each log failure entry.
+
+    Cross-references: other archs that have the same test failing (either as
+    a log failure or as an XML-based failure), plus s2 (CUDA) if it appears
+    in log failures for the same test tuple.
+    """
+    from collections import defaultdict
+    by_tuple_archs = defaultdict(set)
+
+    for lf in log_failures or []:
+        if lf.get('platform', '') == s1_name:
+            test_class, test_name = _parse_log_failure_names(lf)
+            key = (lf.get('test_file', ''), test_class, test_name)
+            by_tuple_archs[key].add(lf.get('arch', ''))
+    for t in failed_tests or []:
+        key = (t['test_file'], t['test_class'], t['test_name'])
+        by_tuple_archs[key].add(t['arch'])
+
+    cuda_log_tuples = set()
+    for lf in log_failures or []:
+        if lf.get('platform', '') == s2_name:
+            test_class, test_name = _parse_log_failure_names(lf)
+            cuda_log_tuples.add((lf.get('test_file', ''), test_class, test_name))
+
+    for lf in log_failures or []:
+        test_class, test_name = _parse_log_failure_names(lf)
+        key = (lf.get('test_file', ''), test_class, test_name)
+        arch = lf.get('arch', '')
+        others = sorted(a for a in by_tuple_archs[key] if a and a != arch)
+        if key in cuda_log_tuples and s2_name not in others:
+            others.append(s2_name)
+        lf['also_failing_in'] = ', '.join(others)
 
 
 def load_log_failures(filepaths):
@@ -376,15 +425,21 @@ def write_csv(rows, archs, output_path, failed_tests=None, s1_name='set1', s2_na
     if s1_failed:
         csv_rows.append(['FAILED TESTS'])
         header = ['Arch', 'Test Config', 'Test File', 'Test Class',
-                  'Test Name', 'Shard', f'Status ({s1_name})']
+                  'Test Name', f'Shard ({s1_name})']
+        if has_set2:
+            header.append(f'Shard ({s2_name})')
+        header.append(f'Status ({s1_name})')
         if has_set2:
             header.append(f'Status ({s2_name})')
         header.append('Also Failing In')
         csv_rows.append(header)
         for t in s1_failed:
             row = [t['arch'], t['test_config'], t['test_file'],
-                   t['test_class'], t['test_name'], t.get('shard', ''),
-                   t[f'status_{s1_name}']]
+                   t['test_class'], t['test_name'],
+                   t.get(f'shard_{s1_name}', '')]
+            if has_set2:
+                row.append(t.get(f'shard_{s2_name}', ''))
+            row.append(t[f'status_{s1_name}'])
             if has_set2:
                 row.append(t.get(f'status_{s2_name}', ''))
             row.append(t.get('also_failing_in', ''))
@@ -392,17 +447,21 @@ def write_csv(rows, archs, output_path, failed_tests=None, s1_name='set1', s2_na
         csv_rows.append([])
 
     if log_failures:
-        csv_rows.append(['LOG-BASED FAILURES (not in XML)'])
-        csv_rows.append(['Arch', 'Platform', 'Test Config', 'Test File', 'Test Class', 'Test Name', 'Shard', 'Category', 'Log File'])
-        for lf in log_failures:
-            test_class, test_name = _parse_log_failure_names(lf)
-            csv_rows.append([
-                lf.get('arch', ''), lf.get('platform', ''), lf.get('test_config', ''),
-                lf.get('test_file', ''), test_class, test_name,
-                lf.get('shard', ''), lf.get('category', ''),
-                lf.get('log_file', ''),
-            ])
-        csv_rows.append([])
+        rocm_log_failures = [lf for lf in log_failures if lf.get('platform', '') == s1_name]
+        if rocm_log_failures:
+            csv_rows.append(['LOG-BASED FAILURES (not in XML)'])
+            csv_rows.append(['Arch', 'Platform', 'Test Config', 'Test File', 'Test Class',
+                             'Test Name', 'Shard', 'Category', 'Also Failing In', 'Log File'])
+            for lf in rocm_log_failures:
+                test_class, test_name = _parse_log_failure_names(lf)
+                csv_rows.append([
+                    lf.get('arch', ''), lf.get('platform', ''), lf.get('test_config', ''),
+                    lf.get('test_file', ''), test_class, test_name,
+                    lf.get('shard', ''), lf.get('category', ''),
+                    lf.get('also_failing_in', ''),
+                    lf.get('log_file', ''),
+                ])
+            csv_rows.append([])
 
     with open(output_path, 'w', newline='') as f:
         csv.writer(f).writerows(csv_rows)
@@ -443,7 +502,10 @@ def write_markdown(rows, archs, output_path, failed_tests=None, s1_name='set1', 
     s1_failed = [t for t in (failed_tests or []) if t.get(f'status_{s1_name}') == 'FAILED']
 
     cols = ['Arch', 'Test Config', 'Test File', 'Test Class', 'Test Name',
-            'Shard', f'Status ({s1_name})']
+            f'Shard ({s1_name})']
+    if has_set2:
+        cols.append(f'Shard ({s2_name})')
+    cols.append(f'Status ({s1_name})')
     if has_set2:
         cols.append(f'Status ({s2_name})')
     cols.append('Also Failing In')
@@ -456,7 +518,10 @@ def write_markdown(rows, archs, output_path, failed_tests=None, s1_name='set1', 
         for t in s1_failed:
             line = (f"| {t['arch']} | {t['test_config']} | {t['test_file']} "
                     f"| {t['test_class']} | {t['test_name']} "
-                    f"| {t.get('shard', '')} | {t[f'status_{s1_name}']}")
+                    f"| {t.get(f'shard_{s1_name}', '')}")
+            if has_set2:
+                line += f" | {t.get(f'shard_{s2_name}', '')}"
+            line += f" | {t[f'status_{s1_name}']}"
             if has_set2:
                 line += f" | {t.get(f'status_{s2_name}', '')}"
             line += f" | {t.get('also_failing_in', '')} |"
@@ -469,22 +534,25 @@ def write_markdown(rows, archs, output_path, failed_tests=None, s1_name='set1', 
         lines.append('')
 
     if log_failures:
-        lines.append('### LOG-BASED FAILURES (not in XML)')
-        lines.append('')
-        lines.append('These test failures were detected from CI log files but have no XML report')
-        lines.append('(typically due to timeouts, crashes, or process kills).')
-        lines.append('')
-        lines.append('| Arch | Platform | Test Config | Test File | Test Class | Test Name | Shard | Category |')
-        lines.append('| --- | --- | --- | --- | --- | --- | --- | --- |')
-        for lf in log_failures:
-            test_class, test_name = _parse_log_failure_names(lf)
-            lines.append(
-                f"| {lf.get('arch', '')} | {lf.get('platform', '')} | {lf.get('test_config', '')} "
-                f"| {lf.get('test_file', '')} | {test_class} "
-                f"| {test_name} | {lf.get('shard', '')} "
-                f"| {lf.get('category', '')} |"
-            )
-        lines.append('')
+        rocm_log_failures = [lf for lf in log_failures if lf.get('platform', '') == s1_name]
+        if rocm_log_failures:
+            lines.append(f'### LOG-BASED FAILURES (not in XML) ({len(rocm_log_failures)})')
+            lines.append('')
+            lines.append('These test failures were detected from CI log files but have no XML report')
+            lines.append('(typically due to timeouts, crashes, or process kills).')
+            lines.append('')
+            lines.append('| Arch | Platform | Test Config | Test File | Test Class | Test Name | Shard | Category | Also Failing In |')
+            lines.append('| --- | --- | --- | --- | --- | --- | --- | --- | --- |')
+            for lf in rocm_log_failures:
+                test_class, test_name = _parse_log_failure_names(lf)
+                lines.append(
+                    f"| {lf.get('arch', '')} | {lf.get('platform', '')} | {lf.get('test_config', '')} "
+                    f"| {lf.get('test_file', '')} | {test_class} "
+                    f"| {test_name} | {lf.get('shard', '')} "
+                    f"| {lf.get('category', '')} "
+                    f"| {lf.get('also_failing_in', '')} |"
+                )
+            lines.append('')
 
     md = '\n'.join(lines)
     with open(output_path, 'w') as f:
@@ -514,6 +582,9 @@ def main():
     failed = collect_failed_tests(arch_data, archs, args.set1_name, args.set2_name)
     any_has_set2 = any(d.get('has_set2', True) for d in arch_data.values())
     log_failures = load_log_failures(args.log_failures) if args.log_failures else []
+
+    _add_cross_arch_info(failed, log_failures, args.set2_name)
+    _add_log_failure_cross_arch(log_failures, failed, args.set1_name, args.set2_name)
 
     output_base = args.output
     if output_base.endswith('.csv') or output_base.endswith('.md'):

--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -322,7 +322,7 @@ jobs:
           ARCH_ARGS=()
           for ARCH in $ARCHS; do
             ARTIFACT_DIR="../../artifacts/${PREFIX}-results-${ARCH}"
-            CSV=$(find "$ARTIFACT_DIR"/ -maxdepth 2 -name "*.csv" ! -name "*_running_time*" ! -name "*_summary*" ! -name "log_failures_*" 2>/dev/null | head -1)
+            CSV=$(find "$ARTIFACT_DIR"/ -maxdepth 2 -name "*.csv" ! -name "*_running_time*" ! -name "*_summary*" ! -name "log_failures_*" ! -name "log_shards_*" 2>/dev/null | head -1)
             if [ -z "$CSV" ]; then
               echo "WARNING: No CSV found for $ARCH, skipping"
               continue

--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -322,7 +322,7 @@ jobs:
           ARCH_ARGS=()
           for ARCH in $ARCHS; do
             ARTIFACT_DIR="../../artifacts/${PREFIX}-results-${ARCH}"
-            CSV=$(find "$ARTIFACT_DIR"/ -maxdepth 2 -name "*.csv" ! -name "*_running_time*" ! -name "*_summary*" ! -name "log_failures_*" ! -name "log_shards_*" 2>/dev/null | head -1)
+            CSV=$(find "$ARTIFACT_DIR"/ -maxdepth 2 -name "*.csv" ! -name "*_running_time*" ! -name "*_summary*" ! -name "log_failures_*" ! -name "log_shards_*" ! -name "flaky_tests_*" 2>/dev/null | head -1)
             if [ -z "$CSV" ]; then
               echo "WARNING: No CSV found for $ARCH, skipping"
               continue


### PR DESCRIPTION
## Summary
- Only display tests where ROCm status is FAILED in the summary (CUDA status shown as a context column alongside). Previously both ROCm and CUDA failures were shown.
- Add "Also Failing In" column that shows which other architectures have the same test tuple (test_file, test_class, test_name) failing, making it easy to distinguish all-ROCm issues from architecture-specific ones.
- Includes count of failed tests in the section header.
- Add job-level and test-level shard info to "LOG-BASED FAILURES (not in XML)" and "FAILED TESTS" section
- Includes flaky tests in "LOG-BASED FAILURES (not in XML)" section for any tests that pass when run in new process

## Test plan

- [x] Cross-arch detection confirmed: tests failing on all 3 archs show the other 2 in "Also Failing In"; single-arch failures show empty
- [x] CSV and Markdown output both updated consistently
Latest run https://github.com/ROCm/pytorch/actions/runs/24798004968
Run without this PR on the same commit: https://github.com/ROCm/pytorch/actions/runs/24796654604