### PR TITLE
[ROCm][CI][release/2.11] Backport checking existence of /etc/rocm_env.sh before sourcing 

### DIFF
--- a/.ci/pytorch/common.sh
+++ b/.ci/pytorch/common.sh
@@ -5,6 +5,12 @@
 source "$(dirname "${BASH_SOURCE[0]}")/common_utils.sh"
 set -ex -o pipefail
 
+# for ROCm environment variables
+if [[ "${BUILD_ENVIRONMENT}" == *rocm* ]] && [[ -f /etc/rocm_env.sh ]]; then
+  # shellcheck disable=SC1091
+  source /etc/rocm_env.sh
+fi
+
 # Required environment variables:
 #   $BUILD_ENVIRONMENT (should be set by your Docker image)
 


### PR DESCRIPTION
## Summary

Fixes the `pytorch_ut` failure introduced in PyTorch 2.11 where `test.sh` exits immediately with code 1 before any tests run.

**Root cause:** PR pytorch/pytorch#168377 added `source /etc/rocm_env.sh` to `.ci/pytorch/common.sh` targeting AMD's internal Jenkins CI, which provisions this file. When cherry-picked into `release/2.11`, this line breaks all TheRock Docker-based CI environments that do **not** provision `/etc/rocm_env.sh`. Since `set -e` is active in `test.sh`, the script exits before a single test runs — causing 0-pass, 1-fail on every host.

**The fix:** Add a `[[ -f /etc/rocm_env.sh ]]` existence check so environments without the file skip sourcing it gracefully, while Jenkins CI (which does provision the file) continues working as before. This matches the fix already present on `pytorch/pytorch main`.

```bash
# Before (broken):
if [[ "${BUILD_ENVIRONMENT}" == *rocm* ]]; then
  source /etc/rocm_env.sh
fi

# After (fixed):
if [[ "${BUILD_ENVIRONMENT}" == *rocm* ]] && [[ -f /etc/rocm_env.sh ]]; then
  source /etc/rocm_env.sh
fi
```

**Impact without this fix:**
- 86/97 `pytorch_ut` runs failed on TheRock build 7.13.0-1208
- Affects all GFX variants and Python versions (3.11, 3.12, 3.13)
- PyTorch 2.10 is unaffected (does not have `source /etc/rocm_env.sh`)

**References:**
- Jira: ROCM-21809
- Upstream issue: pytorch/pytorch#170983
- Regression introduced by: pytorch/pytorch#168377