### PR TITLE
[release/2.9] Fix: python 3.14 numba and onnx versions (cherry-pick #3104)

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -114,7 +114,8 @@ ninja==1.11.1.3
 
 numba==0.49.0 ; python_version < "3.9" and platform_machine != "s390x"
 numba==0.60.0 ; python_version == "3.9" and platform_machine != "s390x"
-numba==0.61.2 ; python_version > "3.9" and platform_machine != "s390x"
+numba==0.61.2 ; python_version > "3.9" and python_version < "3.14" and platform_machine != "s390x"
+numba==0.64.0 ; python_version >= "3.14" and platform_machine != "s390x"
 #Description: Just-In-Time Compiler for Numerical Functions
 #Pinned versions: 0.54.1, 0.49.0, <=0.49.1
 #test that import: test_numba_integration.py
@@ -333,8 +334,9 @@ sympy==1.13.3
 #test that import:
 
 onnx==1.19.1 ; python_version < "3.14"
-# Unpin once Python 3.14 is supported. See  onnxruntime issue 26309.
-onnx==1.18.0 ; python_version == "3.14"
+# onnx 1.20.1 uses abi3 stable ABI wheels (compatible with Python 3.12+).
+# onnx 1.18.0 fails to build on 3.14 due to CMake ABI tag mismatch (onnx#7226).
+onnx==1.20.1 ; python_version >= "3.14"
 #Description: Required by onnx tests, and mypy and test_public_bindings.py when checking torch.onnx._internal
 #Pinned versions:
 #test that import:


### PR DESCRIPTION
## Summary

Fixes PyTorch Docker build failures for Python 3.14 (cp314) by updating dependency versions in `.ci/docker/requirements-ci.txt`.

Cherry-pick of #3104 to release/2.9 branch.

## Changes

### Numba Version Update
- Restricted `numba==0.61.2` to `python_version < "3.14"` (was `> "3.9"`)
- Added `numba==0.64.0` for `python_version >= "3.14"`

**Rationale:** `numba==0.61.2` has a version guard in its setup.py that restricts installation to Python >=3.10,<3.14. Python 3.14 support arrived in numba 0.64.0.

### ONNX Version Update
- Updated `onnx==1.18.0` to `onnx==1.20.1` for `python_version >= "3.14"`

**Rationale:** `onnx==1.18.0` fails to build on Python 3.14 due to CMake ABI tag mismatch. `onnx==1.20.1` provides abi3 stable ABI wheels compatible with Python 3.12+, avoiding compilation issues.

## Impact

Enables successful Python 3.14 wheel and Docker image builds without affecting Python 3.10–3.13 configurations.