### PR TITLE
[ROCm][release/2.10] Fix test_linalg MAGMA test failures

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -2271,6 +2271,7 @@ class TestLinalg(TestCase):
         # check correctness using eigendecomposition identity
         self.assertEqual(a.to(v.dtype) @ v, w * v, atol=1e-3, rtol=1e-3)
 
+    @skipCUDAIf(TEST_WITH_ROCM and not torch.cuda.has_magma, "ROCm hipsolver backend does not currently support eig")
     @onlyCUDA
     @dtypes(torch.float32, torch.float64)
     def test_eig_cuda_complex_eigenvectors(self, device, dtype):
@@ -7047,10 +7048,10 @@ class TestLinalg(TestCase):
     @skipCPUIfNoLapack
     @dtypes(torch.double)
     def test_lobpcg_ortho(self, device, dtype):
-        if torch.version.hip:
+        if torch.version.hip and torch.cuda.has_magma:
             torch.backends.cuda.preferred_linalg_library('magma')
         self._test_lobpcg_method(device, dtype, 'ortho')
-        if torch.version.hip:
+        if torch.version.hip and torch.cuda.has_magma:
             torch.backends.cuda.preferred_linalg_library('default')
 
     def _test_lobpcg_method(self, device, dtype, method):


### PR DESCRIPTION
Fixes ROCM-20786

## Problem
Three tests in `test_linalg.py` fail on ROCm builds when MAGMA is not compiled in:
- `test_eig_cuda_complex_eigenvectors_cuda_float32`
- `test_eig_cuda_complex_eigenvectors_cuda_float64`  
- `test_lobpcg_ortho_cuda_float64`

Previous PRs (#3070, #3096) only fixed `test_vmap.py` and `test_torchinductor.py`, but did NOT fix `test/test_linalg.py` where these three tests actually live, as reported in the latest Jira comments.

## Changes

### 1. `test_eig_cuda_complex_eigenvectors`
Added skip decorator to handle ROCm builds without MAGMA:
```python
@skipCUDAIf(TEST_WITH_ROCM and not torch.cuda.has_magma, "ROCm hipsolver backend does not currently support eig")
```
This aligns with upstream pytorch/pytorch main branch.

### 2. `test_lobpcg_ortho`  
Added `torch.cuda.has_magma` check before setting preferred linalg library:
```python
if torch.version.hip and torch.cuda.has_magma:
    torch.backends.cuda.preferred_linalg_library('magma')
```
Since LOBPCG can run with the default backend, this converts FAIL → PASS instead of skipping.

## Testing
- Tests will SKIP (eig) or PASS (lobpcg) in no-MAGMA TheRock builds
- Tests will continue to PASS in builds with MAGMA compiled in

## References
- Jira: https://amd-hub.atlassian.net/browse/ROCM-20786
- Upstream fix for eig: pytorch/pytorch#173688

🤖 Generated with [Claude Code](https://claude.com/claude-code)