### PR TITLE
[CI][release/2.12] Pin Python dependency versions in requirements files

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -377,7 +377,7 @@ pwlf==2.2.1
 pip==26.0.1
 pyyaml==6.0.3
 pyzstd==0.16.2
-setuptools==78.1.1
+setuptools==79.0.1
 packaging==24.0
 six==1.17.0
 

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -117,7 +117,8 @@ ninja==1.11.1.4
 #Pinned versions: 1.11.1.4
 #test that import: run_test.py, test_cpp_extensions_aot.py,test_determination.py
 
-numba==0.61.2 ; platform_machine != "s390x"
+numba==0.61.2 ; python_version < "3.14" and platform_machine != "s390x"
+numba==0.63.1 ; python_version >= "3.14" and platform_machine != "s390x"
 
 #Description: Just-In-Time Compiler for Numerical Functions
 #Pinned versions: 0.55.2, 0.60.0

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -15,13 +15,13 @@ build==1.3.0
 #Pinned versions: 1.3.0
 #test that import:
 
-click
+click==8.3.1
 #Description: Command Line Interface Creation Kit
-#Pinned versions:
+#Pinned versions: 8.3.1
 #test that import:
 
 coremltools==5.0b5 ; python_version < "3.12"
-coremltools==8.3 ; python_version == "3.12"
+coremltools==8.3.0 ; python_version == "3.12"
 #Description: Apple framework for ML integration
 #Pinned versions: 5.0b5
 #test that import:
@@ -68,7 +68,7 @@ lark==0.12.0
 #Pinned versions: 0.12.0
 #test that import:
 
-librosa>=0.6.2 ; python_version < "3.11" and platform_machine != "s390x"
+librosa==0.10.2 ; python_version < "3.11" and platform_machine != "s390x"
 librosa==0.10.2 ; python_version == "3.12" and platform_machine != "s390x"
 #Description: A python package for music and audio analysis
 #Pinned versions: >=0.6.2
@@ -150,9 +150,9 @@ pandas==2.3.3; python_version >= "3.14"
 #Pinned versions: 1.9.0
 #test that import:
 
-opt-einsum==3.3
+opt-einsum==3.3.0
 #Description: Python library to optimize tensor contraction order, used in einsum
-#Pinned versions: 3.3
+#Pinned versions: 3.3.0
 #test that import: test_linalg.py
 
 optree==0.13.0 ; python_version < "3.14"
@@ -179,9 +179,9 @@ protobuf==6.33.5
 #Pinned versions: 6.33.2
 #test that import: test_tensorboard.py, test/onnx/*
 
-psutil
+psutil==7.2.2
 #Description: information on running processes and system utilization
-#Pinned versions:
+#Pinned versions: 7.2.2
 #test that import: test_profiler.py, test_openmp.py, test_dataloader.py
 
 pytest==7.3.2
@@ -199,9 +199,9 @@ pytest-flakefinder==1.1.0
 #Pinned versions: 1.1.0
 #test that import:
 
-pytest-rerunfailures>=10.3
+pytest-rerunfailures==14.0
 #Description: plugin for rerunning failure tests in pytest
-#Pinned versions:
+#Pinned versions: 14.0
 #test that import:
 
 pytest-subtests==0.13.1
@@ -270,8 +270,7 @@ scipy==1.16.2 ; python_version >= "3.14"
 #test that import:
 
 # needed by torchgen utils
-typing-extensions==4.12.2 ; python_version < "3.14"
-typing-extensions==4.15.0 ; python_version >= "3.14"
+typing-extensions==4.15.0
 #Description: type hints for python
 #Pinned versions:
 #test that import:
@@ -281,7 +280,7 @@ typing-extensions==4.15.0 ; python_version >= "3.14"
 #Pinned versions:
 #test that import:
 
-unittest-xml-reporting<=3.2.0,>=2.0.0
+unittest-xml-reporting==3.2.0
 #Description: saves unit test results to xml
 #Pinned versions:
 #test that import:
