### PR TITLE
Fix Docker Hub secret names for build_portable_linux_pytorch_dockers

### DIFF
--- a/.github/workflows/build_portable_linux_pytorch_dockers.yml
+++ b/.github/workflows/build_portable_linux_pytorch_dockers.yml
@@ -187,11 +187,8 @@ jobs:
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
-          # ROCm/pytorch: use DOCKERUSERNAME / DOCKERTOKEN
-          # username: ${{ secrets.DOCKERUSERNAME }}
-          # password: ${{ secrets.DOCKERTOKEN }}
           username: ${{ secrets.DOCKERUSERNAME }}
-          password: ${{ secrets.DCKRPAT }}
+          password: ${{ secrets.DOCKERTOKEN }}
 
       - name: Prepare build context
         run: |
@@ -366,11 +363,8 @@ jobs:
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
-          # ROCm/pytorch: use DOCKERUSERNAME / DOCKERTOKEN
-          # username: ${{ secrets.DOCKERUSERNAME }}
-          # password: ${{ secrets.DOCKERTOKEN }}
           username: ${{ secrets.DOCKERUSERNAME }}
-          password: ${{ secrets.DCKRPAT }}
+          password: ${{ secrets.DOCKERTOKEN }}
 
       - name: Prepare build context
         run: |


### PR DESCRIPTION
Docker credentials were using the ones from my fork and not rocm/pytorch credentials:
https://github.com/ROCm/pytorch/actions/runs/24479854145/job/71541505148
Latest build
https://github.com/ROCm/pytorch/actions/runs/24480169722/job/71542549933