### PR TITLE
[release/2.10][UP][ROCm][CI] skip MI350 test_effn_attn_bias_padding_misaligned

### DIFF
--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -40,7 +40,9 @@ from torch.testing._internal.common_utils import (
     freeze_rng_state,
     instantiate_parametrized_tests,
     IS_FBCODE,
+    MI350_ARCH,
     parametrize,
+    skipIfRocmArch,
     TEST_WITH_ASAN,
     TEST_WITH_ROCM,
     xfailIfPy312Plus,
@@ -221,6 +223,11 @@ class CudaReproTests(TestCase):
         # dont check rng state
         self.assertEqual(out[:2], fn(query, key, value, input_tensor2)[:2])
 
+    # Fails on ROCm MI350
+    # Mismatched elements: 23 / 33062912 (0.0%)
+    # Greatest absolute difference: 0.07861328125 at index (14, 13, 1008, 36) (up to 1e-05 allowed)
+    # Greatest relative difference: 2.90625 at index (14, 13, 1008, 36) (up to 0.016 allowed)
+    @skipIfRocmArch(MI350_ARCH)
     def test_effn_attn_bias_padding_misaligned(self):
         seqlen_start = 1008
 


### PR DESCRIPTION
Backport of this upstream PR:
https://github.com/pytorch/pytorch/pull/170919

Needed by:
https://amd-hub.atlassian.net/browse/ROCM-20907

Testing:
Ran lintunner locally and there were no issues.