@@ -297,7 +296,7 @@ spin==0.17
 #Pinned versions: 0.17
 #test that import:
 
-redis>=4.0.0
+redis==7.4.0
 #Description: redis database
 #test that import: anything that tests OSS caching/mocking (inductor/test_codecache.py, inductor/test_max_autotune.py)
 
@@ -377,10 +376,10 @@ pwlf==2.2.1
 # To build PyTorch itself
 pip==26.0.1
 pyyaml==6.0.3
-pyzstd
+pyzstd==0.16.2
 setuptools==78.1.1
 packaging==24.0
-six
+six==1.17.0
 
 scons==4.5.2 ; platform_machine == "aarch64"
 
@@ -403,7 +402,7 @@ tlparse==0.4.0
 filelock==3.20.3
 #Description: required for inductor testing
 
-cuda-bindings>=12.0,<13.0 ; platform_machine != "s390x" and platform_system != "Darwin"
+cuda-bindings==12.9.6 ; platform_machine != "s390x" and platform_system != "Darwin"
 #Description: required for testing CUDAGraph::raw_cuda_graph(). See https://nvidia.github.io/cuda-python/cuda-bindings/latest/support.html for how this version was chosen. Note "Any fix in the latest bindings would be backported to the prior major version" means that only the newest version of cuda-bindings will get fixes. Depending on the latest version of 12.x is okay because all 12.y versions will be supported via "CUDA minor version compatibility". Pytorch builds against 13.z versions of cuda toolkit work with 12.x versions of cuda-bindings as well because newer drivers work with old toolkits.
 #test that import: test_cuda.py
 
@@ -413,7 +412,7 @@ pyre-extensions==0.0.32
 tabulate==0.9.0
 #Description: These package are needed to build FBGEMM and torchrec on PyTorch CI
 
-tqdm>=4.66.0
+tqdm==4.67.3
 #Description: progress bar library required for dynamo benchmarks
 #test that import: benchmarks/dynamo/*
 

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -118,7 +118,7 @@ ninja==1.11.1.4
 #test that import: run_test.py, test_cpp_extensions_aot.py,test_determination.py
 
 numba==0.61.2 ; python_version < "3.14" and platform_machine != "s390x"
-numba==0.63.1 ; python_version >= "3.14" and platform_machine != "s390x"
+numba==0.64.0 ; python_version >= "3.14" and platform_machine != "s390x"
 
 #Description: Just-In-Time Compiler for Numerical Functions
 #Pinned versions: 0.55.2, 0.60.0

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -117,8 +117,8 @@ ninja==1.11.1.4
 #Pinned versions: 1.11.1.4
 #test that import: run_test.py, test_cpp_extensions_aot.py,test_determination.py
 
-numba==0.57.1 ; python_version == "3.10" and platform_machine != "s390x"
-numba==0.60.0 ; python_version == "3.12" and platform_machine != "s390x"
+numba==0.61.2 ; platform_machine != "s390x"
+
 #Description: Just-In-Time Compiler for Numerical Functions
 #Pinned versions: 0.55.2, 0.60.0
 #test that import: test_numba_integration.py
@@ -136,13 +136,10 @@ numba==0.60.0 ; python_version == "3.12" and platform_machine != "s390x"
 #test_nn.py, test_namedtensor.py, test_linalg.py, test_jit_cuda_fuser.py,
 #test_jit.py, test_indexing.py, test_datapipe.py, test_dataloader.py,
 #test_binary_ufuncs.py
-numpy==1.23.2; python_version == "3.10"
-numpy==1.26.2; python_version == "3.11" or python_version == "3.12"
-numpy==2.1.2; python_version >= "3.13" and python_version < "3.14"
+numpy==2.1.2 ; python_version < "3.14"
 numpy==2.3.4; python_version >= "3.14"
 
