### PR TITLE
[ROCm][release/2.9] Fix test_lobpcg_ortho MAGMA test failure

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -6707,10 +6707,10 @@ class TestLinalg(TestCase):
     @skipCPUIfNoLapack
     @dtypes(torch.double)
     def test_lobpcg_ortho(self, device, dtype):
-        if torch.version.hip:
+        if torch.version.hip and torch.cuda.has_magma:
             torch.backends.cuda.preferred_linalg_library('magma')
         self._test_lobpcg_method(device, dtype, 'ortho')
-        if torch.version.hip:
+        if torch.version.hip and torch.cuda.has_magma:
             torch.backends.cuda.preferred_linalg_library('default')
 
     def _test_lobpcg_method(self, device, dtype, method):


### PR DESCRIPTION
Fixes ROCM-20786 for release/2.9

## Problem
`test_lobpcg_ortho_cuda_float64` in `test_linalg.py` fails on ROCm builds when MAGMA is not compiled in.

The test unconditionally sets the linalg backend to MAGMA on ROCm, which raises `RuntimeError` when MAGMA is not available.

## Changes

### `test_lobpcg_ortho`  
Added `torch.cuda.has_magma` check before setting preferred linalg library:
```python
if torch.version.hip and torch.cuda.has_magma:
    torch.backends.cuda.preferred_linalg_library('magma')
```
Since LOBPCG can run with the default backend, this converts FAIL → PASS instead of skipping.

## Scope

Note: `test_eig_cuda_complex_eigenvectors` does not exist in release/2.9, so only the lobpcg fix is needed for this branch.

This is the same fix applied to release/2.10 in PR #3171.

## Testing
- Test will PASS in no-MAGMA TheRock builds (instead of FAIL)
- Test will continue to PASS in builds with MAGMA compiled in

## References
- Jira: https://amd-hub.atlassian.net/browse/ROCM-20786
- Related PR for release/2.10: #3171

🤖 Generated with [Claude Code](https://claude.com/claude-code)