### PR TITLE
[ROCm][release/2.10] Fix skipCUDAIf import error in test_linalg.py

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -2271,7 +2271,7 @@ class TestLinalg(TestCase):
         # check correctness using eigendecomposition identity
         self.assertEqual(a.to(v.dtype) @ v, w * v, atol=1e-3, rtol=1e-3)
 
-    @skipCUDAIf(TEST_WITH_ROCM and not torch.cuda.has_magma, "ROCm hipsolver backend does not currently support eig")
+    @skipIf(TEST_WITH_ROCM and not torch.cuda.has_magma, "ROCm hipsolver backend does not currently support eig")
     @onlyCUDA
     @dtypes(torch.float32, torch.float64)
     def test_eig_cuda_complex_eigenvectors(self, device, dtype):


### PR DESCRIPTION
Fixes the NameError reported in ROCM-20786 latest comment.

## Problem
PR #3171 introduced a `@skipCUDAIf` decorator on `test_eig_cuda_complex_eigenvectors`, but `skipCUDAIf` was never imported in `test_linalg.py`, causing:
```
NameError: name 'skipCUDAIf' is not defined. Did you mean: 'skipCUDAIfRocm'?
```

## Solution
Change `@skipCUDAIf` to `@skipIf`, which is already imported from `torch.testing._internal.common_device_type` and provides the same conditional skip functionality.

## Testing
The decorator will now work correctly:
- Skip the test when `TEST_WITH_ROCM and not torch.cuda.has_magma`
- Run the test otherwise

## References
- Jira: https://amd-hub.atlassian.net/browse/ROCM-20786
- Related PR: #3171

🤖 Generated with [Claude Code](https://claude.com/claude-code)