-pandas==2.0.3; python_version < "3.12"
-pandas==2.2.3; python_version >= "3.12" and python_version < "3.14"
+pandas==2.2.3; python_version < "3.14"
 pandas==2.3.3; python_version >= "3.14"
 
 #onnxruntime
@@ -254,9 +251,9 @@ scikit-image==0.22.0
 #Pinned versions: 0.20.3
 #test that import:
 
-scipy==1.10.1 ; python_version <= "3.11"
-scipy==1.14.1 ; python_version > "3.11" and python_version < "3.14"
+scipy==1.14.1 ; python_version < "3.14"
 scipy==1.16.2 ; python_version >= "3.14"
+
 # Pin SciPy because of failing distribution tests (see #60347)
 #Description: scientific python
 #Pinned versions: 1.10.1
@@ -320,8 +317,7 @@ z3-solver==4.15.1.0 ; platform_machine != "s390x"
 #Pinned versions:
 #test that import:
 
-tensorboard==2.13.0 ; python_version < "3.13"
-tensorboard==2.18.0 ; python_version >= "3.13"
+tensorboard==2.18.0
 #Description: Also included in .ci/docker/requirements-docs.txt
 #Pinned versions:
 #test that import: test_tensorboard

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -378,7 +378,7 @@ pip==26.0.1
 pyyaml==6.0.3
 pyzstd==0.16.2
 setuptools==79.0.1
-packaging==24.0
+packaging==25.0
 six==1.17.0
 
 scons==4.5.2 ; platform_machine == "aarch64"

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,11 +1,14 @@
 # Build System requirements
-setuptools>=70.1.0,<82
-cmake>=3.27
-ninja
-numpy
-packaging
-pyyaml
-requests
-six  # dependency chain: NNPACK -> PeachPy -> six
-typing-extensions>=4.15.0
-pip  # not technically needed, but this makes setup.py invocation work
+setuptools==78.1.1
+cmake==3.31.6
+ninja==1.11.1.4
+numpy==1.23.2 ; python_version == "3.10"
+numpy==1.26.2 ; python_version == "3.11" or python_version == "3.12"
+numpy==2.1.2 ; python_version >= "3.13" and python_version < "3.14"
+numpy==2.3.4 ; python_version >= "3.14"
+packaging==24.0
+pyyaml==6.0.3
+requests==2.32.5
+six==1.17.0  # dependency chain: NNPACK -> PeachPy -> six
+typing-extensions==4.15.0
+pip==26.0.1  # not technically needed, but this makes setup.py invocation work

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,5 +1,5 @@
 # Build System requirements
-# setuptools and cmake pinned to match rocm/pytorch release/2.10:
+# Build requirements pinned to match rocm/pytorch release/2.11:
 # https://github.com/ROCm/pytorch/blob/0b21eac93ff682d862b257770fff5f9fc069b30a/requirements-build.txt
 setuptools==79.0.1
 cmake==4.0.0

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,6 +1,6 @@
 # Build System requirements
 # Build requirements pinned to match rocm/pytorch release/2.11:
-# https://github.com/ROCm/pytorch/blob/0b21eac93ff682d862b257770fff5f9fc069b30a/requirements-build.txt
+# https://github.com/ROCm/pytorch/blob/83524a4c7d748e5de89a7a93cd72dab4bd1fa42d/requirements-build.txt
 setuptools==79.0.1
 cmake==4.0.0
 ninja==1.11.1.4

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,14 +1,15 @@
 # Build System requirements
-setuptools==78.1.1
-cmake==3.31.6
+# setuptools and cmake pinned to match rocm/pytorch release/2.10:
+# https://github.com/ROCm/pytorch/blob/0b21eac93ff682d862b257770fff5f9fc069b30a/requirements-build.txt
+setuptools==79.0.1
+cmake==4.0.0
 ninja==1.11.1.4
