### PR TITLE
[Inductor] Fix ReinterpretView stride mismatch in TritonTemplateKernel

### DIFF
--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -1580,7 +1580,13 @@ class TritonTemplateKernel(TritonKernel):
         layout = node.data.layout
         node_name = node.get_name()
 
-        if isinstance(layout, ir.FlexibleLayout):
+        # For ReinterpretView, the view's strides are already determined by its layout.
+        # We skip constraint tracking because node.get_name() returns the underlying
+        # buffer name, not the view's identity, so constraints would be incorrectly
+        # associated with the underlying buffer rather than the view.
+        if isinstance(layout, ir.FlexibleLayout) and not isinstance(
+            node, ir.ReinterpretView
+        ):
             if not use_aten_gemm_kernels():
                 # No ExternKernel fallback available, freeze immediately
                 node.data.freeze_layout()


### PR DESCRIPTION
Fixes a bug where FlexibleLayout on a ReinterpretView incorrectly returns underlying physical buffer strides (e.g., 4D) instead of logical view strides (3D).

This patch skips speculative layout and constraint tracking for ReinterpretView nodes, forcing the use of node.get_stride() to prevent Illegal Memory Access (IMA) on ROCm.

Manual backport from PyTorch 2.12.
Ref commit: https://github.com/pytorch/pytorch/commit/0e1f56285ea65c0fc960ea110cc4088e92eab453

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
