### PR TITLE
Parity Auto Trigger: run parity.yml per upstream commit once CI finishes

### DIFF
--- a/.automation_scripts/pytorch-unit-test-scripts/download_testlogs
+++ b/.automation_scripts/pytorch-unit-test-scripts/download_testlogs
@@ -210,8 +210,10 @@ def _shorten_unzipped_dirs():
 
     Converts names like:
       unzipped-test-reports-runattempt1-test-default-1-6-linux.rocm.gpu.gfx942.1_68613413431.zip
+      unzipped-test-reports-runattempt1-test-osdc-default-1-5-mt-l-x86aavx2-29-113-l4_73385044118.zip
     to:
       test-default-1-6
+      test-default-1-5
 
     Preserves the 'test-<config>' prefix so that summarize_xml_testreports.py
     can still detect workflow type via substring matching.
@@ -220,9 +222,9 @@ def _shorten_unzipped_dirs():
     for d in sorted(Path(".").glob("unzipped-*")):
         if not d.is_dir():
             continue
-        m = re.search(r'(test-\w+-\d+-\d+)', d.name)
+        m = re.search(r'test-(?:osdc-)?(default|distributed|inductor)-(\d+)-(\d+)', d.name)
         if m:
-            short_name = m.group(1)
+            short_name = f"test-{m.group(1)}-{m.group(2)}-{m.group(3)}"
             if not Path(short_name).exists():
                 d.rename(short_name)
                 print(f"  Renamed {d.name} -> {short_name}")
@@ -662,6 +664,7 @@ def main():
 
     if not args.no_cuda:
         cuda_job_prefix = "linux-jammy-cuda13.0-py3.10-gcc11"
+        cuda_test_job_kind = "test-osdc"
         print("==========================================")
         print(f"Finding CUDA tests in workflow '{CUDAWorkflowNames['default']}' by sha: {sha}")
         print("==========================================")
@@ -686,7 +689,10 @@ def main():
 
         for run in trunk_runs:
             jobs = get_workflow_jobs(run)
-            test_jobs = [j for j in jobs if cuda_job_prefix in j['name'] and '/ test' in j['name']]
+            test_jobs = [
+                j for j in jobs
+                if cuda_job_prefix in j['name'] and f'/ {cuda_test_job_kind} (' in j['name']
+            ]
             if test_jobs:
                 trunk_wf = run
                 all_cuda_jobs = jobs
@@ -699,7 +705,7 @@ def main():
             # by the jobs API. Use check-runs API to find the actual run.
             print("No CUDA test jobs in any trunk run's jobs API, trying check-runs API...")
             check_runs = get_check_runs_for_commit(sha, cuda_job_prefix)
-            cuda_test_jobs = [cr for cr in check_runs if '/ test' in cr['name']]
+            cuda_test_jobs = [cr for cr in check_runs if f'/ {cuda_test_job_kind} (' in cr['name']]
             if cuda_test_jobs:
                 # Extract the actual workflow run ID from the check-run details URL
                 import re as _re
@@ -737,18 +743,18 @@ def main():
         # Download logs
         if not args.artifacts_only:
             test_log_list_cuda_default = [
-              ["cuda1.txt", f"{cuda_job_prefix} / test (default, 1, 5"],
-              ["cuda2.txt", f"{cuda_job_prefix} / test (default, 2, 5"],
-              ["cuda3.txt", f"{cuda_job_prefix} / test (default, 3, 5"],
-              ["cuda4.txt", f"{cuda_job_prefix} / test (default, 4, 5"],
-              ["cuda5.txt", f"{cuda_job_prefix} / test (default, 5, 5"],
+              ["cuda1.txt", f"{cuda_job_prefix} / {cuda_test_job_kind} (default, 1, 5"],
+              ["cuda2.txt", f"{cuda_job_prefix} / {cuda_test_job_kind} (default, 2, 5"],
+              ["cuda3.txt", f"{cuda_job_prefix} / {cuda_test_job_kind} (default, 3, 5"],
+              ["cuda4.txt", f"{cuda_job_prefix} / {cuda_test_job_kind} (default, 4, 5"],
+              ["cuda5.txt", f"{cuda_job_prefix} / {cuda_test_job_kind} (default, 5, 5"],
             ]
             test_log_list_cuda = test_log_list_cuda_default
             if not args.exclude_distributed:
                 test_log_list_cuda_distributed = [
-                  ["cuda_dist1.txt", f"{cuda_job_prefix} / test (distributed, 1, 3"],
-                  ["cuda_dist2.txt", f"{cuda_job_prefix} / test (distributed, 2, 3"],
-                  ["cuda_dist3.txt", f"{cuda_job_prefix} / test (distributed, 3, 3"],
+                  ["cuda_dist1.txt", f"{cuda_job_prefix} / {cuda_test_job_kind} (distributed, 1, 3"],
+                  ["cuda_dist2.txt", f"{cuda_job_prefix} / {cuda_test_job_kind} (distributed, 2, 3"],
+                  ["cuda_dist3.txt", f"{cuda_job_prefix} / {cuda_test_job_kind} (distributed, 3, 3"],
                 ]
                 test_log_list_cuda += test_log_list_cuda_distributed
 
@@ -756,11 +762,11 @@ def main():
 
         # Download artifacts
         test_artifacts_list_cuda_default = [
-          "test-reports-test-default-1-5",
-          "test-reports-test-default-2-5",
-          "test-reports-test-default-3-5",
-          "test-reports-test-default-4-5",
-          "test-reports-test-default-5-5",
+          "test-reports-test-osdc-default-1-5",
+          "test-reports-test-osdc-default-2-5",
+          "test-reports-test-osdc-default-3-5",
+          "test-reports-test-osdc-default-4-5",
+          "test-reports-test-osdc-default-5-5",
         ]
 
         test_artifacts_list_cuda = []
@@ -769,9 +775,9 @@ def main():
 
         if not args.exclude_distributed:
             test_artifacts_list_cuda_distributed = [
-              "test-reports-test-distributed-1-3",
-              "test-reports-test-distributed-2-3",
-              "test-reports-test-distributed-3-3",
+              "test-reports-test-osdc-distributed-1-3",
+              "test-reports-test-osdc-distributed-2-3",
+              "test-reports-test-osdc-distributed-3-3",
             ]
             test_artifacts_list_cuda += test_artifacts_list_cuda_distributed
 

--- a/.github/workflows/parity-auto.yml
+++ b/.github/workflows/parity-auto.yml
@@ -1,24 +1,28 @@
 name: Parity Auto Trigger
 run-name: "Parity auto-trigger · pytorch/pytorch main"
 
-# Polls pytorch/pytorch main for commits where the ROCm test check-runs
-# we care about have all completed, and dispatches parity.yml with the
-# subset of archs whose test shards are done (and therefore have S3
-# artifacts we can download).
+# Polls pytorch/pytorch main for commits where ALL ROCm CI has
+# finished, and dispatches parity.yml once for that SHA covering every
+# arch whose test shards actually ran on it.
 #
-# Readiness is determined at the *check-run* level, not the workflow
+# Readiness is evaluated at the *check-run* level, not the workflow
 # level: ROCm test shards post check-runs independently, and a single
 # failing shard flips the parent workflow_run to conclusion=failure
-# while other shards are still running. Relying on workflow_runs would
-# trigger parity too early and yield empty reports. Instead, for each
-# arch we require every check-run whose name matches that arch's regex
-# (e.g. "rocm.*mi355.*/ test \(") to have status=completed — any
-# conclusion is fine, as long as the runner finished and uploaded.
+# while siblings are still executing. Relying on workflow_runs would
+# fire too early and produce empty reports.
 #
-# This is intentionally per-arch, not per-commit-as-a-whole: mi355 (run
-# as part of trunk) is ready on almost every commit, while periodic
-# workflows like rocm-mi300 land on a SHA much less often. We dispatch
-# once per (SHA, arch-set) tuple.
+# Two gates:
+#   1. Every ROCm check-run on the SHA must be status=completed
+#      (across arches and workflows — we don't want to dispatch mi355
+#      while mi300's shards are still running on the same commit).
+#   2. For each arch in scope, we check whether its test shards
+#      actually ran on this SHA; mi300/mi200 etc. only show up when
+#      their periodic workflow happens to land on that SHA.
+#
+# We dispatch once per SHA with the ready subset of arches, so mi355
+# (run as part of trunk) gets a parity report per commit, and mi300/
+# mi200 join the same dispatch whenever their periodic workflow
+# happens to finish on that SHA.
 
 on:
   schedule:
@@ -149,11 +153,9 @@ jobs:
 
             # Pull all ROCm test check-runs for this SHA. We use check-runs
             # (not workflow_runs) because ROCm test shards post check-runs