-numpy==1.23.2 ; python_version == "3.10"
-numpy==1.26.2 ; python_version == "3.11" or python_version == "3.12"
-numpy==2.1.2 ; python_version >= "3.13" and python_version < "3.14"
-numpy==2.3.4 ; python_version >= "3.14"
-packaging==24.0
+numpy==2.0.2 ; python_version == "3.9"
+numpy==2.1.2 ; python_version > "3.9" and python_version < "3.14"
+numpy==2.4.3 ; python_version >= "3.14"
+packaging==25.0
 pyyaml==6.0.3
 requests==2.32.5
 six==1.17.0  # dependency chain: NNPACK -> PeachPy -> six
-typing-extensions==4.15.0
+typing_extensions==4.15.0
 pip==26.0.1  # not technically needed, but this makes setup.py invocation work

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,16 +4,17 @@
 --requirement requirements-build.txt
 
 # Install / Development extra requirements
-build[uv]  # for building sdist and wheel
-expecttest>=0.3.0
-filelock
-fsspec>=0.8.5
-hypothesis
-jinja2
-lintrunner ; platform_machine != "s390x"
-networkx>=2.5.1
-optree>=0.13.0
-psutil
-spin
-sympy>=1.13.3
-wheel
+build[uv]==1.3.0  # for building sdist and wheel
+expecttest==0.3.0
+filelock==3.20.3
+fsspec==2026.2.0
+hypothesis==6.56.4
+jinja2==3.1.6
+lintrunner==0.12.11 ; platform_machine != "s390x"
+networkx==2.8.8
+optree==0.13.0 ; python_version < "3.14"
+optree==0.17.0 ; python_version >= "3.14"
+psutil==7.2.2
+spin==0.17
+sympy==1.13.3
+wheel==0.46.3


### PR DESCRIPTION
Pin dependencies in release/2.12.

Tested in fresh venvs with Python 3.11, 3.12, 3.13, and 3.14 by installing `requirements.txt`, then `.ci/docker/requirements-ci.txt`, then running `pip check`. The Python 3.14 Numba failure is fixed by using ~`numba==0.63.1`~  `numba==0.64.0` (updated to be >= release/2.11 version) for Python 3.14+ while keeping `numba==0.61.2` below Python 3.14.

Build failure unrelated to changes.

Validation snippets:

Python 3.11

```console
$ python3.11 --version
Python 3.11.15
$ python -m pip install -r requirements.txt
Successfully installed packaging-26.2 pip-26.1.1 setuptools-82.0.1 wheel-0.47.0
$ python -m pip install -r .ci/docker/requirements-ci.txt
Successfully installed Deprecated-1.3.1 PyGithub-2.3.0 absl-py-2.4.0 aiohappyeyeballs-2.6.1 aiohttp-3.13.4 aiosignal-1.4.0 boto3-1.35.42 botocore-1.35.99 cffi-2.0.0 click-8.3.1 cmake-3.31.6 colorama-0.4.6 coremltools-5.0b5 cryptography-48.0.0 cuda-bindings-12.9.6 cuda-pathfinder-1.5.4 dataclasses_json-0.6.7 dill-0.3.7 distro-1.9.0 execnet-2.1.2 fbscribelogger-0.1.7 flatbuffers-24.12.23 frozenlist-1.8.0 future-1.0.0 ghstack-0.8.0 grpcio-1.80.0 imageio-2.37.3 iniconfig-2.3.0 intel-cmplr-lib-ur-2026.0.0 intel-openmp-2026.0.0 jmespath-1.1.0 junitparser-2.1.1 lark-0.12.0 lazy_loader-0.5 llvmlite-0.44.0 lxml-5.3.0 markdown-3.10.2 marshmallow-3.26.2 mkl-include-2024.2.0 mkl-static-2024.2.0 ml_dtypes-0.5.4 multidict-6.7.1 mypy-1.16.0 mypy_extensions-1.1.0 numba-0.61.2 onnx-1.21.0 onnx-ir-0.1.16 onnxscript-0.6.2 opt-einsum-3.3.0 pandas-2.2.3 parameterized-0.8.1 pathspec-1.1.1 pillow-12.2.0 pluggy-1.6.0 ply-3.11 propcache-0.5.2 protobuf-6.33.5 pulp-2.9.0 pwlf-2.2.1 pyDOE-0.9.3 pycparser-3.0 pygments-2.20.0 pyjwt-2.12.1 pynacl-1.6.2 pyre-extensions-0.0.32 pytest-7.3.2 pytest-cpp-2.3.0 pytest-flakefinder-1.1.0 pytest-rerunfailures-14.0 pytest-subtests-0.13.1 pytest-xdist-3.3.1 python-dateutil-2.9.0.post0 pytz-2026.2 pywavelets-1.4.1 pyzstd-0.16.2 redis-7.4.0 s3transfer-0.10.4 scikit-build-0.18.1 scikit-image-0.22.0 scipy-1.14.1 setuptools-git-versioning-2.1.0 tabulate-0.9.0 tbb-2021.13.1 tcmlib-1.5.0 tensorboard-2.18.0 tensorboard-data-server-0.7.2 thriftpy2-0.5.3 tifffile-2026.3.3 tlparse-0.4.0 tqdm-4.67.3 typing-inspect-0.9.0 tzdata-2026.2 umf-1.1.0 unittest-xml-reporting-3.2.0 werkzeug-3.1.8 wrapt-2.1.2 xdoctest-1.3.0 yarl-1.23.0 z3-solver-4.15.1.0
$ python -m pip check
No broken requirements found.
STATUS python3.11 0
```

