### PR TITLE
Cleanup custom op polluting global state for subsequent tests

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -10335,6 +10335,7 @@ tensor([[[1.+1.j, 1.+1.j, 1.+1.j,  ..., 1.+1.j, 1.+1.j, 1.+1.j],
         global _my_storage
 
         my_lib = Library("my_lib", "DEF")  # noqa: TOR901
+        self.addCleanup(my_lib._destroy)
         my_lib.define('my_func() -> None')
 
         a = torch.tensor([1.])


### PR DESCRIPTION
`my_lib` in `test_storage_preserve_nonhermetic_in_hermetic_context` leaks into global op space after the test ends and affect subsequent tests in the same process using dynamo.

Without the fix, running any tests requiring checkpoint/compile or dynamo-related after `test_storage_preserve_nonhermetic_in_hermetic_context` fails with 
```
torch._dynamo.exc.BackendCompilerFailed: backend='aot_eager' raised:
TypeError: 'CustomDecompTable' object is not a mapping
```
e.g. `python -m pytest -v pytorch/test/test_torch.py::TestTorch::test_storage_preserve_nonhermetic_in_hermetic_context pytorch/test/test_autograd.py::TestAutograd::test_checkpoint_compile_no_recompile`

Upstream PR: https://github.com/pytorch/pytorch/pull/180998