-            # independently and the overall workflow_run conclusion is
-            # "failure" the moment any shard fails, even if other shards
-            # are still executing. What we actually want is: "have all the
-            # test shards for this arch finished running on upstream?"
-            # Then we can download S3 artifacts without racing against CI.
+            # independently and workflow_run conclusion flips to 'failure'
+            # the moment any shard fails, even while other shards are
+            # still running. We need per-shard state.
             CHECK_RUNS=$(gh api --paginate \
               "repos/$UPSTREAM/commits/$SHA/check-runs?per_page=100" \
               --jq '.check_runs[] | select(.name | test("rocm";"i")) | {name,status,conclusion}' \
@@ -164,11 +166,29 @@ jobs:
               continue
             fi
 
-            # Ready archs = archs for which ALL test check-runs matching
-            # the arch's regex are status=completed, AND at least one such
-            # check-run exists. "status=completed" covers any conclusion
-            # (success/failure/skipped/cancelled) — if the runner ran and
-            # finished, we expect artifacts in S3 whether it passed or not.
+            # Gate 1: require EVERY ROCm check-run for this SHA to be
+            # status=completed (across all arches and workflows). We
+            # don't want to dispatch mi355 while mi300's shards are
+            # still running on the same commit — once we dispatch for a
+            # SHA the parity report is authored, and dispatching a
+            # second time later for a different arch gives users two
+            # partial reports instead of one full one.
+            TOTAL_CR=$(echo "$CHECK_RUNS" | jq 'length')
+            PENDING_CR=$(echo "$CHECK_RUNS" | jq 'map(select(.status != "completed")) | length')
+            if [ "$PENDING_CR" -ne 0 ]; then
+              PENDING_SAMPLE=$(echo "$CHECK_RUNS" | jq -r '
+                map(select(.status != "completed"))
+                | .[0:3]
+                | map(.name)
+                | join(", ")')
+              echo "[$SHORT] $DATE  ${PENDING_CR}/${TOTAL_CR} ROCm check-runs still pending — skip (e.g. $PENDING_SAMPLE)"
+              continue
+            fi
+
+            # Gate 2: for each arch in scope, identify whether that
+            # arch's test shards actually ran on this SHA (some archs
+            # run only on periodic workflows that don't fire every
+            # commit, so mi300/mi200 may legitimately have no shards).
             READY=""
             NOT_READY_NOTES=""
             for ARCH in $ARCHS; do
@@ -177,16 +197,10 @@ jobs:
                 NOT_READY_NOTES="$NOT_READY_NOTES $ARCH:no-regex"
                 continue
               fi
-              COUNTS=$(echo "$CHECK_RUNS" | jq --arg rx "$REGEX" '
-                map(select(.name | test($rx)))
-                | {total: length,
-                   pending: (map(select(.status != "completed")) | length)}')
-              TOTAL=$(echo "$COUNTS" | jq -r '.total')
-              PENDING=$(echo "$COUNTS" | jq -r '.pending')
+              TOTAL=$(echo "$CHECK_RUNS" | jq --arg rx "$REGEX" \
+                'map(select(.name | test($rx))) | length')
               if [ "$TOTAL" -eq 0 ]; then
                 NOT_READY_NOTES="$NOT_READY_NOTES $ARCH:no-shards"
-              elif [ "$PENDING" -ne 0 ]; then
-                NOT_READY_NOTES="$NOT_READY_NOTES $ARCH:${PENDING}/${TOTAL}-pending"
               else
                 READY="$READY $ARCH"
               fi
@@ -195,7 +209,7 @@ jobs:
             NOT_READY_NOTES=$(echo "$NOT_READY_NOTES" | xargs)
 
             if [ -z "$READY" ]; then
-              echo "[$SHORT] $DATE  no ready archs (${NOT_READY_NOTES:-none})"
+              echo "[$SHORT] $DATE  all ROCm check-runs complete but no in-scope arches ran (${NOT_READY_NOTES:-none})"
               continue
             fi
 

--- a/.github/workflows/parity-auto.yml
+++ b/.github/workflows/parity-auto.yml
@@ -1,0 +1,180 @@
+name: Parity Auto Trigger
+run-name: "Parity auto-trigger · pytorch/pytorch main"
+
+# Polls pytorch/pytorch main for commits whose upstream CI has fully finished,
+# then dispatches .github/workflows/parity.yml on the first ready commit we
+# have not already processed. Designed to keep the parity dashboard fresh
+# with minimal manual work.
+
+on:
+  schedule:
+    # Every 30 minutes. Upstream CI on pytorch/pytorch main typically takes
+    # several hours, so this cadence is plenty to catch new "all-green" SHAs.
+    - cron: '*/30 * * * *'
+  workflow_dispatch:
+    inputs:
+      max_commits:
+        description: 'How many of the most recent upstream commits to scan.'
+        required: false
+        default: '15'
+        type: string
+      lookback_hours:
+        description: 'Only consider commits at least this many hours old (gives CI time to start).'
+        required: false
+        default: '1'
+        type: string
+      max_age_hours:
+        description: 'Skip commits older than this many hours (avoid back-filling ancient SHAs).'
+        required: false
+        default: '72'
+        type: string
+      arch:
+        description: 'Architectures to pass through to parity.yml.'
+        required: false
+        default: 'mi355, mi300, mi200'
+        type: string
+      dry_run:
+        description: 'Scan and log, but do not dispatch parity.yml.'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+  actions: write
+
+concurrency:
+  group: parity-auto-trigger
+  cancel-in-progress: false
+
+jobs:
+  scan-and-dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Find a ready upstream commit and dispatch parity.yml
+        env:
+          GH_TOKEN: ${{ github.token }}
+          UPSTREAM: pytorch/pytorch
+          BRANCH: main
+          MAX_COMMITS: ${{ inputs.max_commits || '15' }}
+          LOOKBACK_HOURS: ${{ inputs.lookback_hours || '1' }}
+          MAX_AGE_HOURS: ${{ inputs.max_age_hours || '72' }}
+          ARCH: ${{ inputs.arch || 'mi355, mi300, mi200' }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+          TARGET_REF: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          NOW_EPOCH=$(date -u +%s)
+          MIN_AGE_EPOCH=$((NOW_EPOCH - LOOKBACK_HOURS * 3600))
+          MAX_AGE_EPOCH=$((NOW_EPOCH - MAX_AGE_HOURS  * 3600))
+
+          echo "Upstream:        $UPSTREAM@$BRANCH"
+          echo "Target ref:      $TARGET_REF"
+          echo "Max commits:     $MAX_COMMITS"
+          echo "Min commit age:  ${LOOKBACK_HOURS}h"
+          echo "Max commit age:  ${MAX_AGE_HOURS}h"
+          echo "Arch:            $ARCH"
+          echo "Dry run:         $DRY_RUN"
+          echo
+
+          # --- 1. Recent upstream commits ---------------------------------------
+          COMMITS=$(gh api "repos/$UPSTREAM/commits?sha=$BRANCH&per_page=$MAX_COMMITS" \
+            --jq '.[] | "\(.sha) \(.commit.committer.date)"')
+
+          if [ -z "$COMMITS" ]; then
+            echo "::warning::No commits returned from $UPSTREAM@$BRANCH"
+            exit 0
+          fi
+
+          # --- 2. Already-dispatched SHAs (scan last 100 parity runs in our repo)
+          EXISTING=$(gh run list \
+            --repo "$GITHUB_REPOSITORY" \
+            --workflow parity.yml \
+            --limit 100 \
+            --json displayTitle,status,conclusion 2>/dev/null || echo '[]')
+
+          is_already_processed() {
+            local sha="$1"
+            echo "$EXISTING" | jq -e --arg sha "$sha" \
+              'map(select(.displayTitle | contains($sha))) | length > 0' \
+              > /dev/null
+          }
+
+          # --- 3. Walk commits newest->oldest, dispatch first ready unprocessed -
+          DISPATCHED=""
+          while IFS=' ' read -r SHA DATE; do
+            [ -z "$SHA" ] && continue
+            SHORT=$(echo "$SHA" | cut -c1-8)
+            COMMIT_EPOCH=$(date -u -d "$DATE" +%s)
+
+            if [ "$COMMIT_EPOCH" -lt "$MAX_AGE_EPOCH" ]; then
+              echo "[$SHORT] $DATE  too old (>${MAX_AGE_HOURS}h) — stopping scan"
+              break
+            fi
+            if [ "$COMMIT_EPOCH" -gt "$MIN_AGE_EPOCH" ]; then
+              echo "[$SHORT] $DATE  too new (<${LOOKBACK_HOURS}h) — skip"
+              continue
+            fi
+            if is_already_processed "$SHA"; then
+              echo "[$SHORT] already has a parity run — skip"
+              continue
+            fi
+
+            # All check runs on the upstream commit must be completed.
+            STATUSES=$(gh api --paginate \
+              "repos/$UPSTREAM/commits/$SHA/check-runs?per_page=100" \
+              --jq '.check_runs[].status' 2>/dev/null || true)
+            TOTAL=$(printf '%s\n' "$STATUSES" | grep -c . || true)
+            NOT_DONE=$(printf '%s\n' "$STATUSES" | grep -vc '^completed$' || true)
+
+            if [ "$TOTAL" -lt 1 ]; then
+              echo "[$SHORT] no check-runs yet — skip"
+              continue
+            fi
+            if [ "$NOT_DONE" -gt 0 ]; then
+              echo "[$SHORT] $NOT_DONE/$TOTAL check-runs still running — skip"
+              continue
+            fi
+
+            echo "[$SHORT] READY: $TOTAL check-runs completed (committed $DATE)"
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "[$SHORT] DRY_RUN=true — not dispatching"
+              DISPATCHED="$SHA"
+              break
+            fi
+
+            # csv_name embeds the full SHA so it appears in displayTitle and
+            # future runs of this workflow can detect it via is_already_processed.
+            DATE_TAG=$(date -u +%Y%m%d)
+            CSV_NAME="autoparity-${DATE_TAG}-${SHA}"
+            echo "[$SHORT] Dispatching parity.yml (csv_name=$CSV_NAME, arch=\"$ARCH\")"
+            gh workflow run parity.yml \
+              --repo "$GITHUB_REPOSITORY" \
+              --ref  "$TARGET_REF" \
+              -f sha="$SHA" \
+              -f arch="$ARCH" \
+              -f csv_name="$CSV_NAME"
+
+            DISPATCHED="$SHA"
+            break
+          done <<< "$COMMITS"
+
+          # --- 4. Summary -------------------------------------------------------
+          {
+            echo "### Parity auto-trigger"
+            echo ""
+            echo "- Upstream: \`$UPSTREAM@$BRANCH\`"
+            echo "- Scanned:  $MAX_COMMITS commits"
+            echo "- Window:   ${LOOKBACK_HOURS}h..${MAX_AGE_HOURS}h old"
+            if [ -n "$DISPATCHED" ]; then
+              SHORT=$(echo "$DISPATCHED" | cut -c1-8)
+              if [ "$DRY_RUN" = "true" ]; then
+                echo "- Result:   would dispatch parity for \`$SHORT\` (dry-run)"
+              else
+                echo "- Result:   dispatched parity.yml for \`$SHORT\` (\`$DISPATCHED\`)"
+              fi
+            else
+              echo "- Result:   no ready unprocessed commit found"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/parity-auto.yml
+++ b/.github/workflows/parity-auto.yml
@@ -72,7 +72,11 @@ jobs:
           TARGET_REF_IN: ${{ inputs.target_ref || '' }}
           DRY_RUN: ${{ inputs.dry_run || 'false' }}
         run: |
-          set -euo pipefail
+          # Explicit error handling throughout; `set -e` is too aggressive for
+          # the many pipelines here (grep -q returning 1, date -d edge cases,
+          # paginated API calls, etc.) and has caused the loop to silently
+          # abort after the first "no ready archs" commit.
+          set -uo pipefail
 
           NOW_EPOCH=$(date -u +%s)
           MAX_AGE_EPOCH=$((NOW_EPOCH - MAX_AGE_HOURS * 3600))
@@ -125,9 +129,9 @@ jobs:
           while IFS=' ' read -r SHA DATE; do
             [ -z "$SHA" ] && continue
             SHORT=$(echo "$SHA" | cut -c1-8)
-            COMMIT_EPOCH=$(date -u -d "$DATE" +%s)
+            COMMIT_EPOCH=$(date -u -d "$DATE" +%s 2>/dev/null || echo 0)
 
-            if [ "$COMMIT_EPOCH" -lt "$MAX_AGE_EPOCH" ]; then
+            if [ "$COMMIT_EPOCH" -ne 0 ] && [ "$COMMIT_EPOCH" -lt "$MAX_AGE_EPOCH" ]; then
               echo "[$SHORT] $DATE  too old (>${MAX_AGE_HOURS}h) — stopping scan"
               break
             fi

--- a/.github/workflows/parity-auto.yml
+++ b/.github/workflows/parity-auto.yml
@@ -1,40 +1,49 @@
 name: Parity Auto Trigger
 run-name: "Parity auto-trigger · pytorch/pytorch main"
 
-# Polls pytorch/pytorch main for commits whose upstream CI has fully finished,
-# then dispatches .github/workflows/parity.yml on the first ready commit we
-# have not already processed. Designed to keep the parity dashboard fresh
-# with minimal manual work.
+# Polls pytorch/pytorch main for commits where any of the upstream CI
+# workflows we care about have completed, and dispatches parity.yml
+# with only the subset of archs whose required workflow is ready.
+#
+# This is intentionally per-arch, not per-commit-as-a-whole: most
+# commits only have `trunk` completed (so only mi355 is runnable),
+# while periodic workflows like `rocm-mi300` or `trunk-rocm-sandbox`
+# land on a SHA much less often. We dispatch once per (SHA, arch-set)
+# tuple so mi355 gets a parity run per commit and mi300/mi200 get
+# one whenever their periodic workflow happens to finish on a SHA.
 
 on:
   schedule:
-    # Every 30 minutes. Upstream CI on pytorch/pytorch main typically takes
-    # several hours, so this cadence is plenty to catch new "all-green" SHAs.
     - cron: '*/30 * * * *'
   workflow_dispatch:
     inputs:
       max_commits:
         description: 'How many of the most recent upstream commits to scan.'
         required: false
-        default: '15'
-        type: string
-      lookback_hours:
-        description: 'Only consider commits at least this many hours old (gives CI time to start).'
-        required: false
-        default: '1'
+        default: '20'
         type: string
       max_age_hours:
-        description: 'Skip commits older than this many hours (avoid back-filling ancient SHAs).'
+        description: 'Skip commits older than this (avoid back-filling ancient SHAs).'
         required: false
         default: '72'
         type: string
-      arch:
-        description: 'Architectures to pass through to parity.yml.'
+      archs:
+        description: 'Architectures to consider (comma/space separated).'
         required: false
         default: 'mi355, mi300, mi200'
         type: string
+      arch_workflow_map:
+        description: 'JSON: arch → required upstream workflow name (default tier).'
+        required: false
+        default: '{"mi355":"trunk","mi300":"rocm-mi300","mi200":"trunk-rocm-sandbox","navi31":"rocm-navi31","nightly":"rocm-nightly"}'
+        type: string
+      target_ref:
+        description: 'Ref of this repo to dispatch parity.yml against. Leave blank to use this workflow run''s ref.'
+        required: false
+        default: ''
+        type: string
       dry_run:
-        description: 'Scan and log, but do not dispatch parity.yml.'
+        description: 'Scan and log, but do not actually dispatch parity.yml.'
         required: false
         default: false
         type: boolean
@@ -51,34 +60,35 @@ jobs:
   scan-and-dispatch:
     runs-on: ubuntu-latest
     steps:
-      - name: Find a ready upstream commit and dispatch parity.yml
+      - name: Find ready arches per upstream commit and dispatch parity.yml
         env:
           GH_TOKEN: ${{ github.token }}
           UPSTREAM: pytorch/pytorch
           BRANCH: main
-          MAX_COMMITS: ${{ inputs.max_commits || '15' }}
-          LOOKBACK_HOURS: ${{ inputs.lookback_hours || '1' }}
+          MAX_COMMITS: ${{ inputs.max_commits || '20' }}
           MAX_AGE_HOURS: ${{ inputs.max_age_hours || '72' }}
-          ARCH: ${{ inputs.arch || 'mi355, mi300, mi200' }}
+          ARCHS_IN: ${{ inputs.archs || 'mi355, mi300, mi200' }}
+          ARCH_WORKFLOW_MAP: ${{ inputs.arch_workflow_map || '{"mi355":"trunk","mi300":"rocm-mi300","mi200":"trunk-rocm-sandbox","navi31":"rocm-navi31","nightly":"rocm-nightly"}' }}
+          TARGET_REF_IN: ${{ inputs.target_ref || '' }}
           DRY_RUN: ${{ inputs.dry_run || 'false' }}
-          TARGET_REF: ${{ github.ref_name }}
         run: |
           set -euo pipefail
 
           NOW_EPOCH=$(date -u +%s)
-          MIN_AGE_EPOCH=$((NOW_EPOCH - LOOKBACK_HOURS * 3600))
-          MAX_AGE_EPOCH=$((NOW_EPOCH - MAX_AGE_HOURS  * 3600))
+          MAX_AGE_EPOCH=$((NOW_EPOCH - MAX_AGE_HOURS * 3600))
+          TARGET_REF="${TARGET_REF_IN:-$GITHUB_REF_NAME}"
+          ARCHS=$(echo "$ARCHS_IN" | tr ',' ' ' | xargs)
 
-          echo "Upstream:        $UPSTREAM@$BRANCH"
-          echo "Target ref:      $TARGET_REF"
-          echo "Max commits:     $MAX_COMMITS"
-          echo "Min commit age:  ${LOOKBACK_HOURS}h"
-          echo "Max commit age:  ${MAX_AGE_HOURS}h"
-          echo "Arch:            $ARCH"
-          echo "Dry run:         $DRY_RUN"
+          echo "Upstream:       $UPSTREAM@$BRANCH"
+          echo "Target ref:     $TARGET_REF"
+          echo "Scope archs:    $ARCHS"
+          echo "Max commits:    $MAX_COMMITS"
+          echo "Max age:        ${MAX_AGE_HOURS}h"
+          echo "Dry run:        $DRY_RUN"
+          echo "Arch→workflow:  $ARCH_WORKFLOW_MAP"
           echo
 
-          # --- 1. Recent upstream commits ---------------------------------------
+          # --- 1. Recent upstream commits --------------------------------------
           COMMITS=$(gh api "repos/$UPSTREAM/commits?sha=$BRANCH&per_page=$MAX_COMMITS" \
             --jq '.[] | "\(.sha) \(.commit.committer.date)"')
 
@@ -87,22 +97,31 @@ jobs:
             exit 0
           fi
 
-          # --- 2. Already-dispatched SHAs (scan last 100 parity runs in our repo)
+          # --- 2. Already-dispatched (SHA,arch) pairs in our repo --------------
+          # Pull last 200 parity runs. Run titles look like:
+          #   "<csv_name or SHA> · mi355, mi300, mi200"
+          # So for each run that mentions a SHA, the arch list is everything
+          # after ' · '.
           EXISTING=$(gh run list \
             --repo "$GITHUB_REPOSITORY" \
             --workflow parity.yml \
-            --limit 100 \
-            --json displayTitle,status,conclusion 2>/dev/null || echo '[]')
+            --limit 200 \
+            --json displayTitle 2>/dev/null || echo '[]')
 
-          is_already_processed() {
+          archs_already_for_sha() {
             local sha="$1"
-            echo "$EXISTING" | jq -e --arg sha "$sha" \
-              'map(select(.displayTitle | contains($sha))) | length > 0' \
-              > /dev/null
+            echo "$EXISTING" | jq -r --arg sha "$sha" \
+              'map(select(.displayTitle | contains($sha))) | .[].displayTitle' \
+              | sed 's/.* · //' \
+              | tr ',' '\n' \
+              | tr -d ' ' \
+              | grep -v '^$' \
+              | sort -u
           }
 
-          # --- 3. Walk commits newest->oldest, dispatch first ready unprocessed -
-          DISPATCHED=""
+          # --- 3. Walk commits, dispatch first SHA with unprocessed ready archs
+          DISPATCHED_SHA=""
+          DISPATCHED_ARCHS=""
           while IFS=' ' read -r SHA DATE; do
             [ -z "$SHA" ] && continue
             SHORT=$(echo "$SHA" | cut -c1-8)
@@ -112,51 +131,72 @@ jobs:
               echo "[$SHORT] $DATE  too old (>${MAX_AGE_HOURS}h) — stopping scan"
               break
             fi
-            if [ "$COMMIT_EPOCH" -gt "$MIN_AGE_EPOCH" ]; then
-              echo "[$SHORT] $DATE  too new (<${LOOKBACK_HOURS}h) — skip"
-              continue
-            fi
-            if is_already_processed "$SHA"; then
-              echo "[$SHORT] already has a parity run — skip"
+
+            # Which upstream workflows have a completed run on this SHA?
+            COMPLETED_WFS=$(gh api --paginate \
+              "repos/$UPSTREAM/actions/runs?head_sha=$SHA&per_page=100" \
+              --jq '.workflow_runs[] | select(.status == "completed") | .name' \
+              2>/dev/null | sort -u || true)
+
+            if [ -z "$COMPLETED_WFS" ]; then
+              echo "[$SHORT] $DATE  no completed upstream workflow runs yet — skip"
               continue
             fi
 
-            # All check runs on the upstream commit must be completed.
-            STATUSES=$(gh api --paginate \
-              "repos/$UPSTREAM/commits/$SHA/check-runs?per_page=100" \
-              --jq '.check_runs[].status' 2>/dev/null || true)
-            TOTAL=$(printf '%s\n' "$STATUSES" | grep -c . || true)
-            NOT_DONE=$(printf '%s\n' "$STATUSES" | grep -vc '^completed$' || true)
+            # Ready archs = archs whose required upstream workflow is completed.
+            READY=""
+            for ARCH in $ARCHS; do
+              REQ_WF=$(echo "$ARCH_WORKFLOW_MAP" | jq -r --arg a "$ARCH" '.[$a] // ""')
+              if [ -z "$REQ_WF" ]; then
+                echo "[$SHORT] arch '$ARCH' has no arch→workflow entry — skip this arch"
+                continue
+              fi
+              if printf '%s\n' "$COMPLETED_WFS" | grep -qx "$REQ_WF"; then
+                READY="$READY $ARCH"
+              fi
+            done
+            READY=$(echo "$READY" | xargs)
 
-            if [ "$TOTAL" -lt 1 ]; then
-              echo "[$SHORT] no check-runs yet — skip"
+            if [ -z "$READY" ]; then
+              COMPLETED_SUMMARY=$(printf '%s\n' "$COMPLETED_WFS" | paste -sd, -)
+              echo "[$SHORT] no ready archs (completed upstream workflows: $COMPLETED_SUMMARY)"
               continue
             fi
-            if [ "$NOT_DONE" -gt 0 ]; then
-              echo "[$SHORT] $NOT_DONE/$TOTAL check-runs still running — skip"
+
+            # Subtract archs already dispatched for this SHA.
+            ALREADY=$(archs_already_for_sha "$SHA" | tr '\n' ' ')
+            TODO=""
+            for A in $READY; do
+              if ! printf '%s\n' $ALREADY | grep -qx "$A"; then
+                TODO="$TODO $A"
+              fi
+            done
+            TODO=$(echo "$TODO" | xargs)
+
+            if [ -z "$TODO" ]; then
+              echo "[$SHORT] all ready archs already dispatched (ready=$(echo "$READY" | tr ' ' ','))"
               continue
             fi
 
-            echo "[$SHORT] READY: $TOTAL check-runs completed (committed $DATE)"
+            ARCH_DISPATCH=$(echo "$TODO" | sed 's/ /, /g')
+            CSV_NAME="autoparity-$(date -u +%Y%m%d)-$SHA"
+            echo "[$SHORT] READY archs: '$(echo "$READY" | tr ' ' ',')' (committed $DATE)"
+            echo "[$SHORT] already dispatched for this SHA: '$(echo "$ALREADY" | xargs | tr ' ' ',')'"
+            echo "[$SHORT] dispatching for: '$(echo "$TODO" | tr ' ' ',')'"
+
             if [ "$DRY_RUN" = "true" ]; then
               echo "[$SHORT] DRY_RUN=true — not dispatching"
-              DISPATCHED="$SHA"
-              break
+            else
+              gh workflow run parity.yml \
+                --repo "$GITHUB_REPOSITORY" \
+                --ref  "$TARGET_REF" \
+                -f sha="$SHA" \
+                -f arch="$ARCH_DISPATCH" \
+                -f csv_name="$CSV_NAME"
             fi
 
-            # csv_name embeds the full SHA so it appears in displayTitle and
-            # future runs of this workflow can detect it via is_already_processed.
-            DATE_TAG=$(date -u +%Y%m%d)
-            CSV_NAME="autoparity-${DATE_TAG}-${SHA}"
-            echo "[$SHORT] Dispatching parity.yml (csv_name=$CSV_NAME, arch=\"$ARCH\")"
-            gh workflow run parity.yml \
-              --repo "$GITHUB_REPOSITORY" \
-              --ref  "$TARGET_REF" \
-              -f sha="$SHA" \
-              -f arch="$ARCH" \
-              -f csv_name="$CSV_NAME"
-
-            DISPATCHED="$SHA"
+            DISPATCHED_SHA="$SHA"
+            DISPATCHED_ARCHS="$ARCH_DISPATCH"
             break
           done <<< "$COMMITS"
 
@@ -164,17 +204,18 @@ jobs:
           {
             echo "### Parity auto-trigger"
             echo ""
-            echo "- Upstream: \`$UPSTREAM@$BRANCH\`"
-            echo "- Scanned:  $MAX_COMMITS commits"
-            echo "- Window:   ${LOOKBACK_HOURS}h..${MAX_AGE_HOURS}h old"
-            if [ -n "$DISPATCHED" ]; then
-              SHORT=$(echo "$DISPATCHED" | cut -c1-8)
+            echo "- Upstream:     \`$UPSTREAM@$BRANCH\`"
+            echo "- Scope archs:  \`$ARCHS\`"
+            echo "- Max age:      ${MAX_AGE_HOURS}h"
+            echo "- Target ref:   \`$TARGET_REF\`"
+            if [ -n "$DISPATCHED_SHA" ]; then
+              SHORT=$(echo "$DISPATCHED_SHA" | cut -c1-8)
               if [ "$DRY_RUN" = "true" ]; then
-                echo "- Result:   would dispatch parity for \`$SHORT\` (dry-run)"
+                echo "- Result:       would dispatch parity for \`$SHORT\` arches \`$DISPATCHED_ARCHS\` (dry-run)"
               else
-                echo "- Result:   dispatched parity.yml for \`$SHORT\` (\`$DISPATCHED\`)"
+                echo "- Result:       dispatched parity.yml for \`$SHORT\` arches \`$DISPATCHED_ARCHS\`"
               fi
             else
-              echo "- Result:   no ready unprocessed commit found"
+              echo "- Result:       no ready unprocessed (SHA, arch) pairs found"
             fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/parity-auto.yml
+++ b/.github/workflows/parity-auto.yml
@@ -1,16 +1,24 @@
 name: Parity Auto Trigger
 run-name: "Parity auto-trigger · pytorch/pytorch main"
 
-# Polls pytorch/pytorch main for commits where any of the upstream CI
-# workflows we care about have completed, and dispatches parity.yml
-# with only the subset of archs whose required workflow is ready.
+# Polls pytorch/pytorch main for commits where the ROCm test check-runs
+# we care about have all completed, and dispatches parity.yml with the
+# subset of archs whose test shards are done (and therefore have S3
+# artifacts we can download).
 #
-# This is intentionally per-arch, not per-commit-as-a-whole: most
-# commits only have `trunk` completed (so only mi355 is runnable),
-# while periodic workflows like `rocm-mi300` or `trunk-rocm-sandbox`
-# land on a SHA much less often. We dispatch once per (SHA, arch-set)
-# tuple so mi355 gets a parity run per commit and mi300/mi200 get
-# one whenever their periodic workflow happens to finish on a SHA.
+# Readiness is determined at the *check-run* level, not the workflow
+# level: ROCm test shards post check-runs independently, and a single
+# failing shard flips the parent workflow_run to conclusion=failure
+# while other shards are still running. Relying on workflow_runs would
+# trigger parity too early and yield empty reports. Instead, for each
+# arch we require every check-run whose name matches that arch's regex
+# (e.g. "rocm.*mi355.*/ test \(") to have status=completed — any
+# conclusion is fine, as long as the runner finished and uploaded.
+#
+# This is intentionally per-arch, not per-commit-as-a-whole: mi355 (run
+# as part of trunk) is ready on almost every commit, while periodic
+# workflows like rocm-mi300 land on a SHA much less often. We dispatch
+# once per (SHA, arch-set) tuple.
 
 on:
   schedule:
@@ -32,10 +40,10 @@ on:
         required: false
         default: 'mi355, mi300, mi200'
         type: string
-      arch_workflow_map:
-        description: 'JSON: arch → required upstream workflow name (default tier).'
+      arch_jobname_regex_map:
+        description: 'JSON: arch → PCRE regex that matches the check-run names of that arch''s ROCm test shards on pytorch/pytorch. An arch is considered "ready" only when every check-run whose name matches has status=completed (so we wait for all test shards, not just workflow completion).'
         required: false
-        default: '{"mi355":"trunk","mi300":"rocm-mi300","mi200":"trunk-rocm-sandbox","navi31":"rocm-navi31","nightly":"rocm-nightly"}'
+        default: '{"mi355":"rocm.*mi355.*/ test \\(","mi300":"rocm.*mi300.*/ test \\(","mi200":"rocm.*(mi200|mi210).*/ test \\(","navi31":"rocm.*navi31.*/ test \\(","nightly":"rocm-nightly.*/ test \\("}'
         type: string
       target_ref:
         description: 'Ref of this repo to dispatch parity.yml against. Leave blank to use this workflow run''s ref.'
@@ -68,7 +76,7 @@ jobs:
           MAX_COMMITS: ${{ inputs.max_commits || '20' }}
           MAX_AGE_HOURS: ${{ inputs.max_age_hours || '72' }}
           ARCHS_IN: ${{ inputs.archs || 'mi355, mi300, mi200' }}
-          ARCH_WORKFLOW_MAP: ${{ inputs.arch_workflow_map || '{"mi355":"trunk","mi300":"rocm-mi300","mi200":"trunk-rocm-sandbox","navi31":"rocm-navi31","nightly":"rocm-nightly"}' }}
+          ARCH_JOBNAME_REGEX_MAP: ${{ inputs.arch_jobname_regex_map || '{"mi355":"rocm.*mi355.*/ test \\(","mi300":"rocm.*mi300.*/ test \\(","mi200":"rocm.*(mi200|mi210).*/ test \\(","navi31":"rocm.*navi31.*/ test \\(","nightly":"rocm-nightly.*/ test \\("}' }}
           TARGET_REF_IN: ${{ inputs.target_ref || '' }}
           DRY_RUN: ${{ inputs.dry_run || 'false' }}
         run: |
@@ -92,7 +100,7 @@ jobs:
           echo "Max commits:    $MAX_COMMITS"
           echo "Max age:        ${MAX_AGE_HOURS}h"
           echo "Dry run:        $DRY_RUN"
-          echo "Arch→workflow:  $ARCH_WORKFLOW_MAP"
+          echo "Arch→regex:     $ARCH_JOBNAME_REGEX_MAP"
           echo
 
           # --- 1. Recent upstream commits --------------------------------------
@@ -139,34 +147,55 @@ jobs:
               break
             fi
 
-            # Which upstream workflows have a completed run on this SHA?
-            COMPLETED_WFS=$(gh api --paginate \
-              "repos/$UPSTREAM/actions/runs?head_sha=$SHA&per_page=100" \
-              --jq '.workflow_runs[] | select(.status == "completed") | .name' \
-              2>/dev/null | sort -u || true)
+            # Pull all ROCm test check-runs for this SHA. We use check-runs
+            # (not workflow_runs) because ROCm test shards post check-runs
+            # independently and the overall workflow_run conclusion is
+            # "failure" the moment any shard fails, even if other shards
+            # are still executing. What we actually want is: "have all the
+            # test shards for this arch finished running on upstream?"
+            # Then we can download S3 artifacts without racing against CI.
+            CHECK_RUNS=$(gh api --paginate \
+              "repos/$UPSTREAM/commits/$SHA/check-runs?per_page=100" \
+              --jq '.check_runs[] | select(.name | test("rocm";"i")) | {name,status,conclusion}' \
+              2>/dev/null | jq -s '.' || echo '[]')
 
-            if [ -z "$COMPLETED_WFS" ]; then
-              echo "[$SHORT] $DATE  no completed upstream workflow runs yet — skip"
+            if [ "$(echo "$CHECK_RUNS" | jq 'length')" -eq 0 ]; then
+              echo "[$SHORT] $DATE  no ROCm check-runs yet on upstream — skip"
               continue
             fi
 
-            # Ready archs = archs whose required upstream workflow is completed.
+            # Ready archs = archs for which ALL test check-runs matching
+            # the arch's regex are status=completed, AND at least one such
+            # check-run exists. "status=completed" covers any conclusion
+            # (success/failure/skipped/cancelled) — if the runner ran and
+            # finished, we expect artifacts in S3 whether it passed or not.
             READY=""
+            NOT_READY_NOTES=""
             for ARCH in $ARCHS; do
-              REQ_WF=$(echo "$ARCH_WORKFLOW_MAP" | jq -r --arg a "$ARCH" '.[$a] // ""')
-              if [ -z "$REQ_WF" ]; then
-                echo "[$SHORT] arch '$ARCH' has no arch→workflow entry — skip this arch"
+              REGEX=$(echo "$ARCH_JOBNAME_REGEX_MAP" | jq -r --arg a "$ARCH" '.[$a] // ""')
+              if [ -z "$REGEX" ]; then
+                NOT_READY_NOTES="$NOT_READY_NOTES $ARCH:no-regex"
                 continue
               fi
-              if printf '%s\n' "$COMPLETED_WFS" | grep -qx "$REQ_WF"; then
+              COUNTS=$(echo "$CHECK_RUNS" | jq --arg rx "$REGEX" '
+                map(select(.name | test($rx)))
+                | {total: length,
+                   pending: (map(select(.status != "completed")) | length)}')
+              TOTAL=$(echo "$COUNTS" | jq -r '.total')
+              PENDING=$(echo "$COUNTS" | jq -r '.pending')
+              if [ "$TOTAL" -eq 0 ]; then
+                NOT_READY_NOTES="$NOT_READY_NOTES $ARCH:no-shards"
+              elif [ "$PENDING" -ne 0 ]; then
+                NOT_READY_NOTES="$NOT_READY_NOTES $ARCH:${PENDING}/${TOTAL}-pending"
+              else
                 READY="$READY $ARCH"
               fi
             done
             READY=$(echo "$READY" | xargs)
+            NOT_READY_NOTES=$(echo "$NOT_READY_NOTES" | xargs)
 
             if [ -z "$READY" ]; then
-              COMPLETED_SUMMARY=$(printf '%s\n' "$COMPLETED_WFS" | paste -sd, -)
-              echo "[$SHORT] no ready archs (completed upstream workflows: $COMPLETED_SUMMARY)"
+              echo "[$SHORT] $DATE  no ready archs (${NOT_READY_NOTES:-none})"
               continue
             fi
 
@@ -187,7 +216,7 @@ jobs:
 
             ARCH_DISPATCH=$(echo "$TODO" | sed 's/ /, /g')
             CSV_NAME="autoparity-$(date -u +%Y%m%d)-$SHA"
-            echo "[$SHORT] READY archs: '$(echo "$READY" | tr ' ' ',')' (committed $DATE)"
+            echo "[$SHORT] READY archs: '$(echo "$READY" | tr ' ' ',')' (committed $DATE; still-pending: ${NOT_READY_NOTES:-none})"
             echo "[$SHORT] already dispatched for this SHA: '$(echo "$ALREADY" | xargs | tr ' ' ',')'"
             echo "[$SHORT] dispatching for: '$(echo "$TODO" | tr ' ' ',')'"
 

--- a/.github/workflows/parity-auto.yml
+++ b/.github/workflows/parity-auto.yml
@@ -72,10 +72,13 @@ jobs:
           TARGET_REF_IN: ${{ inputs.target_ref || '' }}
           DRY_RUN: ${{ inputs.dry_run || 'false' }}
         run: |
-          # Explicit error handling throughout; `set -e` is too aggressive for
-          # the many pipelines here (grep -q returning 1, date -d edge cases,
-          # paginated API calls, etc.) and has caused the loop to silently
-          # abort after the first "no ready archs" commit.
+          # GitHub Actions launches this with `bash -e {0}`, so -e is already on
+          # from the shebang. It's too aggressive for the many pipelines here
+          # (grep -q returning 1, date -d edge cases, paginated API calls,
+          # etc.) and has caused the loop to silently abort after the first
+          # "no ready archs" commit. Explicitly turn -e OFF and keep -u +
+          # pipefail so undefined-variable bugs still surface.
+          set +e
           set -uo pipefail
 
           NOW_EPOCH=$(date -u +%s)

--- a/.github/workflows/parity-auto.yml
+++ b/.github/workflows/parity-auto.yml
@@ -20,7 +20,7 @@ run-name: "Parity auto-trigger · pytorch/pytorch main"
 #      actually ran on this SHA; mi300/mi200 etc. only show up when
 #      their periodic workflow happens to land on that SHA.
 #
-# We dispatch once per SHA with the ready subset of arches, so mi355
+# We dispatch at most once per SHA with the ready subset of arches, so mi355
 # (run as part of trunk) gets a parity report per commit, and mi300/
 # mi200 join the same dispatch whenever their periodic workflow
 # happens to finish on that SHA.
@@ -33,12 +33,17 @@ on:
       max_commits:
         description: 'How many of the most recent upstream commits to scan.'
         required: false
-        default: '20'
+        default: '15'
+        type: string
+      max_dispatches:
+        description: 'Maximum number of ready upstream commits to dispatch in one scan.'
+        required: false
+        default: '10'
         type: string
       max_age_hours:
         description: 'Skip commits older than this (avoid back-filling ancient SHAs).'
         required: false
-        default: '72'
+        default: '10'
         type: string
       archs:
         description: 'Architectures to consider (comma/space separated).'
@@ -78,8 +83,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           UPSTREAM: pytorch/pytorch
           BRANCH: main
-          MAX_COMMITS: ${{ inputs.max_commits || '20' }}
-          MAX_AGE_HOURS: ${{ inputs.max_age_hours || '72' }}
+          MAX_COMMITS: ${{ inputs.max_commits || '15' }}
+          MAX_DISPATCHES: ${{ inputs.max_dispatches || '10' }}
+          MAX_AGE_HOURS: ${{ inputs.max_age_hours || '10' }}
           ARCHS_IN: ${{ inputs.archs || 'mi355, mi300, mi200' }}
           ARCH_JOBNAME_REGEX_MAP: ${{ inputs.arch_jobname_regex_map || '{"mi355":"rocm.*mi355.*/ test \\(","mi300":"rocm.*mi300.*/ test \\(","mi200":"rocm.*(mi200|mi210).*/ test \\(","navi31":"rocm.*navi31.*/ test \\(","nightly":"rocm-nightly.*/ test \\("}' }}
           TARGET_REF_IN: ${{ inputs.target_ref || '' }}
@@ -103,6 +109,7 @@ jobs:
           echo "Target ref:     $TARGET_REF"
           echo "Scope archs:    $ARCHS"
           echo "Max commits:    $MAX_COMMITS"
+          echo "Max dispatches: $MAX_DISPATCHES"
           echo "Max age:        ${MAX_AGE_HOURS}h"
           echo "Dry run:        $DRY_RUN"
           echo "Arch→regex:     $ARCH_JOBNAME_REGEX_MAP"
@@ -117,31 +124,27 @@ jobs:
             exit 0
           fi
 
-          # --- 2. Already-dispatched (SHA,arch) pairs in our repo --------------
+          # --- 2. Already-dispatched SHAs in our repo --------------------------
           # Pull last 200 parity runs. Run titles look like:
           #   "<csv_name or SHA> · mi355, mi300, mi200"
-          # So for each run that mentions a SHA, the arch list is everything
-          # after ' · '.
+          # Once any parity run exists for a SHA, we do not dispatch another
+          # report for that SHA. This keeps the dashboard to one report per
+          # upstream commit.
           EXISTING=$(gh run list \
             --repo "$GITHUB_REPOSITORY" \
             --workflow parity.yml \
             --limit 200 \
             --json displayTitle 2>/dev/null || echo '[]')
 
-          archs_already_for_sha() {
+          sha_already_dispatched() {
             local sha="$1"
-            echo "$EXISTING" | jq -r --arg sha "$sha" \
-              'map(select(.displayTitle | contains($sha))) | .[].displayTitle' \
-              | sed 's/.* · //' \
-              | tr ',' '\n' \
-              | tr -d ' ' \
-              | grep -v '^$' \
-              | sort -u
+            echo "$EXISTING" | jq -e --arg sha "$sha" \
+              'any(.[]; .displayTitle | contains($sha))' >/dev/null
           }
 
-          # --- 3. Walk commits, dispatch first SHA with unprocessed ready archs
-          DISPATCHED_SHA=""
-          DISPATCHED_ARCHS=""
+          # --- 3. Walk commits, dispatch each ready unprocessed SHA ------------
+          DISPATCHED_COUNT=0
+          DISPATCHED_SUMMARY=""
           while IFS=' ' read -r SHA DATE; do
             [ -z "$SHA" ] && continue
             SHORT=$(echo "$SHA" | cut -c1-8)
@@ -150,6 +153,11 @@ jobs:
             if [ "$COMMIT_EPOCH" -ne 0 ] && [ "$COMMIT_EPOCH" -lt "$MAX_AGE_EPOCH" ]; then
               echo "[$SHORT] $DATE  too old (>${MAX_AGE_HOURS}h) — stopping scan"
               break
+            fi
+
+            if sha_already_dispatched "$SHA"; then
+              echo "[$SHORT] parity report already exists for this SHA — skip"
+              continue
             fi
 
             # Pull relevant upstream check-runs for this SHA. We use
@@ -236,26 +244,10 @@ jobs:
               continue
             fi
 
-            # Subtract archs already dispatched for this SHA.
-            ALREADY=$(archs_already_for_sha "$SHA" | tr '\n' ' ')
-            TODO=""
-            for A in $READY; do
-              if ! printf '%s\n' $ALREADY | grep -qx "$A"; then
-                TODO="$TODO $A"
-              fi
-            done
-            TODO=$(echo "$TODO" | xargs)
-
-            if [ -z "$TODO" ]; then
-              echo "[$SHORT] all ready archs already dispatched (ready=$(echo "$READY" | tr ' ' ','))"
-              continue
-            fi
-
-            ARCH_DISPATCH=$(echo "$TODO" | sed 's/ /, /g')
+            ARCH_DISPATCH=$(echo "$READY" | sed 's/ /, /g')
             CSV_NAME="autoparity-$(date -u +%Y%m%d)-$SHA"
             echo "[$SHORT] READY archs: '$(echo "$READY" | tr ' ' ',')' (committed $DATE; still-pending: ${NOT_READY_NOTES:-none})"
-            echo "[$SHORT] already dispatched for this SHA: '$(echo "$ALREADY" | xargs | tr ' ' ',')'"
-            echo "[$SHORT] dispatching for: '$(echo "$TODO" | tr ' ' ',')'"
+            echo "[$SHORT] dispatching for: '$(echo "$READY" | tr ' ' ',')'"
 
             if [ "$DRY_RUN" = "true" ]; then
               echo "[$SHORT] DRY_RUN=true — not dispatching"
@@ -268,9 +260,12 @@ jobs:
                 -f csv_name="$CSV_NAME"
             fi
 
-            DISPATCHED_SHA="$SHA"
-            DISPATCHED_ARCHS="$ARCH_DISPATCH"
-            break
+            DISPATCHED_COUNT=$((DISPATCHED_COUNT + 1))
+            DISPATCHED_SUMMARY="${DISPATCHED_SUMMARY}${SHORT}:${ARCH_DISPATCH}"$'\n'
+            if [ "$DISPATCHED_COUNT" -ge "$MAX_DISPATCHES" ]; then
+              echo "Reached max dispatches for this scan ($MAX_DISPATCHES); stopping"
+              break
+            fi
           done <<< "$COMMITS"
 
           # --- 4. Summary -------------------------------------------------------
@@ -279,16 +274,22 @@ jobs:
             echo ""
             echo "- Upstream:     \`$UPSTREAM@$BRANCH\`"
             echo "- Scope archs:  \`$ARCHS\`"
+            echo "- Max commits:  $MAX_COMMITS"
+            echo "- Max dispatches: $MAX_DISPATCHES"
             echo "- Max age:      ${MAX_AGE_HOURS}h"
             echo "- Target ref:   \`$TARGET_REF\`"
-            if [ -n "$DISPATCHED_SHA" ]; then
-              SHORT=$(echo "$DISPATCHED_SHA" | cut -c1-8)
+            if [ "$DISPATCHED_COUNT" -gt 0 ]; then
               if [ "$DRY_RUN" = "true" ]; then
-                echo "- Result:       would dispatch parity for \`$SHORT\` arches \`$DISPATCHED_ARCHS\` (dry-run)"
+                echo "- Result:       would dispatch $DISPATCHED_COUNT parity run(s) (dry-run)"
               else
-                echo "- Result:       dispatched parity.yml for \`$SHORT\` arches \`$DISPATCHED_ARCHS\`"
+                echo "- Result:       dispatched $DISPATCHED_COUNT parity run(s)"
               fi
+              echo ""
+              echo "$DISPATCHED_SUMMARY" | while IFS= read -r LINE; do
+                [ -z "$LINE" ] && continue
+                echo "- $LINE"
+              done
             else
-              echo "- Result:       no ready unprocessed (SHA, arch) pairs found"
+              echo "- Result:       no ready unprocessed SHAs found"
             fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/parity-auto.yml
+++ b/.github/workflows/parity-auto.yml
@@ -14,8 +14,8 @@ run-name: "Parity auto-trigger · pytorch/pytorch main"
 # Two gates:
 #   1. Every ROCm arch test check-run and every CUDA test check-run
 #      consumed by download_testlogs on the SHA must be status=completed.
-#      We don't want to dispatch mi355 while mi300, CUDA trunk, or CUDA
-#      inductor shards are still running on the same commit.
+#      We don't want to dispatch mi355 while mi300, CUDA trunk OSDC, or
+#      CUDA inductor shards are still running on the same commit.
 #   2. For each arch in scope, we check whether its test shards
 #      actually ran on this SHA; mi300/mi200 etc. only show up when
 #      their periodic workflow happens to land on that SHA.
@@ -173,7 +173,7 @@ jobs:
                 <(echo "$ARCH_CHECK_RUNS"))
             done
 
-            CUDA_JOBNAME_REGEX='(linux-jammy-cuda13[.]0-py3[.]10-gcc11.*/ test [(](default|distributed),|unit-test / inductor-test / test [(]inductor,)'
+            CUDA_JOBNAME_REGEX='(linux-jammy-cuda13[.]0-py3[.]10-gcc11.*/ test-osdc [(](default|distributed),|unit-test / inductor-test / test [(]inductor,)'
             CUDA_CHECK_RUNS=$(echo "$ALL_CHECK_RUNS" | jq --arg rx "$CUDA_JOBNAME_REGEX" \
               '[.[] | select(.name | test($rx))]')
 

--- a/.github/workflows/parity-auto.yml
+++ b/.github/workflows/parity-auto.yml
@@ -12,10 +12,10 @@ run-name: "Parity auto-trigger · pytorch/pytorch main"
 # fire too early and produce empty reports.
 #
 # Two gates:
-#   1. Every ROCm check-run and every CUDA test check-run consumed by
-#      download_testlogs on the SHA must be status=completed. We don't
-#      want to dispatch mi355 while mi300, CUDA trunk, or CUDA inductor
-#      shards are still running on the same commit.
+#   1. Every ROCm arch test check-run and every CUDA test check-run
+#      consumed by download_testlogs on the SHA must be status=completed.
+#      We don't want to dispatch mi355 while mi300, CUDA trunk, or CUDA
+#      inductor shards are still running on the same commit.
 #   2. For each arch in scope, we check whether its test shards
 #      actually ran on this SHA; mi300/mi200 etc. only show up when
 #      their periodic workflow happens to land on that SHA.
@@ -162,13 +162,23 @@ jobs:
               --jq '.check_runs[] | {name,status,conclusion}' \
               2>/dev/null | jq -s '.' || echo '[]')
 
+            CHECK_RUNS='[]'
+            for ARCH in $ARCHS; do
+              REGEX=$(echo "$ARCH_JOBNAME_REGEX_MAP" | jq -r --arg a "$ARCH" '.[$a] // ""')
+              [ -z "$REGEX" ] && continue
+              ARCH_CHECK_RUNS=$(echo "$ALL_CHECK_RUNS" | jq --arg rx "$REGEX" \
+                '[.[] | select(.name | test($rx))]')
+              CHECK_RUNS=$(jq -s 'add | unique_by(.name)' \
+                <(echo "$CHECK_RUNS") \
+                <(echo "$ARCH_CHECK_RUNS"))
+            done
+
             CUDA_JOBNAME_REGEX='(linux-jammy-cuda13[.]0-py3[.]10-gcc11.*/ test [(](default|distributed),|unit-test / inductor-test / test [(]inductor,)'
-            CHECK_RUNS=$(echo "$ALL_CHECK_RUNS" | jq '[.[] | select(.name | test("rocm";"i"))]')
             CUDA_CHECK_RUNS=$(echo "$ALL_CHECK_RUNS" | jq --arg rx "$CUDA_JOBNAME_REGEX" \
               '[.[] | select(.name | test($rx))]')
 
             if [ "$(echo "$CHECK_RUNS" | jq 'length')" -eq 0 ]; then
-              echo "[$SHORT] $DATE  no ROCm check-runs yet on upstream — skip"
+              echo "[$SHORT] $DATE  no in-scope ROCm parity check-runs yet on upstream — skip"
               continue
             fi
 
@@ -177,12 +187,12 @@ jobs:
               continue
             fi
 
-            # Gate 1: require EVERY relevant upstream check-run for this
-            # SHA to be status=completed (ROCm across arches/workflows,
-            # plus CUDA default/distributed/inductor tests). Once we
-            # dispatch for a SHA the parity report is authored, so
-            # dispatching before CUDA or another arch finishes produces
-            # partial reports.
+            # Gate 1: require EVERY upstream check-run consumed by the
+            # parity report for this SHA to be status=completed (ROCm
+            # arch test shards, plus CUDA default/distributed/inductor
+            # tests). Once we dispatch for a SHA the parity report is
+            # authored, so dispatching before CUDA or another arch
+            # finishes produces partial reports.
             GATE_CHECK_RUNS=$(jq -s 'add' \
               <(echo "$CHECK_RUNS") \
               <(echo "$CUDA_CHECK_RUNS"))

--- a/.github/workflows/parity-auto.yml
+++ b/.github/workflows/parity-auto.yml
@@ -27,7 +27,7 @@ run-name: "Parity auto-trigger · pytorch/pytorch main"
 
 on:
   schedule:
-    - cron: '*/30 * * * *'
+    - cron: '*/10 * * * *'
   workflow_dispatch:
     inputs:
       max_commits:

--- a/.github/workflows/parity-auto.yml
+++ b/.github/workflows/parity-auto.yml
@@ -1,9 +1,9 @@
 name: Parity Auto Trigger
 run-name: "Parity auto-trigger · pytorch/pytorch main"
 
-# Polls pytorch/pytorch main for commits where ALL ROCm CI has
-# finished, and dispatches parity.yml once for that SHA covering every
-# arch whose test shards actually ran on it.
+# Polls pytorch/pytorch main for commits where all CI consumed by
+# parity.yml has finished, and dispatches parity.yml once for that SHA
+# covering every arch whose test shards actually ran on it.
 #
 # Readiness is evaluated at the *check-run* level, not the workflow
 # level: ROCm test shards post check-runs independently, and a single
@@ -12,9 +12,10 @@ run-name: "Parity auto-trigger · pytorch/pytorch main"
 # fire too early and produce empty reports.
 #
 # Two gates:
-#   1. Every ROCm check-run on the SHA must be status=completed
-#      (across arches and workflows — we don't want to dispatch mi355
-#      while mi300's shards are still running on the same commit).
+#   1. Every ROCm check-run and every CUDA test check-run consumed by
+#      download_testlogs on the SHA must be status=completed. We don't
+#      want to dispatch mi355 while mi300, CUDA trunk, or CUDA inductor
+#      shards are still running on the same commit.
 #   2. For each arch in scope, we check whether its test shards
 #      actually ran on this SHA; mi300/mi200 etc. only show up when
 #      their periodic workflow happens to land on that SHA.
@@ -151,37 +152,49 @@ jobs:
               break
             fi
 
-            # Pull all ROCm test check-runs for this SHA. We use check-runs
-            # (not workflow_runs) because ROCm test shards post check-runs
-            # independently and workflow_run conclusion flips to 'failure'
-            # the moment any shard fails, even while other shards are
-            # still running. We need per-shard state.
-            CHECK_RUNS=$(gh api --paginate \
+            # Pull relevant upstream check-runs for this SHA. We use
+            # check-runs (not workflow_runs) because test shards post
+            # check-runs independently and workflow_run conclusion flips
+            # to 'failure' the moment any shard fails, even while siblings
+            # are still running. We need per-shard state.
+            ALL_CHECK_RUNS=$(gh api --paginate \
               "repos/$UPSTREAM/commits/$SHA/check-runs?per_page=100" \
-              --jq '.check_runs[] | select(.name | test("rocm";"i")) | {name,status,conclusion}' \
+              --jq '.check_runs[] | {name,status,conclusion}' \
               2>/dev/null | jq -s '.' || echo '[]')
+
+            CUDA_JOBNAME_REGEX='(linux-jammy-cuda13[.]0-py3[.]10-gcc11.*/ test [(](default|distributed),|unit-test / inductor-test / test [(]inductor,)'
+            CHECK_RUNS=$(echo "$ALL_CHECK_RUNS" | jq '[.[] | select(.name | test("rocm";"i"))]')
+            CUDA_CHECK_RUNS=$(echo "$ALL_CHECK_RUNS" | jq --arg rx "$CUDA_JOBNAME_REGEX" \
+              '[.[] | select(.name | test($rx))]')
 
             if [ "$(echo "$CHECK_RUNS" | jq 'length')" -eq 0 ]; then
               echo "[$SHORT] $DATE  no ROCm check-runs yet on upstream — skip"
               continue
             fi
 
-            # Gate 1: require EVERY ROCm check-run for this SHA to be
-            # status=completed (across all arches and workflows). We
-            # don't want to dispatch mi355 while mi300's shards are
-            # still running on the same commit — once we dispatch for a
-            # SHA the parity report is authored, and dispatching a
-            # second time later for a different arch gives users two
-            # partial reports instead of one full one.
-            TOTAL_CR=$(echo "$CHECK_RUNS" | jq 'length')
-            PENDING_CR=$(echo "$CHECK_RUNS" | jq 'map(select(.status != "completed")) | length')
+            if [ "$(echo "$CUDA_CHECK_RUNS" | jq 'length')" -eq 0 ]; then
+              echo "[$SHORT] $DATE  no CUDA parity check-runs yet on upstream — skip"
+              continue
+            fi
+
+            # Gate 1: require EVERY relevant upstream check-run for this
+            # SHA to be status=completed (ROCm across arches/workflows,
+            # plus CUDA default/distributed/inductor tests). Once we
+            # dispatch for a SHA the parity report is authored, so
+            # dispatching before CUDA or another arch finishes produces
+            # partial reports.
+            GATE_CHECK_RUNS=$(jq -s 'add' \
+              <(echo "$CHECK_RUNS") \
+              <(echo "$CUDA_CHECK_RUNS"))
+            TOTAL_CR=$(echo "$GATE_CHECK_RUNS" | jq 'length')
+            PENDING_CR=$(echo "$GATE_CHECK_RUNS" | jq 'map(select(.status != "completed")) | length')
             if [ "$PENDING_CR" -ne 0 ]; then
-              PENDING_SAMPLE=$(echo "$CHECK_RUNS" | jq -r '
+              PENDING_SAMPLE=$(echo "$GATE_CHECK_RUNS" | jq -r '
                 map(select(.status != "completed"))
                 | .[0:3]
                 | map(.name)
                 | join(", ")')
-              echo "[$SHORT] $DATE  ${PENDING_CR}/${TOTAL_CR} ROCm check-runs still pending — skip (e.g. $PENDING_SAMPLE)"
+              echo "[$SHORT] $DATE  ${PENDING_CR}/${TOTAL_CR} parity check-runs still pending — skip (e.g. $PENDING_SAMPLE)"
               continue
             fi
 


### PR DESCRIPTION
## Summary

Adds `.github/workflows/parity-auto.yml` so ROCm/pytorch automatically dispatches `parity.yml` for upstream `pytorch/pytorch:main` commits once the CI jobs needed for the parity report have finished.

The workflow currently:

1. Polls recent upstream commits on a cron and via `workflow_dispatch`.
2. Reads upstream check-runs for each SHA rather than relying on parent workflow status.
3. Waits for every in-scope ROCm parity test shard to be `status=completed`.
4. Waits for the CUDA jobs consumed by `download_testlogs` to be `status=completed`:
   - `linux-jammy-cuda13.0-py3.10-gcc11 / test-osdc (default, ...)`
   - `linux-jammy-cuda13.0-py3.10-gcc11 / test-osdc (distributed, ...)`
   - `unit-test / inductor-test / test (inductor, ...)`
5. Dispatches `parity.yml` once for the ready, unprocessed arch subset.
6. Embeds the upstream SHA in `csv_name`/run title so the next scan can avoid duplicates.

The cron is set to every 10 minutes to reduce dispatch latency after upstream CI finishes.

## Notable details

- Readiness is based on check-run `status=completed`, not `conclusion=success`; failing test shards are still useful because they produce logs/artifacts.
- ROCm readiness is scoped to the configured arch test-shard regexes, so unrelated ROCm benchmark/periodic jobs do not block parity reports.
- CUDA default/distributed now uses the upstream OSDC CUDA jobs and `test-reports-test-osdc-*` artifact prefixes.
- `download_testlogs` normalizes extracted CUDA OSDC artifact folders back to `test-default-*` / `test-distributed-*` so the existing XML summarizer keeps producing the same `test_config` values.

## Testing on fork

This version has been deployed on `ethanwee1/pytorch:main` for live testing.

Recent successful scheduled auto-trigger runs on the latest fork head `b490444...`:

- https://github.com/ethanwee1/pytorch/actions/runs/25171202507
- https://github.com/ethanwee1/pytorch/actions/runs/25165015185
- https://github.com/ethanwee1/pytorch/actions/runs/25161829713
- https://github.com/ethanwee1/pytorch/actions/runs/25156781905

Recent parity reports dispatched by the auto-trigger after the latest fixes:

- https://github.com/ethanwee1/pytorch/actions/runs/25165084598 — success
- https://github.com/ethanwee1/pytorch/actions/runs/25161924236 — success
- https://github.com/ethanwee1/pytorch/actions/runs/25146703765 — success
- https://github.com/ethanwee1/pytorch/actions/runs/25171334003 — in progress at time of PR update

Earlier failures on the fork were from older revisions before the CSV field-size and CUDA OSDC fixes. The latest completed reports on the current fork head are green.

## Follow-up after merge

After this lands on ROCm/pytorch `develop`, disable the fork cron to avoid duplicate polling/dispatching:

```bash
gh workflow disable parity-auto.yml --repo ethanwee1/pytorch
```