Python 3.12

```console
$ python3.12 --version
Python 3.12.13
$ python -m pip install -r requirements.txt
Successfully installed packaging-26.2 pip-26.1.1 setuptools-82.0.1 wheel-0.47.0
$ python -m pip install -r .ci/docker/requirements-ci.txt
Successfully installed Deprecated-1.3.1 PyGithub-2.3.0 absl-py-2.4.0 aiohappyeyeballs-2.6.1 aiohttp-3.13.4 aiosignal-1.4.0 audioread-3.1.0 boto3-1.35.42 botocore-1.35.99 cattrs-26.1.0 cffi-2.0.0 click-8.3.1 cmake-3.31.6 colorama-0.4.6 coremltools-8.3.0 cryptography-48.0.0 cuda-bindings-12.9.6 cuda-pathfinder-1.5.4 dataclasses_json-0.6.7 decorator-5.2.1 dill-0.3.7 distro-1.9.0 execnet-2.1.2 fbscribelogger-0.1.7 flatbuffers-24.12.23 frozenlist-1.8.0 future-1.0.0 ghstack-0.8.0 grpcio-1.80.0 imageio-2.37.3 iniconfig-2.3.0 intel-cmplr-lib-ur-2026.0.0 intel-openmp-2026.0.0 jmespath-1.1.0 joblib-1.5.3 junitparser-2.1.1 lark-0.12.0 lazy-loader-0.5 librosa-0.10.2 llvmlite-0.44.0 lxml-5.3.0 markdown-3.10.2 marshmallow-3.26.2 mkl-include-2024.2.0 mkl-static-2024.2.0 ml_dtypes-0.5.4 msgpack-1.1.2 multidict-6.7.1 mypy-1.16.0 mypy_extensions-1.1.0 numba-0.61.2 onnx-1.21.0 onnx-ir-0.1.16 onnxscript-0.6.2 opt-einsum-3.3.0 pandas-2.2.3 parameterized-0.8.1 pathspec-1.1.1 pillow-12.2.0 platformdirs-4.9.6 pluggy-1.6.0 ply-3.11 pooch-1.9.0 propcache-0.5.2 protobuf-6.33.5 pulp-2.9.0 pwlf-2.2.1 pyDOE-0.9.3 pyaml-26.2.1 pycparser-3.0 pygments-2.20.0 pyjwt-2.12.1 pynacl-1.6.2 pyre-extensions-0.0.32 pytest-7.3.2 pytest-cpp-2.3.0 pytest-flakefinder-1.1.0 pytest-rerunfailures-14.0 pytest-subtests-0.13.1 pytest-xdist-3.3.1 python-dateutil-2.9.0.post0 pytz-2026.2 pywavelets-1.7.0 pyzstd-0.16.2 redis-7.4.0 s3transfer-0.10.4 scikit-build-0.18.1 scikit-image-0.22.0 scikit-learn-1.8.0 scipy-1.14.1 setuptools-git-versioning-2.1.0 soundfile-0.13.1 soxr-1.1.0 tabulate-0.9.0 tbb-2021.13.1 tcmlib-1.5.0 tensorboard-2.18.0 tensorboard-data-server-0.7.2 threadpoolctl-3.6.0 thriftpy2-0.5.3 tifffile-2026.5.2 tlparse-0.4.0 tqdm-4.67.3 typing-inspect-0.9.0 tzdata-2026.2 umf-1.1.0 unittest-xml-reporting-3.2.0 werkzeug-3.1.8 wrapt-2.1.2 xdoctest-1.3.0 yarl-1.23.0 z3-solver-4.15.1.0
$ python -m pip check
No broken requirements found.
STATUS python3.12 0
```

Python 3.13

```console
$ python3.13 --version
Python 3.13.12
$ python -m pip install -r requirements.txt
Successfully installed packaging-26.2 pip-26.1.1 setuptools-82.0.1 wheel-0.47.0
$ python -m pip install -r .ci/docker/requirements-ci.txt
Successfully installed Deprecated-1.3.1 PyGithub-2.3.0 absl-py-2.4.0 aiohappyeyeballs-2.6.1 aiohttp-3.13.4 aiosignal-1.4.0 boto3-1.35.42 botocore-1.35.99 cffi-2.0.0 click-8.3.1 cmake-3.31.6 colorama-0.4.6 cryptography-48.0.0 cuda-bindings-12.9.6 cuda-pathfinder-1.5.4 dataclasses_json-0.6.7 dill-0.3.7 distro-1.9.0 execnet-2.1.2 fbscribelogger-0.1.7 flatbuffers-24.12.23 frozenlist-1.8.0 future-1.0.0 ghstack-0.8.0 grpcio-1.80.0 imageio-2.37.3 iniconfig-2.3.0 intel-cmplr-lib-ur-2026.0.0 intel-openmp-2026.0.0 jmespath-1.1.0 junitparser-2.1.1 lark-0.12.0 lazy_loader-0.5 llvmlite-0.44.0 lxml-5.3.0 markdown-3.10.2 marshmallow-3.26.2 mkl-include-2024.2.0 mkl-static-2024.2.0 ml_dtypes-0.5.4 multidict-6.7.1 mypy-1.16.0 mypy_extensions-1.1.0 numba-0.61.2 onnx-1.21.0 onnx-ir-0.1.16 onnxscript-0.6.2 opt-einsum-3.3.0 pandas-2.2.3 parameterized-0.8.1 pathspec-1.1.1 pillow-12.2.0 pluggy-1.6.0 ply-3.11 propcache-0.5.2 protobuf-6.33.5 pulp-2.9.0 pwlf-2.2.1 pyDOE-0.9.3 pycparser-3.0 pygments-2.20.0 pyjwt-2.12.1 pynacl-1.6.2 pyre-extensions-0.0.32 pytest-7.3.2 pytest-cpp-2.3.0 pytest-flakefinder-1.1.0 pytest-rerunfailures-14.0 pytest-subtests-0.13.1 pytest-xdist-3.3.1 python-dateutil-2.9.0.post0 pytz-2026.2 pywavelets-1.7.0 pyzstd-0.16.2 redis-7.4.0 s3transfer-0.10.4 scikit-build-0.18.1 scikit-image-0.22.0 scipy-1.14.1 setuptools-git-versioning-2.1.0 tabulate-0.9.0 tbb-2021.13.1 tcmlib-1.5.0 tensorboard-2.18.0 tensorboard-data-server-0.7.2 thriftpy2-0.5.3 tifffile-2026.5.2 tlparse-0.4.0 tqdm-4.67.3 typing-inspect-0.9.0 tzdata-2026.2 umf-1.1.0 unittest-xml-reporting-3.2.0 werkzeug-3.1.8 wrapt-2.1.2 xdoctest-1.3.0 yarl-1.23.0 z3-solver-4.15.1.0
$ python -m pip check
No broken requirements found.
STATUS python3.13 0
```

Python 3.14

```console
$ python3.14 --version
Python 3.14.3
$ python -m pip install -r requirements.txt
Successfully installed packaging-26.2 pip-26.1.1 setuptools-82.0.1 wheel-0.47.0
$ python -m pip install -r .ci/docker/requirements-ci.txt
Successfully installed Deprecated-1.3.1 PyGithub-2.3.0 absl-py-2.4.0 aiohappyeyeballs-2.6.1 aiohttp-3.13.4 aiosignal-1.4.0 boto3-1.35.42 botocore-1.35.99 cffi-2.0.0 click-8.3.1 cmake-3.31.6 colorama-0.4.6 cryptography-48.0.0 cuda-bindings-12.9.6 cuda-pathfinder-1.5.4 dataclasses_json-0.6.7 dill-0.3.7 distro-1.9.0 execnet-2.1.2 fbscribelogger-0.1.7 flatbuffers-24.12.23 frozenlist-1.8.0 future-1.0.0 ghstack-0.8.0 grpcio-1.80.0 imageio-2.37.3 iniconfig-2.3.0 intel-cmplr-lib-ur-2026.0.0 intel-openmp-2026.0.0 jmespath-1.1.0 junitparser-2.1.1 lark-0.12.0 lazy_loader-0.5 llvmlite-0.46.0 lxml-6.0.2 markdown-3.10.2 marshmallow-3.26.2 mkl-include-2024.2.0 mkl-static-2024.2.0 ml_dtypes-0.5.4 multidict-6.7.1 mypy-1.16.0 mypy_extensions-1.1.0 numba-0.63.1 numpy-2.3.4 onnx-1.21.0 onnx-ir-0.1.16 onnxscript-0.6.2 opt-einsum-3.3.0 pandas-2.3.3 parameterized-0.8.1 pathspec-1.1.1 pillow-12.2.0 pluggy-1.6.0 ply-3.11 propcache-0.5.2 protobuf-6.33.5 pulp-2.9.0 pwlf-2.2.1 pyDOE-1.0.1 pycparser-3.0 pygments-2.20.0 pyjwt-2.12.1 pynacl-1.6.2 pyre-extensions-0.0.32 pytest-7.3.2 pytest-cpp-2.3.0 pytest-flakefinder-1.1.0 pytest-rerunfailures-14.0 pytest-subtests-0.13.1 pytest-xdist-3.3.1 python-dateutil-2.9.0.post0 pytz-2026.2 pywavelets-1.7.0 pyzstd-0.16.2 redis-7.4.0 s3transfer-0.10.4 scikit-build-0.18.1 scikit-image-0.22.0 scipy-1.16.2 setuptools-git-versioning-2.1.0 tabulate-0.9.0 tbb-2021.13.1 tcmlib-1.5.0 tensorboard-2.18.0 tensorboard-data-server-0.7.2 thriftpy2-0.5.3 tifffile-2026.5.2 tlparse-0.4.0 tqdm-4.67.3 typing-inspect-0.9.0 tzdata-2026.2 umf-1.1.0 unittest-xml-reporting-3.2.0 werkzeug-3.1.8 wrapt-2.1.2 xdoctest-1.3.0 yarl-1.23.0 z3-solver-4.15.1.0
$ python -m pip check
No broken requirements found.
STATUS python3.14 0
```
