### PR TITLE
[ROCm] Integrate hipDNN as an SDPA backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,7 @@ torch/lib/*.lib
 torch/lib/*.pdb
 torch/lib/*.so*
 torch/lib/protobuf*.pc
+torch/lib/aotriton.images/
 torch/lib/build
 torch/lib/caffe2/
 torch/lib/cmake

--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -653,6 +653,7 @@ if(USE_ROCM)
     ${native_miopen_cpp}
     ${native_hipdnn_cpp}
     ${native_cudnn_cpp}
+    ${native_cudnn_hip_cpp}
     ${miopen_cpp}
     ${all_hip_cpp}
   )

--- a/aten/src/ATen/native/cudnn/MHA.cpp
+++ b/aten/src/ATen/native/cudnn/MHA.cpp
@@ -6,7 +6,10 @@
 #include <cudnn_frontend.h>
 #endif
 
-#if defined(USE_ROCM) || !AT_CUDNN_ENABLED() ||         \
+#if defined(USE_ROCM)
+// On ROCm, hipDNN provides its own MHA implementation in
+// native/cudnn/hip/MHA.cpp.
+#elif !AT_CUDNN_ENABLED() ||                            \
     (defined(CUDNN_VERSION) && CUDNN_VERSION < 8900) || \
     (defined(CUDNN_FRONTEND_VERSION) && CUDNN_FRONTEND_VERSION < 10100)
 namespace at {

--- a/aten/src/ATen/native/cudnn/MHA.h
+++ b/aten/src/ATen/native/cudnn/MHA.h
@@ -97,4 +97,16 @@ void run_cudnn_SDP_bprop_nestedtensor(
     const Tensor& dropoutseed,
     const Tensor& dropoutoffset);
 
+#if defined(USE_ROCM)
+// Query backend to determine if graph configuration is supported.
+bool check_cudnn_sdpa_support(
+    int64_t b, int64_t h, int64_t s_q, int64_t s_kv,
+    int64_t d_qk, int64_t d_v,
+    float scaling_factor,
+    bool return_softmaxstats, bool is_causal,
+    double dropout_probability,
+    const Tensor& q, const Tensor& k, const Tensor& v,
+    const std::optional<Tensor>& attn_bias);
+#endif
+
 } // namespace at::native

--- a/aten/src/ATen/native/cudnn/MHA.h
+++ b/aten/src/ATen/native/cudnn/MHA.h
@@ -1,6 +1,10 @@
 #pragma once
 #include <ATen/core/Tensor.h>
 
+#if defined(USE_ROCM)
+#include <ATen/native/transformers/sdp_utils_cpp.h>
+#endif
+
 namespace at::native {
 
 void run_cudnn_SDP_fprop(
@@ -99,14 +103,7 @@ void run_cudnn_SDP_bprop_nestedtensor(
 
 #if defined(USE_ROCM)
 // Query backend to determine if graph configuration is supported.
-bool check_cudnn_sdpa_support(
-    int64_t b, int64_t h, int64_t s_q, int64_t s_kv,
-    int64_t d_qk, int64_t d_v,
-    float scaling_factor,
-    bool return_softmaxstats, bool is_causal,
-    double dropout_probability,
-    const Tensor& q, const Tensor& k, const Tensor& v,
-    const std::optional<Tensor>& attn_bias);
+bool check_cudnn_sdpa_support(sdp::sdp_params const& params);
 #endif
 
 } // namespace at::native

--- a/aten/src/ATen/native/cudnn/hip/MHA.cpp
+++ b/aten/src/ATen/native/cudnn/hip/MHA.cpp
@@ -112,4 +112,1766 @@ void run_cudnn_SDP_bprop_nestedtensor(
 } // namespace native
 } // namespace at
 
+#else // USE_HIPDNN
+
+#include <ATen/cudnn/Descriptors.h>
+#include <ATen/cudnn/Types.h>
+#include <ATen/cudnn/Utils.h>
+#include <ATen/native/cudnn/MHA.h>
+#include <ATen/native/transformers/sdp_utils.h>
+
+#include <ATen/cuda/Exceptions.h>
+
+#include <ATen/TensorUtils.h>
+#include <ATen/native/utils/ParamsHash.h>
+
+#include <c10/cuda/CUDACachingAllocator.h>
+#include <cudnn.h>
+
+#include <iostream>
+
+namespace at::native {
+
+namespace fe = cudnn_frontend;
+
+constexpr uint8_t MAX_MHA_DIM = 4;
+
+// Whether we will use ragged offsets in the dense (non-nested) path
+// to avoid recompilation
+bool use_ragged_in_dense(
+    const Tensor& q,
+    const Tensor& k,
+    const Tensor& v,
+    const Tensor& o,
+    bool has_bias) {
+  static bool flag =
+      c10::utils::check_env("TORCH_CUDNN_SDPA_AVOID_RECOMPILE") == true;
+  if (!flag) {
+    return flag;
+  }
+  TORCH_WARN_ONCE(
+      "TORCH_CUDNN_SDPA_AVOID_RECOMPILE=1 is currently experimental. "
+      "Please report any issues to https://github.com/pytorch/pytorch/issues.");
+  if (has_bias) {
+    TORCH_WARN_ONCE(
+        "TORCH_CUDNN_SDPA_AVOID_RECOMPILE=1 only works without bias."
+        "Consider using the is_causal hint instead of bias for causal masking."
+        "Falling back to regular dense case, which may trigger excessive recompilation.");
+    return !has_bias;
+  }
+  bool all_bshd = q.dim() == 4 && q.transpose(1, 2).is_contiguous() &&
+      k.dim() == 4 && k.transpose(1, 2).is_contiguous() && v.dim() == 4 &&
+      v.transpose(1, 2).is_contiguous() && o.dim() == 4 &&
+      o.transpose(1, 2).is_contiguous();
+  if (!all_bshd) {
+    TORCH_WARN_ONCE(
+        "TORCH_CUDNN_SDPA_AVOID_RECOMPILE=1 only works with Q, K, V, and output in BSHD memory layout,"
+        "e.g., Q, K, V must be allocated with torch.randn((B, S, H, D).transpose(1, 2)."
+        "Falling back to regular dense case, which may trigger excessive recompilation.");
+  }
+  return all_bshd;
+}
+
+int roundup_power2(int dim) {
+  if (!dim) {
+    return 1;
+  }
+  dim--;
+  dim |= dim >> 1;
+  dim |= dim >> 2;
+  dim |= dim >> 4;
+  dim |= dim >> 8;
+  dim |= dim >> 16;
+  dim++;
+  return dim;
+}
+
+struct MHAParams {
+  c10::DeviceIndex device_id;
+  fe::DataType_t dataType;
+  std::array<int, MAX_MHA_DIM> q_dim;
+  std::array<int, MAX_MHA_DIM> k_dim;
+  std::array<int, MAX_MHA_DIM> v_dim;
+  std::array<int, MAX_MHA_DIM> q_stride;
+  std::array<int, MAX_MHA_DIM> k_stride;
+  std::array<int, MAX_MHA_DIM> v_stride;
+  std::array<int, MAX_MHA_DIM> bias_dim;
+  std::array<int, MAX_MHA_DIM> bias_stride;
+  int64_t b;
+  int64_t h;
+  int64_t s_q;
+  int64_t s_kv;
+  int64_t d_qk;
+  int64_t d_v;
+  double dropout_probability;
+  bool is_causal;
+  bool return_softmaxstats;
+  // might be redundant if we take 0 dim/stride
+  // as signaling no-bias
+  bool has_attn_bias;
+  bool use_ragged;
+};
+
+void setMHAParams(
+    MHAParams& params,
+    int64_t b,
+    int64_t h,
+    int64_t s_q,
+    int64_t s_kv,
+    int64_t d_qk,
+    int64_t d_v,
+    const Tensor& q,
+    const Tensor& k,
+    const Tensor& v,
+    const std::optional<Tensor>& attn_bias,
+    double dropout_probability,
+    bool is_causal,
+    bool return_softmaxstats,
+    bool is_nested) {
+  memset(&params, 0, sizeof(MHAParams));
+  params.device_id = at::cuda::current_device();
+  params.dataType = fe::DataType_t::HALF;
+  if (q.scalar_type() == kBFloat16) {
+    params.dataType = fe::DataType_t::BFLOAT16;
+  }
+  params.b = b;
+  params.h = h;
+  params.d_qk = d_qk;
+  params.d_v = d_v;
+  params.s_q = s_q;
+  params.s_kv = s_kv;
+  params.dropout_probability = dropout_probability;
+  params.is_causal = is_causal;
+  params.return_softmaxstats = return_softmaxstats;
+  params.has_attn_bias = attn_bias.has_value();
+  // Expect 4D dense tensor, 3D nested case (THD)
+  TORCH_INTERNAL_ASSERT(
+      q.sizes().size() == (uint8_t)(MAX_MHA_DIM - (uint8_t)is_nested),
+      "Q tensor has unexpected number of dims, please report a bug to PyTorch.");
+  TORCH_INTERNAL_ASSERT(
+      q.strides().size() == (uint8_t)(MAX_MHA_DIM - (uint8_t)is_nested),
+      "Q tensor has unexpected number of dims, please report a bug to PyTorch.");
+  TORCH_INTERNAL_ASSERT(
+      k.sizes().size() == (uint8_t)(MAX_MHA_DIM - (uint8_t)is_nested),
+      "K tensor has unexpected number of dims, please report a bug to PyTorch.");
+  TORCH_INTERNAL_ASSERT(
+      k.strides().size() == (uint8_t)(MAX_MHA_DIM - (uint8_t)is_nested),
+      "K tensor has unexpected number of dims, please report a bug to PyTorch.");
+  TORCH_INTERNAL_ASSERT(
+      v.sizes().size() == (uint8_t)(MAX_MHA_DIM - (uint8_t)is_nested),
+      "V tensor has unexpected number of dims, please report a bug to PyTorch.");
+  TORCH_INTERNAL_ASSERT(
+      v.strides().size() == (uint8_t)(MAX_MHA_DIM - (uint8_t)is_nested),
+      "V tensor has unexpected number of dims, please report a bug to PyTorch.");
+  std::copy(q.sizes().begin(), q.sizes().end(), params.q_dim.begin());
+  std::copy(q.strides().begin(), q.strides().end(), params.q_stride.begin());
+  std::copy(k.sizes().begin(), k.sizes().end(), params.k_dim.begin());
+  std::copy(k.strides().begin(), k.strides().end(), params.k_stride.begin());
+  std::copy(v.sizes().begin(), v.sizes().end(), params.v_dim.begin());
+  std::copy(v.strides().begin(), v.strides().end(), params.v_stride.begin());
+  bool use_ragged = use_ragged_in_dense(q, k, v, q, params.has_attn_bias);
+  params.use_ragged = use_ragged;
+  if (use_ragged) {
+    // ignore B - stride in BSHD (THD) avoid-recompile
+    params.q_stride[0] = INT_MAX;
+    params.k_stride[0] = INT_MAX;
+    params.v_stride[0] = INT_MAX;
+    // fix seqlen to rounded value
+    params.s_q = roundup_power2(params.s_q);
+    params.s_kv = roundup_power2(params.s_kv);
+    params.q_dim[2] = roundup_power2(params.q_dim[2]);
+    params.k_dim[2] = roundup_power2(params.k_dim[2]);
+    params.v_dim[2] = roundup_power2(params.v_dim[2]);
+  }
+  // uninit is OK as the struct is memset 0'd
+  if (params.has_attn_bias) {
+    std::copy(
+        attn_bias.value().sizes().begin(),
+        attn_bias.value().sizes().end(),
+        params.bias_dim.begin());
+    std::copy(
+        attn_bias.value().strides().begin(),
+        attn_bias.value().strides().end(),
+        params.bias_stride.begin());
+  }
+}
+
+struct MHACacheKeyWrapper : ParamsWrapper<MHAParams> {
+  MHACacheKeyWrapper(
+      int64_t b,
+      int64_t h,
+      int64_t s_q,
+      int64_t s_kv,
+      int64_t d_qk,
+      int64_t d_v,
+      const Tensor& q,
+      const Tensor& k,
+      const Tensor& v,
+      const std::optional<Tensor>& attn_bias,
+      double dropout_probability,
+      bool is_causal,
+      bool return_softmaxstats,
+      bool is_nested) {
+    setMHAParams(
+        this->pod,
+        b,
+        h,
+        s_q,
+        s_kv,
+        d_qk,
+        d_v,
+        q,
+        k,
+        v,
+        attn_bias,
+        dropout_probability,
+        is_causal,
+        return_softmaxstats,
+        is_nested);
+  }
+};
+
+struct MHAGraphCache {
+  using KeyType = MHACacheKeyWrapper;
+  using ValueType = std::unique_ptr<fe::graph::Graph>;
+  using MapType =
+      std::unordered_map<KeyType, ValueType, ParamsWrapperHash<KeyType>>;
+  using iterator = typename MapType::iterator;
+  using const_iterator = typename MapType::const_iterator;
+
+  MapType engine_cache;
+  int count = 0;
+  int hits = 0;
+
+  // no mutexes here as caches are now thread local for v8, can also return a
+  // pointer to the Execution Plan if we know it will not be invalidated by
+  // another thread
+  iterator find(const KeyType& key) {
+    static bool flag =
+        c10::utils::check_env("TORCH_CUDNN_SDPA_CACHE_DEBUG") == true;
+    if (flag && count) {
+      TORCH_WARN(
+          "SDPA Cache Called ",
+          count,
+          " times. Hit rate: ",
+          100 * hits / count,
+          "%");
+    }
+    count++;
+    auto it = engine_cache.find(key);
+    if (it != engine_cache.end()) {
+      hits++;
+    }
+    return it;
+  }
+
+  const_iterator end() const {
+    return engine_cache.end();
+  }
+
+  template <typename... Args>
+  std::pair<iterator, bool> try_emplace(const KeyType& key, Args&&... args) {
+    return engine_cache.try_emplace(key, std::forward<Args>(args)...);
+  }
+};
+
+// @eqy: use thread local caches as cuDNN Execution Plans are not guaranteed to
+// be thread safe across all engines see Limitations in
+// https://docs.nvidia.com/deeplearning/cudnn/backend/latest/release-notes.html
+// We also leak the caches to workaround potential teardown race issues.
+
+MHAGraphCache& getMHAGraphCache_() {
+  thread_local MHAGraphCache* instance{new MHAGraphCache()};
+  return *instance;
+}
+
+MHAGraphCache& getMHAGraphBackwardCache_() {
+  thread_local MHAGraphCache* instance{new MHAGraphCache()};
+  return *instance;
+}
+
+namespace {
+
+enum UIDS {
+  Q,
+  K,
+  V,
+  O,
+  BIAS,
+  SCALE,
+  SEED,
+  OFFSET,
+  LSE,
+  DO,
+  DQ,
+  DK,
+  DV,
+  SEQ_LEN_Q,
+  SEQ_LEN_KV,
+  RAG_Q_OFF,
+  RAG_K_OFF,
+  RAG_V_OFF,
+  RAG_O_OFF,
+  RAG_LSE_OFF
+};
+
+// analogous to the same function in Descriptors.h for cuDNN Convolutions...
+auto fixSizeOneDimStrideSDPA(
+    const IntArrayRef sizes,
+    std::vector<int64_t> strides) {
+  int dims = sizes.size();
+  for (int d = 0; d < dims; d++) {
+    int64_t curr_stride = strides[d];
+    if (sizes[d] == 1 && !curr_stride) {
+      curr_stride = 1;
+      for (int d2 = d + 1; d2 < dims; d2++) {
+        curr_stride *= strides[d2];
+      }
+      strides[d] = curr_stride;
+    }
+  }
+  return strides;
+}
+
+} // namespace
+
+std::unique_ptr<fe::graph::Graph> build_graph(
+    int64_t b,
+    int64_t h,
+    int64_t s_q,
+    int64_t s_kv,
+    int64_t d_qk,
+    int64_t d_v,
+    float scaling_factor,
+    bool return_softmaxstats,
+    bool is_causal,
+    double dropout_probability,
+    const Tensor& q,
+    const Tensor& k,
+    const Tensor& v,
+    const std::optional<Tensor>& attn_bias,
+    Tensor& softmaxstats,
+    Tensor& o,
+    Tensor& dropoutseed,
+    Tensor& dropoutoffset,
+    cudnnHandle_t& handle) {
+  auto dtype = fe::DataType_t::HALF;
+  if (q.scalar_type() == kBFloat16) {
+    dtype = fe::DataType_t::BFLOAT16;
+  }
+  auto mha_graph = std::make_unique<fe::graph::Graph>();
+  // We're baking in float accumulation and scale types
+  // in theory the graph may support other types, but they
+  // have not been tested
+  mha_graph->set_io_data_type(dtype)
+      .set_intermediate_data_type(fe::DataType_t::FLOAT)
+      .set_compute_data_type(fe::DataType_t::FLOAT);
+  auto attn_scale =
+      mha_graph->tensor(fe::graph::Tensor_attributes()
+                            .set_uid(SCALE)
+                            .set_name("Attn_scale")
+                            .set_dim({1, 1, 1, 1})
+                            .set_stride({1, 1, 1, 1})
+                            .set_is_pass_by_value(true)
+                            .set_data_type(fe::DataType_t::FLOAT));
+  auto scaled_dot_product_flash_attention_options =
+      fe::graph::SDPA_attributes()
+          .set_name("CUDNN_SDPA")
+#if CUDNN_FRONTEND_VERSION <= 11200
+          .set_is_inference(!return_softmaxstats)
+#else
+          .set_generate_stats(return_softmaxstats)
+#endif
+          .set_causal_mask(is_causal)
+          .set_attn_scale(attn_scale);
+  if (use_ragged_in_dense(q, k, v, o, attn_bias.has_value())) {
+    auto SEQ_LEN_Q_ =
+        mha_graph->tensor(fe::graph::Tensor_attributes()
+                              .set_uid(SEQ_LEN_Q)
+                              .set_name("Seq_q")
+                              .set_dim({b, 1, 1, 1})
+                              .set_stride({1, 1, 1, 1})
+                              .set_data_type(fe::DataType_t::INT32));
+    auto SEQ_LEN_KV_ =
+        mha_graph->tensor(fe::graph::Tensor_attributes()
+                              .set_uid(SEQ_LEN_KV)
+                              .set_name("Seq_kv")
+                              .set_dim({b, 1, 1, 1})
+                              .set_stride({1, 1, 1, 1})
+                              .set_data_type(fe::DataType_t::INT32));
+    scaled_dot_product_flash_attention_options.set_seq_len_q(SEQ_LEN_Q_)
+        .set_seq_len_kv(SEQ_LEN_KV_)
+        .set_padding_mask(true);
+  }
+  if (dropout_probability != 0.0f) {
+    auto seed = mha_graph->tensor(fe::graph::Tensor_attributes()
+                                      .set_uid(SEED)
+                                      .set_name("Seed")
+                                      .set_dim({1, 1, 1, 1})
+                                      .set_stride({1, 1, 1, 1})
+                                      .set_data_type(
+                                          dropoutseed.dtype() == kInt
+                                              ? fe::DataType_t::INT32
+                                              : fe::DataType_t::INT64));
+    auto offset = mha_graph->tensor(fe::graph::Tensor_attributes()
+                                        .set_uid(OFFSET)
+                                        .set_name("Offset")
+                                        .set_dim({1, 1, 1, 1})
+                                        .set_stride({1, 1, 1, 1})
+                                        .set_data_type(
+                                            dropoutoffset.dtype() == kInt
+                                                ? fe::DataType_t::INT32
+                                                : fe::DataType_t::INT64));
+    scaled_dot_product_flash_attention_options.set_dropout(
+        dropout_probability, seed, offset);
+  }
+  auto Q_ = mha_graph->tensor(
+      fe::graph::Tensor_attributes().set_uid(Q).set_name("Q"));
+  auto K_ = mha_graph->tensor(
+      fe::graph::Tensor_attributes().set_uid(K).set_name("K"));
+  auto V_ = mha_graph->tensor(
+      fe::graph::Tensor_attributes().set_uid(V).set_name("V"));
+  if (attn_bias.has_value()) {
+    scaled_dot_product_flash_attention_options.set_bias(
+        mha_graph->tensor(fe::graph::Tensor_attributes()
+                              .set_uid(BIAS)
+                              .set_name("bias")
+                              .set_dim(attn_bias.value().sizes().vec())
+                              .set_stride(attn_bias.value().strides().vec())));
+  }
+
+  auto [O_, Stats] =
+      mha_graph->sdpa(Q_, K_, V_, scaled_dot_product_flash_attention_options);
+  O_->set_uid(O).set_output(true);
+  if (Stats) {
+    Stats->set_uid(LSE)
+        .set_output(true)
+        .set_data_type(fe::DataType_t::FLOAT)
+        .set_stride(softmaxstats.strides().vec());
+  }
+  if (use_ragged_in_dense(q, k, v, o, attn_bias.has_value())) {
+    auto RAG_Q_OFF_ =
+        mha_graph->tensor(fe::graph::Tensor_attributes()
+                              .set_uid(RAG_Q_OFF)
+                              .set_name("cum_seq_q")
+                              .set_dim({b + 1, 1, 1, 1})
+                              .set_stride({1, 1, 1, 1})
+                              .set_data_type(fe::DataType_t::INT32));
+    auto RAG_K_OFF_ =
+        mha_graph->tensor(fe::graph::Tensor_attributes()
+                              .set_uid(RAG_K_OFF)
+                              .set_name("cum_seq_k")
+                              .set_dim({b + 1, 1, 1, 1})
+                              .set_stride({1, 1, 1, 1})
+                              .set_data_type(fe::DataType_t::INT32));
+    auto RAG_V_OFF_ =
+        mha_graph->tensor(fe::graph::Tensor_attributes()
+                              .set_uid(RAG_V_OFF)
+                              .set_name("cum_seq_v")
+                              .set_dim({b + 1, 1, 1, 1})
+                              .set_stride({1, 1, 1, 1})
+                              .set_data_type(fe::DataType_t::INT32));
+    auto RAG_O_OFF_ =
+        mha_graph->tensor(fe::graph::Tensor_attributes()
+                              .set_uid(RAG_O_OFF)
+                              .set_name("cum_seq_o")
+                              .set_dim({b + 1, 1, 1, 1})
+                              .set_stride({1, 1, 1, 1})
+                              .set_data_type(fe::DataType_t::INT32));
+    auto RAG_STATS_OFF_ =
+        mha_graph->tensor(fe::graph::Tensor_attributes()
+                              .set_uid(RAG_LSE_OFF)
+                              .set_name("cum_seq_stats")
+                              .set_dim({b + 1, 1, 1, 1})
+                              .set_stride({1, 1, 1, 1})
+                              .set_data_type(fe::DataType_t::INT32));
+    O_->set_ragged_offset(RAG_O_OFF_);
+    Q_->set_ragged_offset(RAG_Q_OFF_);
+    K_->set_ragged_offset(RAG_K_OFF_);
+    V_->set_ragged_offset(RAG_V_OFF_);
+    auto qsizevec = q.sizes().vec();
+    auto ksizevec = k.sizes().vec();
+    auto vsizevec = v.sizes().vec();
+    auto osizevec = o.sizes().vec();
+    qsizevec[2] = roundup_power2(qsizevec[2]);
+    ksizevec[2] = roundup_power2(ksizevec[2]);
+    vsizevec[2] = roundup_power2(vsizevec[2]);
+    osizevec[2] = roundup_power2(osizevec[2]);
+    // we checked for BSHD contig., set fake strides as cuDNN will complain
+    // if e.g., a ragged dim is smaller than a non-ragged one:
+    // consider HBSD tensor where H is 1
+    Q_->set_dim(qsizevec).set_stride(
+        {INT_MAX, qsizevec[3], qsizevec[1] * qsizevec[3], 1});
+    K_->set_dim(ksizevec).set_stride(
+        {INT_MAX, ksizevec[3], ksizevec[1] * ksizevec[3], 1});
+    V_->set_dim(vsizevec).set_stride(
+        {INT_MAX, vsizevec[3], vsizevec[1] * vsizevec[3], 1});
+    O_->set_dim(osizevec).set_stride(
+        {INT_MAX, osizevec[3], osizevec[1] * osizevec[3], 1});
+    if (Stats) {
+      Stats->set_ragged_offset(RAG_STATS_OFF_);
+      auto statssizevec = softmaxstats.sizes().vec();
+      statssizevec[2] = roundup_power2(statssizevec[2]);
+      Stats->set_dim(statssizevec);
+    }
+  } else {
+    Q_->set_dim(q.sizes().vec())
+        .set_stride(fixSizeOneDimStrideSDPA(q.sizes(), q.strides().vec()));
+    K_->set_dim(k.sizes().vec())
+        .set_stride(fixSizeOneDimStrideSDPA(k.sizes(), k.strides().vec()));
+    V_->set_dim(v.sizes().vec())
+        .set_stride(fixSizeOneDimStrideSDPA(v.sizes(), v.strides().vec()));
+    O_->set_dim(o.sizes().vec())
+        .set_stride(fixSizeOneDimStrideSDPA(o.sizes(), o.strides().vec()));
+    if (Stats) {
+      Stats->set_dim(softmaxstats.sizes().vec());
+    }
+  }
+
+  AT_CUDNN_FRONTEND_CHECK(mha_graph->validate());
+  AT_CUDNN_FRONTEND_CHECK(mha_graph->build_operation_graph(handle));
+  AT_CUDNN_FRONTEND_CHECK(
+      mha_graph->create_execution_plans({fe::HeurMode_t::A}));
+  AT_CUDNN_FRONTEND_CHECK(mha_graph->check_support(handle));
+  AT_CUDNN_FRONTEND_CHECK(mha_graph->build_plans(handle));
+
+  return mha_graph;
+}
+
+std::unique_ptr<fe::graph::Graph> build_graph_nestedtensor(
+    int64_t b,
+    int64_t h_q,
+    int64_t h_k,
+    int64_t h_v,
+    int64_t s_q,
+    int64_t s_kv,
+    int64_t d_qk,
+    int64_t d_v,
+    float scaling_factor,
+    bool return_softmaxstats,
+    bool is_causal,
+    double dropout_probability,
+    const Tensor& cum_seqlen_q,
+    const Tensor& cum_seqlen_kv,
+    const Tensor& q,
+    const Tensor& k,
+    const Tensor& v,
+    const std::optional<Tensor>& attn_bias,
+    Tensor& softmaxstats,
+    Tensor& o,
+    Tensor& dropoutseed,
+    Tensor& dropoutoffset,
+    cudnnHandle_t& handle) {
+  auto dtype = fe::DataType_t::HALF;
+  if (q.scalar_type() == kBFloat16) {
+    dtype = fe::DataType_t::BFLOAT16;
+  }
+  auto mha_graph = std::make_unique<fe::graph::Graph>();
+  // We're baking in float accumulation and scale types
+  // in theory the graph may support other types, but they
+  // have not been tested
+  mha_graph->set_io_data_type(dtype)
+      .set_intermediate_data_type(fe::DataType_t::FLOAT)
+      .set_compute_data_type(fe::DataType_t::FLOAT);
+  auto attn_scale =
+      mha_graph->tensor(fe::graph::Tensor_attributes()
+                            .set_uid(SCALE)
+                            .set_name("Attn_scale")
+                            .set_dim({1, 1, 1, 1})
+                            .set_stride({1, 1, 1, 1})
+                            .set_is_pass_by_value(true)
+                            .set_data_type(fe::DataType_t::FLOAT));
+  auto SEQ_LEN_Q_ =
+      mha_graph->tensor(fe::graph::Tensor_attributes()
+                            .set_uid(SEQ_LEN_Q)
+                            .set_name("Seq_q")
+                            .set_dim({b, 1, 1, 1})
+                            .set_stride({1, 1, 1, 1})
+                            .set_data_type(fe::DataType_t::INT32));
+  auto SEQ_LEN_KV_ =
+      mha_graph->tensor(fe::graph::Tensor_attributes()
+                            .set_uid(SEQ_LEN_KV)
+                            .set_name("Seq_kv")
+                            .set_dim({b, 1, 1, 1})
+                            .set_stride({1, 1, 1, 1})
+                            .set_data_type(fe::DataType_t::INT32));
+
+  auto scaled_dot_product_flash_attention_options =
+      fe::graph::SDPA_attributes()
+          .set_name("CUDNN_SDPA_NESTEDTENSOR")
+#if CUDNN_FRONTEND_VERSION <= 11200
+          .set_is_inference(!return_softmaxstats)
+#else
+          .set_generate_stats(return_softmaxstats)
+#endif
+          .set_causal_mask(is_causal)
+          .set_attn_scale(attn_scale)
+          .set_seq_len_q(SEQ_LEN_Q_)
+          .set_seq_len_kv(SEQ_LEN_KV_)
+          .set_padding_mask(true);
+  if (dropout_probability != 0.0f) {
+    auto seed = mha_graph->tensor(fe::graph::Tensor_attributes()
+                                      .set_uid(SEED)
+                                      .set_name("Seed")
+                                      .set_dim({1, 1, 1, 1})
+                                      .set_stride({1, 1, 1, 1})
+                                      .set_data_type(
+                                          dropoutseed.dtype() == kInt
+                                              ? fe::DataType_t::INT32
+                                              : fe::DataType_t::INT64));
+    auto offset = mha_graph->tensor(fe::graph::Tensor_attributes()
+                                        .set_uid(OFFSET)
+                                        .set_name("Offset")
+                                        .set_dim({1, 1, 1, 1})
+                                        .set_stride({1, 1, 1, 1})
+                                        .set_data_type(
+                                            dropoutoffset.dtype() == kInt
+                                                ? fe::DataType_t::INT32
+                                                : fe::DataType_t::INT64));
+    scaled_dot_product_flash_attention_options.set_dropout(
+        dropout_probability, seed, offset);
+  }
+  // We hardcode BSHD to cuDNN even though the underlying layout is THD
+  auto q_strides = q.strides();
+  auto k_strides = k.strides();
+  auto v_strides = v.strides();
+  // NB: cuDNN API shape is transposed: we pass it nominally as HTD
+  constexpr int strideidx0 = 1;
+  constexpr int strideidx1 = 0;
+  constexpr int strideidx2 = 2;
+  auto Q_ = mha_graph->tensor(fe::graph::Tensor_attributes()
+                                  .set_uid(Q)
+                                  .set_name("Q")
+                                  .set_dim({b, h_q, s_q, d_qk})
+                                  .set_stride(
+                                      {INT_MAX,
+                                       q_strides[strideidx0],
+                                       q_strides[strideidx1],
+                                       q_strides[strideidx2]}));
+  auto K_ = mha_graph->tensor(fe::graph::Tensor_attributes()
+                                  .set_uid(K)
+                                  .set_name("K")
+                                  .set_dim({b, h_k, s_kv, d_qk})
+                                  .set_stride(
+                                      {INT_MAX,
+                                       k_strides[strideidx0],
+                                       k_strides[strideidx1],
+                                       k_strides[strideidx2]}));
+  auto V_ = mha_graph->tensor(fe::graph::Tensor_attributes()
+                                  .set_uid(V)
+                                  .set_name("V")
+                                  .set_dim({b, h_v, s_kv, d_v})
+                                  .set_stride(
+                                      {INT_MAX,
+                                       v_strides[strideidx0],
+                                       v_strides[strideidx1],
+                                       v_strides[strideidx2]}));
+  if (attn_bias.has_value()) {
+    TORCH_CHECK(
+        false,
+        "attn_bias not yet supported with cuDNN Attention and NestedTensor");
+    scaled_dot_product_flash_attention_options.set_bias(
+        mha_graph->tensor(fe::graph::Tensor_attributes()
+                              .set_uid(BIAS)
+                              .set_name("bias")
+                              .set_dim(attn_bias.value().sizes().vec())
+                              .set_stride(attn_bias.value().strides().vec())));
+  }
+  auto RAG_Q_OFF_ =
+      mha_graph->tensor(fe::graph::Tensor_attributes()
+                            .set_uid(RAG_Q_OFF)
+                            .set_name("cum_seq_q")
+                            .set_dim({b + 1, 1, 1, 1})
+                            .set_stride({1, 1, 1, 1})
+                            .set_data_type(fe::DataType_t::INT32));
+  auto RAG_K_OFF_ =
+      mha_graph->tensor(fe::graph::Tensor_attributes()
+                            .set_uid(RAG_K_OFF)
+                            .set_name("cum_seq_k")
+                            .set_dim({b + 1, 1, 1, 1})
+                            .set_stride({1, 1, 1, 1})
+                            .set_data_type(fe::DataType_t::INT32));
+  auto RAG_V_OFF_ =
+      mha_graph->tensor(fe::graph::Tensor_attributes()
+                            .set_uid(RAG_V_OFF)
+                            .set_name("cum_seq_v")
+                            .set_dim({b + 1, 1, 1, 1})
+                            .set_stride({1, 1, 1, 1})
+                            .set_data_type(fe::DataType_t::INT32));
+  auto RAG_O_OFF_ =
+      mha_graph->tensor(fe::graph::Tensor_attributes()
+                            .set_uid(RAG_O_OFF)
+                            .set_name("cum_seq_o")
+                            .set_dim({b + 1, 1, 1, 1})
+                            .set_stride({1, 1, 1, 1})
+                            .set_data_type(fe::DataType_t::INT32));
+  Q_->set_ragged_offset(RAG_Q_OFF_);
+  K_->set_ragged_offset(RAG_K_OFF_);
+  V_->set_ragged_offset(RAG_V_OFF_);
+  auto [O_, Stats] =
+      mha_graph->sdpa(Q_, K_, V_, scaled_dot_product_flash_attention_options);
+  auto o_strides = o.strides();
+  O_->set_output(true)
+      .set_uid(O)
+      .set_dim({b, h_q, s_q, d_v})
+      .set_stride(
+          {INT_MAX,
+           o_strides[strideidx0],
+           o_strides[strideidx1],
+           o_strides[strideidx2]});
+
+  O_->set_ragged_offset(RAG_O_OFF_);
+  if (Stats) {
+    auto RAG_STATS_OFF =
+        mha_graph->tensor(fe::graph::Tensor_attributes()
+                              .set_uid(RAG_LSE_OFF)
+                              .set_name("cum_seq_stats")
+                              .set_dim({b + 1, 1, 1, 1})
+                              .set_stride({1, 1, 1, 1})
+                              .set_data_type(fe::DataType_t::INT32));
+    Stats->set_output(true)
+        .set_uid(LSE)
+        .set_data_type(fe::DataType_t::FLOAT)
+        .set_dim({b, h_q, s_q, 1})
+        .set_stride({h_q * s_q, 1, h_q, 1});
+    Stats->set_ragged_offset(RAG_STATS_OFF);
+  }
+  AT_CUDNN_FRONTEND_CHECK(mha_graph->validate());
+  AT_CUDNN_FRONTEND_CHECK(mha_graph->build_operation_graph(handle));
+  AT_CUDNN_FRONTEND_CHECK(
+      mha_graph->create_execution_plans({fe::HeurMode_t::A}));
+  AT_CUDNN_FRONTEND_CHECK(mha_graph->check_support(handle));
+  AT_CUDNN_FRONTEND_CHECK(mha_graph->build_plans(handle));
+  return mha_graph;
+}
+
+std::unique_ptr<fe::graph::Graph> build_graph_backward(
+    int64_t b,
+    int64_t h,
+    int64_t s_q,
+    int64_t s_kv,
+    int64_t d_qk,
+    int64_t d_v,
+    float scaling_factor,
+    bool is_causal,
+    float dropout_probability,
+    const Tensor& q,
+    const Tensor& k,
+    const Tensor& v,
+    const std::optional<Tensor>& attn_bias,
+    const Tensor& o,
+    const Tensor& dO,
+    const Tensor& softmaxstats,
+    Tensor& dQ,
+    Tensor& dK,
+    Tensor& dV,
+    const Tensor& dropoutseed,
+    const Tensor& dropoutoffset,
+    cudnnHandle_t& handle) {
+  auto dtype = fe::DataType_t::HALF;
+  if (q.scalar_type() == kBFloat16) {
+    dtype = fe::DataType_t::BFLOAT16;
+  }
+  auto mha_graph = std::make_unique<fe::graph::Graph>();
+  // We're baking in float accumulation and scale types
+  // in theory the graph may support other types, but they
+  // have not been tested
+  mha_graph->set_io_data_type(dtype)
+      .set_intermediate_data_type(fe::DataType_t::FLOAT)
+      .set_compute_data_type(fe::DataType_t::FLOAT);
+  auto attn_scale =
+      mha_graph->tensor(fe::graph::Tensor_attributes()
+                            .set_uid(SCALE)
+                            .set_name("Attn_scale")
+                            .set_dim({1, 1, 1, 1})
+                            .set_stride({1, 1, 1, 1})
+                            .set_is_pass_by_value(true)
+                            .set_data_type(fe::DataType_t::FLOAT));
+  auto sdpa_backward_options = fe::graph::SDPA_backward_attributes()
+                                   .set_name("CUDNN_SDPA_BACKWARD")
+                                   .set_causal_mask(is_causal)
+                                   .set_attn_scale(attn_scale);
+  if (use_ragged_in_dense(q, k, v, o, attn_bias.has_value())) {
+    auto SEQ_LEN_Q_ =
+        mha_graph->tensor(fe::graph::Tensor_attributes()
+                              .set_uid(SEQ_LEN_Q)
+                              .set_name("Seq_q")
+                              .set_dim({b, 1, 1, 1})
+                              .set_stride({1, 1, 1, 1})
+                              .set_data_type(fe::DataType_t::INT32));
+    auto SEQ_LEN_KV_ =
+        mha_graph->tensor(fe::graph::Tensor_attributes()
+                              .set_uid(SEQ_LEN_KV)
+                              .set_name("Seq_kv")
+                              .set_dim({b, 1, 1, 1})
+                              .set_stride({1, 1, 1, 1})
+                              .set_data_type(fe::DataType_t::INT32));
+    sdpa_backward_options.set_seq_len_q(SEQ_LEN_Q_)
+        .set_seq_len_kv(SEQ_LEN_KV_)
+        .set_padding_mask(true);
+  }
+
+  auto Q_ = mha_graph->tensor(
+      fe::graph::Tensor_attributes().set_uid(Q).set_name("Q"));
+  auto K_ = mha_graph->tensor(
+      fe::graph::Tensor_attributes().set_uid(K).set_name("K"));
+  auto V_ = mha_graph->tensor(
+      fe::graph::Tensor_attributes().set_uid(V).set_name("V"));
+  if (attn_bias.has_value()) {
+    sdpa_backward_options.set_bias(
+        mha_graph->tensor(fe::graph::Tensor_attributes()
+                              .set_uid(BIAS)
+                              .set_name("bias")
+                              .set_dim(attn_bias.value().sizes().vec())
+                              .set_stride(attn_bias.value().strides().vec())));
+  }
+  if (dropout_probability != 0.0f) {
+    auto seed = mha_graph->tensor(fe::graph::Tensor_attributes()
+                                      .set_uid(SEED)
+                                      .set_name("Seed")
+                                      .set_dim({1, 1, 1, 1})
+                                      .set_stride({1, 1, 1, 1})
+                                      .set_data_type(
+                                          dropoutseed.dtype() == kInt
+                                              ? fe::DataType_t::INT32
+                                              : fe::DataType_t::INT64));
+    auto offset = mha_graph->tensor(fe::graph::Tensor_attributes()
+                                        .set_uid(OFFSET)
+                                        .set_name("Offset")
+                                        .set_dim({1, 1, 1, 1})
+                                        .set_stride({1, 1, 1, 1})
+                                        .set_data_type(
+                                            dropoutoffset.dtype() == kInt
+                                                ? fe::DataType_t::INT32
+                                                : fe::DataType_t::INT64));
+    sdpa_backward_options.set_dropout(dropout_probability, seed, offset);
+  }
+  auto O_ = mha_graph->tensor(
+      fe::graph::Tensor_attributes().set_uid(O).set_name("O"));
+  auto Stats = mha_graph->tensor(fe::graph::Tensor_attributes()
+                                     .set_uid(LSE)
+                                     .set_name("Stats")
+                                     .set_stride(softmaxstats.strides().vec())
+                                     .set_data_type(fe::DataType_t::FLOAT));
+  auto Do = mha_graph->tensor(
+      fe::graph::Tensor_attributes().set_uid(DO).set_name("DO"));
+  auto [Dq, Dk, Dv] = mha_graph->sdpa_backward(
+      Q_, K_, V_, O_, Do, Stats, sdpa_backward_options);
+  Dq->set_uid(DQ).set_output(true);
+  Dk->set_uid(DK).set_output(true);
+  Dv->set_uid(DV).set_output(true);
+  if (use_ragged_in_dense(q, k, v, o, attn_bias.has_value())) {
+    auto RAG_Q_OFF_ =
+        mha_graph->tensor(fe::graph::Tensor_attributes()
+                              .set_uid(RAG_Q_OFF)
+                              .set_name("cum_seq_q")
+                              .set_dim({b + 1, 1, 1, 1})
+                              .set_stride({1, 1, 1, 1})
+                              .set_data_type(fe::DataType_t::INT32));
+    auto RAG_K_OFF_ =
+        mha_graph->tensor(fe::graph::Tensor_attributes()
+                              .set_uid(RAG_K_OFF)
+                              .set_name("cum_seq_k")
+                              .set_dim({b + 1, 1, 1, 1})
+                              .set_stride({1, 1, 1, 1})
+                              .set_data_type(fe::DataType_t::INT32));
+    auto RAG_V_OFF_ =
+        mha_graph->tensor(fe::graph::Tensor_attributes()
+                              .set_uid(RAG_V_OFF)
+                              .set_name("cum_seq_v")
+                              .set_dim({b + 1, 1, 1, 1})
+                              .set_stride({1, 1, 1, 1})
+                              .set_data_type(fe::DataType_t::INT32));
+    auto RAG_O_OFF_ =
+        mha_graph->tensor(fe::graph::Tensor_attributes()
+                              .set_uid(RAG_O_OFF)
+                              .set_name("cum_seq_o")
+                              .set_dim({b + 1, 1, 1, 1})
+                              .set_stride({1, 1, 1, 1})
+                              .set_data_type(fe::DataType_t::INT32));
+    auto RAG_STATS_OFF_ =
+        mha_graph->tensor(fe::graph::Tensor_attributes()
+                              .set_uid(RAG_LSE_OFF)
+                              .set_name("cum_seq_stats")
+                              .set_dim({b + 1, 1, 1, 1})
+                              .set_stride({1, 1, 1, 1})
+                              .set_data_type(fe::DataType_t::INT32));
+    O_->set_ragged_offset(RAG_O_OFF_);
+    Q_->set_ragged_offset(RAG_Q_OFF_);
+    K_->set_ragged_offset(RAG_K_OFF_);
+    V_->set_ragged_offset(RAG_V_OFF_);
+    Dq->set_ragged_offset(RAG_Q_OFF_);
+    Dk->set_ragged_offset(RAG_K_OFF_);
+    Dv->set_ragged_offset(RAG_V_OFF_);
+    Do->set_ragged_offset(RAG_O_OFF_);
+    auto qsizevec = q.sizes().vec();
+    auto ksizevec = k.sizes().vec();
+    auto vsizevec = v.sizes().vec();
+    auto osizevec = o.sizes().vec();
+    qsizevec[2] = roundup_power2(qsizevec[2]);
+    ksizevec[2] = roundup_power2(ksizevec[2]);
+    vsizevec[2] = roundup_power2(vsizevec[2]);
+    osizevec[2] = roundup_power2(osizevec[2]);
+    // see corresponding section in the forward about the hardcoding
+    // of strides here
+    Q_->set_dim(qsizevec).set_stride(
+        {INT_MAX, qsizevec[3], qsizevec[1] * qsizevec[3], 1});
+    K_->set_dim(ksizevec).set_stride(
+        {INT_MAX, ksizevec[3], ksizevec[1] * ksizevec[3], 1});
+    V_->set_dim(vsizevec).set_stride(
+        {INT_MAX, vsizevec[3], vsizevec[1] * vsizevec[3], 1});
+    O_->set_dim(osizevec).set_stride(
+        {INT_MAX, osizevec[3], osizevec[1] * osizevec[3], 1});
+    // should be identical to their non-d counterparts
+    Dq->set_dim(qsizevec).set_stride(
+        {INT_MAX, qsizevec[3], qsizevec[1] * qsizevec[3], 1});
+    Dk->set_dim(ksizevec).set_stride(
+        {INT_MAX, ksizevec[3], ksizevec[1] * ksizevec[3], 1});
+    Dv->set_dim(vsizevec).set_stride(
+        {INT_MAX, vsizevec[3], vsizevec[1] * vsizevec[3], 1});
+    Do->set_dim(osizevec).set_stride(
+        {INT_MAX, osizevec[3], osizevec[1] * osizevec[3], 1});
+
+    Stats->set_ragged_offset(RAG_STATS_OFF_);
+    auto statssizevec = softmaxstats.sizes().vec();
+    statssizevec[2] = roundup_power2(statssizevec[2]);
+    Stats->set_dim(statssizevec);
+  } else {
+    O_->set_dim(o.sizes().vec()).set_stride(o.strides().vec());
+    Q_->set_dim(q.sizes().vec()).set_stride(q.strides().vec());
+    K_->set_dim(k.sizes().vec()).set_stride(k.strides().vec());
+    V_->set_dim(v.sizes().vec()).set_stride(v.strides().vec());
+    Dq->set_dim(dQ.sizes().vec()).set_stride(dQ.strides().vec());
+    Dk->set_dim(dK.sizes().vec()).set_stride(dK.strides().vec());
+    Dv->set_dim(dV.sizes().vec()).set_stride(dV.strides().vec());
+    Do->set_dim(dO.sizes().vec()).set_stride(dO.strides().vec());
+    Stats->set_dim(softmaxstats.sizes().vec());
+  }
+
+  AT_CUDNN_FRONTEND_CHECK(mha_graph->validate());
+  AT_CUDNN_FRONTEND_CHECK(mha_graph->build_operation_graph(handle));
+  AT_CUDNN_FRONTEND_CHECK(
+      mha_graph->create_execution_plans({fe::HeurMode_t::A}));
+  AT_CUDNN_FRONTEND_CHECK(mha_graph->check_support(handle));
+  AT_CUDNN_FRONTEND_CHECK(mha_graph->build_plans(handle));
+  return mha_graph;
+}
+
+std::unique_ptr<fe::graph::Graph> build_graph_backward_nestedtensor(
+    int64_t b,
+    int64_t h_q,
+    int64_t h_k,
+    int64_t h_v,
+    int64_t s_q,
+    int64_t s_kv,
+    int64_t d_qk,
+    int64_t d_v,
+    float scaling_factor,
+    bool is_causal,
+    float dropout_probability,
+    const Tensor& cum_seqlen_q,
+    const Tensor& cum_seqlen_kv,
+    const Tensor& q,
+    const Tensor& k,
+    const Tensor& v,
+    const std::optional<Tensor>& attn_bias,
+    const Tensor& o,
+    const Tensor& dO,
+    const Tensor& softmaxstats,
+    Tensor& dQ,
+    Tensor& dK,
+    Tensor& dV,
+    const Tensor& dropoutseed,
+    const Tensor& dropoutoffset,
+    cudnnHandle_t& handle) {
+  auto dtype = fe::DataType_t::HALF;
+  if (q.scalar_type() == kBFloat16) {
+    dtype = fe::DataType_t::BFLOAT16;
+  }
+  auto mha_graph = std::make_unique<fe::graph::Graph>();
+  // We're baking in float accumulation and scale types
+  // in theory the graph may support other types, but they
+  // have not been tested
+  mha_graph->set_io_data_type(dtype)
+      .set_intermediate_data_type(fe::DataType_t::FLOAT)
+      .set_compute_data_type(fe::DataType_t::FLOAT);
+  auto attn_scale =
+      mha_graph->tensor(fe::graph::Tensor_attributes()
+                            .set_uid(SCALE)
+                            .set_name("Attn_scale")
+                            .set_dim({1, 1, 1, 1})
+                            .set_stride({1, 1, 1, 1})
+                            .set_is_pass_by_value(true)
+                            .set_data_type(fe::DataType_t::FLOAT));
+
+  auto SEQ_LEN_Q_ =
+      mha_graph->tensor(fe::graph::Tensor_attributes()
+                            .set_uid(SEQ_LEN_Q)
+                            .set_name("Seq_q")
+                            .set_dim({b, 1, 1, 1})
+                            .set_stride({1, 1, 1, 1})
+                            .set_data_type(fe::DataType_t::INT32));
+  auto SEQ_LEN_KV_ =
+      mha_graph->tensor(fe::graph::Tensor_attributes()
+                            .set_uid(SEQ_LEN_KV)
+                            .set_name("Seq_kv")
+                            .set_dim({b, 1, 1, 1})
+                            .set_stride({1, 1, 1, 1})
+                            .set_data_type(fe::DataType_t::INT32));
+  auto sdpa_backward_options = fe::graph::SDPA_backward_attributes()
+                                   .set_name("CUDNN_SDPA_NESTEDTENSOR_BACKWARD")
+                                   .set_causal_mask(is_causal)
+                                   .set_attn_scale(attn_scale)
+                                   .set_seq_len_q(SEQ_LEN_Q_)
+                                   .set_seq_len_kv(SEQ_LEN_KV_)
+                                   .set_padding_mask(true);
+  if (dropout_probability != 0.0f) {
+    auto seed = mha_graph->tensor(fe::graph::Tensor_attributes()
+                                      .set_uid(SEED)
+                                      .set_name("Seed")
+                                      .set_dim({1, 1, 1, 1})
+                                      .set_stride({1, 1, 1, 1})
+                                      .set_data_type(
+                                          dropoutseed.dtype() == kInt
+                                              ? fe::DataType_t::INT32
+                                              : fe::DataType_t::INT64));
+    auto offset = mha_graph->tensor(fe::graph::Tensor_attributes()
+                                        .set_uid(OFFSET)
+                                        .set_name("Offset")
+                                        .set_dim({1, 1, 1, 1})
+                                        .set_stride({1, 1, 1, 1})
+                                        .set_data_type(
+                                            dropoutoffset.dtype() == kInt
+                                                ? fe::DataType_t::INT32
+                                                : fe::DataType_t::INT64));
+    sdpa_backward_options.set_dropout(dropout_probability, seed, offset);
+  }
+  auto q_strides = q.strides();
+  auto k_strides = k.strides();
+  auto v_strides = v.strides();
+  // NB: cuDNN API shape is transposed
+  constexpr int strideidx0 = 1;
+  constexpr int strideidx1 = 0;
+  constexpr int strideidx2 = 2;
+  auto Q_ = mha_graph->tensor(fe::graph::Tensor_attributes()
+                                  .set_uid(Q)
+                                  .set_name("Q")
+                                  .set_dim({b, h_q, s_q, d_qk})
+                                  .set_stride(
+                                      {INT_MAX,
+                                       q_strides[strideidx0],
+                                       q_strides[strideidx1],
+                                       q_strides[strideidx2]}));
+  auto K_ = mha_graph->tensor(fe::graph::Tensor_attributes()
+                                  .set_uid(K)
+                                  .set_name("K")
+                                  .set_dim({b, h_k, s_kv, d_qk})
+                                  .set_stride(
+                                      {INT_MAX,
+                                       k_strides[strideidx0],
+                                       k_strides[strideidx1],
+                                       k_strides[strideidx2]}));
+  auto V_ = mha_graph->tensor(fe::graph::Tensor_attributes()
+                                  .set_uid(V)
+                                  .set_name("V")
+                                  .set_dim({b, h_v, s_kv, d_v})
+                                  .set_stride(
+                                      {INT_MAX,
+                                       v_strides[strideidx0],
+                                       v_strides[strideidx1],
+                                       v_strides[strideidx2]}));
+  auto o_strides = o.strides();
+  auto O_ = mha_graph->tensor(fe::graph::Tensor_attributes()
+                                  .set_uid(O)
+                                  .set_name("O")
+                                  .set_dim({b, h_q, s_q, d_v})
+                                  .set_stride(
+                                      {INT_MAX,
+                                       o_strides[strideidx0],
+                                       o_strides[strideidx1],
+                                       o_strides[strideidx2]}));
+
+  if (attn_bias.has_value()) {
+    TORCH_CHECK(
+        false,
+        "attn_bias not yet supported with cuDNN Attention and NestedTensor");
+    sdpa_backward_options.set_bias(
+        mha_graph->tensor(fe::graph::Tensor_attributes()
+                              .set_uid(BIAS)
+                              .set_name("bias")
+                              .set_dim(attn_bias.value().sizes().vec())
+                              .set_stride(attn_bias.value().strides().vec())));
+  }
+  auto RAG_Q_OFF_ =
+      mha_graph->tensor(fe::graph::Tensor_attributes()
+                            .set_uid(RAG_Q_OFF)
+                            .set_name("cum_seq_q")
+                            .set_dim({b + 1, 1, 1, 1})
+                            .set_stride({1, 1, 1, 1})
+                            .set_data_type(fe::DataType_t::INT32));
+  auto RAG_K_OFF_ =
+      mha_graph->tensor(fe::graph::Tensor_attributes()
+                            .set_uid(RAG_K_OFF)
+                            .set_name("cum_seq_k")
+                            .set_dim({b + 1, 1, 1, 1})
+                            .set_stride({1, 1, 1, 1})
+                            .set_data_type(fe::DataType_t::INT32));
+  auto RAG_V_OFF_ =
+      mha_graph->tensor(fe::graph::Tensor_attributes()
+                            .set_uid(RAG_V_OFF)
+                            .set_name("cum_seq_v")
+                            .set_dim({b + 1, 1, 1, 1})
+                            .set_stride({1, 1, 1, 1})
+                            .set_data_type(fe::DataType_t::INT32));
+  auto RAG_O_OFF_ =
+      mha_graph->tensor(fe::graph::Tensor_attributes()
+                            .set_uid(RAG_O_OFF)
+                            .set_name("cum_seq_o")
+                            .set_dim({b + 1, 1, 1, 1})
+                            .set_stride({1, 1, 1, 1})
+                            .set_data_type(fe::DataType_t::INT32));
+  auto RAG_STATS_OFF_ =
+      mha_graph->tensor(fe::graph::Tensor_attributes()
+                            .set_uid(RAG_LSE_OFF)
+                            .set_name("cum_seq_stats")
+                            .set_dim({b + 1, 1, 1, 1})
+                            .set_stride({1, 1, 1, 1})
+                            .set_data_type(fe::DataType_t::INT32));
+  O_->set_ragged_offset(RAG_O_OFF_);
+  Q_->set_ragged_offset(RAG_Q_OFF_);
+  K_->set_ragged_offset(RAG_K_OFF_);
+  V_->set_ragged_offset(RAG_V_OFF_);
+  auto STATS = mha_graph->tensor(fe::graph::Tensor_attributes()
+                                     .set_uid(LSE)
+                                     .set_name("stats")
+                                     .set_dim({b, h_q, s_q, 1})
+                                     .set_stride({s_q * h_q, 1, h_q, 1})
+                                     .set_data_type(fe::DataType_t::FLOAT));
+  STATS->set_ragged_offset(RAG_STATS_OFF_);
+  auto do_strides = dO.strides();
+  auto DO_ = mha_graph->tensor(fe::graph::Tensor_attributes()
+                                   .set_ragged_offset(RAG_O_OFF_)
+                                   .set_uid(DO)
+                                   .set_name("DO")
+                                   .set_dim({b, h_q, s_q, d_v})
+                                   .set_stride(
+                                       {INT_MAX,
+                                        do_strides[strideidx0],
+                                        do_strides[strideidx1],
+                                        do_strides[strideidx2]}));
+  auto [Dq, Dk, Dv] = mha_graph->sdpa_backward(
+      Q_, K_, V_, O_, DO_, STATS, sdpa_backward_options);
+  Dq->set_output(true)
+      .set_uid(DQ)
+      .set_ragged_offset(RAG_Q_OFF_)
+      .set_dim({b, h_q, s_q, d_qk})
+      .set_stride(
+          {INT_MAX,
+           q_strides[strideidx0],
+           q_strides[strideidx1],
+           q_strides[strideidx2]});
+  Dk->set_output(true)
+      .set_uid(DK)
+      .set_ragged_offset(RAG_K_OFF_)
+      .set_dim({b, h_k, s_kv, d_qk})
+      .set_stride(
+          {INT_MAX,
+           k_strides[strideidx0],
+           k_strides[strideidx1],
+           k_strides[strideidx2]});
+  Dv->set_output(true)
+      .set_uid(DV)
+      .set_ragged_offset(RAG_V_OFF_)
+      .set_dim({b, h_v, s_kv, d_v})
+      .set_stride(
+          {INT_MAX,
+           v_strides[strideidx0],
+           v_strides[strideidx1],
+           v_strides[strideidx2]});
+
+  AT_CUDNN_FRONTEND_CHECK(mha_graph->validate());
+  AT_CUDNN_FRONTEND_CHECK(mha_graph->build_operation_graph(handle));
+  AT_CUDNN_FRONTEND_CHECK(
+      mha_graph->create_execution_plans({fe::HeurMode_t::A}));
+  AT_CUDNN_FRONTEND_CHECK(mha_graph->check_support(handle));
+  AT_CUDNN_FRONTEND_CHECK(mha_graph->build_plans(handle));
+  return mha_graph;
+}
+
+void run_cudnn_SDP_fprop(
+    int64_t b,
+    int64_t h,
+    int64_t s_q,
+    int64_t s_kv,
+    int64_t d_qk,
+    int64_t d_v,
+    float scaling_factor,
+    bool return_softmaxstats,
+    bool is_causal,
+    double dropout_probability,
+    const Tensor& q,
+    const Tensor& k,
+    const Tensor& v,
+    const std::optional<Tensor>& attn_bias,
+    Tensor& softmaxstats,
+    Tensor& o,
+    Tensor& dropoutseed,
+    Tensor& dropoutoffset) {
+  // do nothing if we got 0-element tensors
+  if (!q.numel() || !k.numel() || !v.numel()) {
+    return;
+  }
+  Tensor seqlen_q, seqlen_kv;
+  Tensor rag_off_q, rag_off_k, rag_off_v, rag_off_o, rag_off_lse;
+
+  if (!o.defined()) {
+    // q is passed to us in BHSD dim order
+    alloc_with_matching_layout(q, o, {b, h, s_q, d_v});
+  }
+  bool use_ragged = use_ragged_in_dense(q, k, v, o, attn_bias.has_value());
+  if (return_softmaxstats && !softmaxstats.defined()) {
+    // TODO(eqy): investigate why cuDNN doesn't like BSH layout softmaxstats
+    if (!use_ragged) {
+      softmaxstats = at::empty({b, h, s_q, 1}, q.options().dtype(kFloat));
+    } else {
+      softmaxstats =
+          at::empty({b, s_q, h, 1}, q.options().dtype(kFloat)).transpose(1, 2);
+    }
+  }
+
+  if (use_ragged) {
+    seqlen_q = at::full({b, 1, 1, 1}, s_q, q.options().dtype(kInt));
+    seqlen_kv = at::full({b, 1, 1, 1}, s_kv, q.options().dtype(kInt));
+    auto cum_seqlen_q = at::full({b + 1, 1, 1, 1}, s_q, q.options().dtype(kInt))
+                            .cumsum(0, kInt)
+                            .add_(-s_q);
+    auto cum_seqlen_kv =
+        at::full({b + 1, 1, 1, 1}, s_kv, q.options().dtype(kInt))
+            .cumsum(0, kInt)
+            .add_(-s_kv);
+    rag_off_q = cum_seqlen_q.mul(q.stride(-2));
+    rag_off_k = cum_seqlen_kv.mul(k.stride(-2));
+    rag_off_v = cum_seqlen_kv.mul(v.stride(-2));
+    rag_off_o = cum_seqlen_q.mul(o.stride(-2));
+    if (return_softmaxstats) {
+      rag_off_lse = cum_seqlen_q.mul(softmaxstats.stride(-2));
+    }
+  }
+
+  const auto dprops = at::cuda::getCurrentDeviceProperties();
+  auto _dropoutseed = dropoutseed;
+  auto _dropoutoffset = dropoutoffset;
+  // cuDNN dropout bug requires these to be in int64
+  if (dprops->major == 10 && dprops->minor == 0) {
+    _dropoutseed = dropoutseed.to(kLong);
+    _dropoutoffset = dropoutoffset.to(kLong);
+  }
+
+  cudnnHandle_t handle = getCudnnHandle();
+
+  // NB: The key initialization will round up sequence length, stride data etc.
+  // if use_ragged_in_dense is enabled (to allow multiple sequence lengths to
+  // reuse the same cached value/graph)
+  MHACacheKeyWrapper key(
+      b,
+      h,
+      s_q,
+      s_kv,
+      d_qk,
+      d_v,
+      q,
+      k,
+      v,
+      attn_bias,
+      dropout_probability,
+      is_causal,
+      return_softmaxstats,
+      false);
+  auto [cache_it, not_found] = getMHAGraphCache_().try_emplace(key, nullptr);
+  if (not_found) {
+    cache_it->second = build_graph(
+        b,
+        h,
+        s_q,
+        s_kv,
+        d_qk,
+        d_v,
+        scaling_factor,
+        return_softmaxstats,
+        is_causal,
+        dropout_probability,
+        q,
+        k,
+        v,
+        attn_bias,
+        softmaxstats,
+        o,
+        _dropoutseed,
+        _dropoutoffset,
+        handle);
+  }
+  const fe::graph::Graph& mha_graph = *cache_it->second;
+  std::unordered_map<int64_t, void*> variant_pack = {
+      {Q, q.mutable_data_ptr()},
+      {K, k.mutable_data_ptr()},
+      {V, v.mutable_data_ptr()},
+      {SCALE, &scaling_factor},
+      {O, o.mutable_data_ptr()}};
+  if (return_softmaxstats) {
+    variant_pack[LSE] = softmaxstats.mutable_data_ptr();
+  }
+  if (attn_bias.has_value()) {
+    variant_pack[BIAS] = attn_bias.value().mutable_data_ptr();
+  }
+  if (dropout_probability != 0.0f) {
+    variant_pack[SEED] = _dropoutseed.mutable_data_ptr();
+    variant_pack[OFFSET] = _dropoutoffset.mutable_data_ptr();
+  }
+  if (use_ragged_in_dense(q, k, v, o, attn_bias.has_value())) {
+    variant_pack[SEQ_LEN_Q] = seqlen_q.mutable_data_ptr();
+    variant_pack[SEQ_LEN_KV] = seqlen_kv.mutable_data_ptr();
+    variant_pack[RAG_Q_OFF] = rag_off_q.mutable_data_ptr();
+    variant_pack[RAG_K_OFF] = rag_off_k.mutable_data_ptr();
+    variant_pack[RAG_V_OFF] = rag_off_v.mutable_data_ptr();
+    variant_pack[RAG_O_OFF] = rag_off_o.mutable_data_ptr();
+    if (return_softmaxstats) {
+      variant_pack[RAG_LSE_OFF] = rag_off_lse.mutable_data_ptr();
+    }
+  }
+  auto workspace_size = mha_graph.get_workspace_size();
+  auto workspace_ptr =
+      c10::cuda::CUDACachingAllocator::get()->allocate(workspace_size);
+  TORCH_CHECK(
+      mha_graph.execute(handle, variant_pack, workspace_ptr.get()).is_good());
+}
+
+void run_cudnn_SDP_fprop_nestedtensor(
+    int64_t b,
+    int64_t h_q,
+    int64_t h_k,
+    int64_t h_v,
+    int64_t s_q,
+    int64_t s_kv,
+    int64_t d_qk,
+    int64_t d_v,
+    float scaling_factor,
+    bool return_softmaxstats,
+    bool is_causal,
+    double dropout_probability,
+    const Tensor& cum_seqlen_q,
+    const Tensor& cum_seqlen_kv,
+    const Tensor& q,
+    const Tensor& k,
+    const Tensor& v,
+    const std::optional<Tensor>& attn_bias,
+    Tensor& softmaxstats,
+    Tensor& o,
+    Tensor& dropoutseed,
+    Tensor& dropoutoffset) {
+  cudnnHandle_t handle = getCudnnHandle();
+  // do nothing if we got 0-element tensors
+  if (!q.numel() || !k.numel() || !v.numel()) {
+    return;
+  }
+
+  if (!o.defined()) {
+    o = at::empty({q.size(0), h_q, d_v}, q.options());
+  }
+
+  if (return_softmaxstats && !softmaxstats.defined()) {
+    softmaxstats = at::empty({q.size(0), h_q, 1}, q.options().dtype(kFloat));
+  }
+
+  MHACacheKeyWrapper key(
+      b,
+      h_q,
+      s_q, // max-seqlen-q
+      s_kv, // max-seqlen-kv
+      d_qk,
+      d_v,
+      q,
+      k,
+      v,
+      attn_bias,
+      dropout_probability,
+      is_causal,
+      return_softmaxstats,
+      true);
+
+  MHAGraphCache& cache = getMHAGraphCache_();
+  auto cache_it = cache.find(key);
+  std::unique_ptr<fe::graph::Graph> mha_graph_storage;
+  if (cache_it == cache.end()) {
+    mha_graph_storage = build_graph_nestedtensor(
+        b,
+        h_q,
+        h_k,
+        h_v,
+        s_q,
+        s_kv,
+        d_qk,
+        d_v,
+        scaling_factor,
+        return_softmaxstats,
+        is_causal,
+        dropout_probability,
+        cum_seqlen_q,
+        cum_seqlen_kv,
+        q,
+        k,
+        v,
+        attn_bias,
+        softmaxstats,
+        o,
+        dropoutseed,
+        dropoutoffset,
+        handle);
+  }
+  const fe::graph::Graph& mha_graph =
+      mha_graph_storage ? *mha_graph_storage : *cache_it->second;
+
+  auto seqlen_q = at::diff(cum_seqlen_q, 1, 0);
+  auto seqlen_kv = at::diff(cum_seqlen_kv, 1, 0);
+  auto rag_q_off = cum_seqlen_q.mul(q.stride(-3));
+  auto rag_k_off = cum_seqlen_kv.mul(k.stride(-3));
+  auto rag_v_off = cum_seqlen_kv.mul(v.stride(-3));
+  auto rag_o_off = cum_seqlen_q.mul(o.stride(-3));
+  auto rag_stats_off = cum_seqlen_q.mul(h_q);
+  std::unordered_map<int64_t, void*> variant_pack = {
+      {Q, q.mutable_data_ptr()},
+      {K, k.mutable_data_ptr()},
+      {V, v.mutable_data_ptr()},
+      {SCALE, &scaling_factor},
+      {O, o.mutable_data_ptr()},
+      {RAG_Q_OFF, rag_q_off.mutable_data_ptr()},
+      {RAG_O_OFF, rag_o_off.mutable_data_ptr()},
+      {RAG_K_OFF, rag_k_off.mutable_data_ptr()},
+      {RAG_V_OFF, rag_v_off.mutable_data_ptr()},
+      {SEQ_LEN_Q, seqlen_q.mutable_data_ptr()},
+      {SEQ_LEN_KV, seqlen_kv.mutable_data_ptr()}};
+  if (return_softmaxstats) {
+    variant_pack[LSE] = softmaxstats.mutable_data_ptr();
+    variant_pack[RAG_LSE_OFF] = rag_stats_off.mutable_data_ptr();
+  }
+  if (dropout_probability != 0.0f) {
+    variant_pack[SEED] = dropoutseed.mutable_data_ptr();
+    variant_pack[OFFSET] = dropoutoffset.mutable_data_ptr();
+  }
+  if (attn_bias.has_value()) {
+    TORCH_CHECK(false, "bias not supported with nestedtensor");
+  }
+  auto workspace_size = mha_graph.get_workspace_size();
+  auto workspace_ptr =
+      c10::cuda::CUDACachingAllocator::get()->allocate(workspace_size);
+  TORCH_CHECK(
+      mha_graph.execute(handle, variant_pack, workspace_ptr.get()).is_good());
+}
+
+void run_cudnn_SDP_bprop(
+    int64_t b,
+    int64_t h,
+    int64_t s_q,
+    int64_t s_kv,
+    int64_t d_qk,
+    int64_t d_v,
+    float scaling_factor,
+    bool is_causal,
+    float dropout_probability,
+    const Tensor& q,
+    const Tensor& k,
+    const Tensor& v,
+    const std::optional<Tensor>& attn_bias,
+    const Tensor& o,
+    const Tensor& dO,
+    const Tensor& softmaxstats,
+    Tensor& dQ,
+    Tensor& dK,
+    Tensor& dV,
+    const Tensor& dropoutseed,
+    const Tensor& dropoutoffset) {
+  // do nothing if we got 0-element tensors
+  if (!q.numel() || !k.numel() || !v.numel() || !o.numel() || !dO.numel() ||
+      !softmaxstats.numel()) {
+    return;
+  }
+  Tensor seqlen_q, seqlen_kv;
+  Tensor rag_off_q, rag_off_k, rag_off_v, rag_off_o, rag_off_lse;
+
+  auto dprops = at::cuda::getCurrentDeviceProperties();
+  auto _dropoutseed = dropoutseed;
+  auto _dropoutoffset = dropoutoffset;
+  // cuDNN dropout bug requires these to be in int64
+  if (dprops->major == 10 && dprops->minor == 0) {
+    _dropoutseed = dropoutseed.to(kLong);
+    _dropoutoffset = dropoutoffset.to(kLong);
+  }
+
+  Tensor dO_ = dO;
+// cuDNN < 9.5.1 assumes gradOutput has same strides as Output
+#if defined(CUDNN_VERSION) && CUDNN_VERSION < 90501
+  if (!same_strides(o, dO)) {
+    TORCH_WARN_ONCE(
+        "cuDNN SDPA backward got grad_output.strides() != output.strides(), "
+        "attempting to materialize a grad_output with matching strides."
+        "Consider upgrading cuDNN v9.5.1+ to avoid this warning.");
+    permute_to_matching_layout(o, dO_);
+  }
+  TORCH_INTERNAL_ASSERT(
+      same_strides(o, dO_),
+      "cuDNN SDPA expected grad_output.strides() == output.strides(), "
+      "the previous step probably failed to materialize a grad_output "
+      "with matching strides...");
+#else
+  const auto innermost_dO_stride = dO.strides()[dO.strides().size() - 1];
+  if (innermost_dO_stride != 1 ||
+      use_ragged_in_dense(q, k, v, o, attn_bias.has_value())) {
+    permute_to_matching_layout(o, dO_);
+  }
+#endif
+  if (use_ragged_in_dense(q, k, v, o, attn_bias.has_value())) {
+    seqlen_q = at::full({b, 1, 1, 1}, s_q, q.options().dtype(kInt));
+    seqlen_kv = at::full({b, 1, 1, 1}, s_kv, q.options().dtype(kInt));
+    auto cum_seqlen_q = at::full({b + 1, 1, 1, 1}, s_q, q.options().dtype(kInt))
+                            .cumsum(0, kInt)
+                            .add_(-s_q);
+    auto cum_seqlen_kv =
+        at::full({b + 1, 1, 1, 1}, s_kv, q.options().dtype(kInt))
+            .cumsum(0, kInt)
+            .add_(-s_kv);
+    rag_off_q = cum_seqlen_q.mul(q.stride(-2));
+    rag_off_k = cum_seqlen_kv.mul(k.stride(-2));
+    rag_off_v = cum_seqlen_kv.mul(v.stride(-2));
+    rag_off_o = cum_seqlen_q.mul(o.stride(-2));
+    rag_off_lse = cum_seqlen_q.mul(softmaxstats.stride(-2));
+  }
+
+  cudnnHandle_t handle = getCudnnHandle();
+  MHACacheKeyWrapper key(
+      b,
+      h,
+      s_q,
+      s_kv,
+      d_qk,
+      d_v,
+      q,
+      k,
+      v,
+      attn_bias,
+      dropout_probability,
+      is_causal,
+      true,
+      false);
+  auto [cache_it, not_found] =
+      getMHAGraphBackwardCache_().try_emplace(key, nullptr);
+  if (not_found) {
+    cache_it->second = build_graph_backward(
+        b,
+        h,
+        s_q,
+        s_kv,
+        d_qk,
+        d_v,
+        scaling_factor,
+        is_causal,
+        dropout_probability,
+        q,
+        k,
+        v,
+        attn_bias,
+        o,
+        dO_,
+        softmaxstats,
+        dQ,
+        dK,
+        dV,
+        _dropoutseed,
+        _dropoutoffset,
+        handle);
+  }
+  const fe::graph::Graph& mha_graph = *cache_it->second;
+
+  std::unordered_map<int64_t, void*> variant_pack = {
+      // inputs
+      {Q, q.mutable_data_ptr()},
+      {K, k.mutable_data_ptr()},
+      {V, v.mutable_data_ptr()},
+      {O, o.mutable_data_ptr()},
+      {DO, dO_.mutable_data_ptr()},
+      {LSE, softmaxstats.mutable_data_ptr()},
+      // outputs
+      {DQ, dQ.mutable_data_ptr()},
+      {DK, dK.mutable_data_ptr()},
+      {DV, dV.mutable_data_ptr()},
+      {SCALE, &scaling_factor}};
+  if (dropout_probability != 0.0f) {
+    variant_pack[SEED] = _dropoutseed.mutable_data_ptr();
+    variant_pack[OFFSET] = _dropoutoffset.mutable_data_ptr();
+  }
+  if (attn_bias.has_value()) {
+    variant_pack[BIAS] = attn_bias.value().mutable_data_ptr();
+  }
+  if (use_ragged_in_dense(q, k, v, o, attn_bias.has_value())) {
+    variant_pack[SEQ_LEN_Q] = seqlen_q.mutable_data_ptr();
+    variant_pack[SEQ_LEN_KV] = seqlen_kv.mutable_data_ptr();
+    variant_pack[RAG_Q_OFF] = rag_off_q.mutable_data_ptr();
+    variant_pack[RAG_K_OFF] = rag_off_k.mutable_data_ptr();
+    variant_pack[RAG_V_OFF] = rag_off_v.mutable_data_ptr();
+    variant_pack[RAG_O_OFF] = rag_off_o.mutable_data_ptr();
+    variant_pack[RAG_LSE_OFF] = rag_off_lse.mutable_data_ptr();
+  }
+
+  auto workspace_size = mha_graph.get_workspace_size();
+  auto workspace_ptr =
+      c10::cuda::CUDACachingAllocator::get()->allocate(workspace_size);
+  TORCH_CHECK(!workspace_size || workspace_ptr.get());
+  TORCH_CHECK(
+      mha_graph.execute(handle, variant_pack, workspace_ptr.get()).is_good());
+}
+
+void run_cudnn_SDP_bprop_nestedtensor(
+    int64_t b,
+    int64_t h_q,
+    int64_t h_k,
+    int64_t h_v,
+    int64_t s_q,
+    int64_t s_kv,
+    int64_t d_qk,
+    int64_t d_v,
+    float scaling_factor,
+    bool is_causal,
+    float dropout_probability,
+    const Tensor& cum_seqlen_q,
+    const Tensor& cum_seqlen_kv,
+    const Tensor& q,
+    const Tensor& k,
+    const Tensor& v,
+    const std::optional<Tensor>& attn_bias,
+    const Tensor& o,
+    const Tensor& dO,
+    const Tensor& softmaxstats,
+    Tensor& dQ,
+    Tensor& dK,
+    Tensor& dV,
+    const Tensor& dropoutseed,
+    const Tensor& dropoutoffset) {
+  // do nothing if we got 0-element tensors
+  if (!q.numel() || !k.numel() || !v.numel() || !o.numel() || !dO.numel() ||
+      !softmaxstats.numel()) {
+    return;
+  }
+
+  Tensor dO_ = dO;
+  const auto innermost_dO_stride = dO.strides()[dO.strides().size() - 1];
+  if (innermost_dO_stride != 1) {
+    permute_to_matching_layout(o, dO_);
+  }
+
+  auto seqlen_q = at::diff(cum_seqlen_q, 1, 0);
+  auto seqlen_kv = at::diff(cum_seqlen_kv, 1, 0);
+  auto rag_q_off = cum_seqlen_q.mul(q.stride(-3));
+  auto rag_k_off = cum_seqlen_kv.mul(k.stride(-3));
+  auto rag_v_off = cum_seqlen_kv.mul(v.stride(-3));
+  auto rag_o_off = cum_seqlen_q.mul(o.stride(-3));
+  auto rag_stats_off = cum_seqlen_q.mul(h_q);
+
+  auto dprops = at::cuda::getCurrentDeviceProperties();
+  auto _dropoutseed = dropoutseed;
+  auto _dropoutoffset = dropoutoffset;
+  // cuDNN dropout bug requires these to be in int64
+  if (dprops->major == 10 && dprops->minor == 0) {
+    _dropoutseed = dropoutseed.to(kLong);
+    _dropoutoffset = dropoutoffset.to(kLong);
+  }
+
+  cudnnHandle_t handle = getCudnnHandle();
+
+  MHACacheKeyWrapper key(
+      b,
+      h_q,
+      s_q, // max-seqlen-q
+      s_kv, // max-seqlen-kv
+      d_qk,
+      d_v,
+      q,
+      k,
+      v,
+      attn_bias,
+      dropout_probability,
+      is_causal,
+      true,
+      true);
+
+  MHAGraphCache& cache = getMHAGraphCache_();
+  auto cache_it = cache.find(key);
+  std::unique_ptr<fe::graph::Graph> mha_graph_storage;
+  if (cache_it == cache.end()) {
+    mha_graph_storage = build_graph_backward_nestedtensor(
+        b,
+        h_q,
+        h_k,
+        h_v,
+        s_q,
+        s_kv,
+        d_qk,
+        d_v,
+        scaling_factor,
+        is_causal,
+        dropout_probability,
+        cum_seqlen_q,
+        cum_seqlen_kv,
+        q,
+        k,
+        v,
+        attn_bias,
+        o,
+        dO_,
+        softmaxstats,
+        dQ,
+        dK,
+        dV,
+        dropoutseed,
+        dropoutoffset,
+        handle);
+  }
+  const fe::graph::Graph& mha_graph =
+      mha_graph_storage ? *mha_graph_storage : *cache_it->second;
+
+  std::unordered_map<int64_t, void*> variant_pack = {
+      // inputs
+      {Q, q.mutable_data_ptr()},
+      {K, k.mutable_data_ptr()},
+      {V, v.mutable_data_ptr()},
+      {O, o.mutable_data_ptr()},
+      {DO, dO_.mutable_data_ptr()},
+      {LSE, softmaxstats.mutable_data_ptr()},
+      // outputs
+      {DQ, dQ.mutable_data_ptr()},
+      {DK, dK.mutable_data_ptr()},
+      {DV, dV.mutable_data_ptr()},
+      {SCALE, &scaling_factor},
+      {RAG_Q_OFF, rag_q_off.mutable_data_ptr()},
+      {RAG_O_OFF, rag_o_off.mutable_data_ptr()},
+      {RAG_K_OFF, rag_k_off.mutable_data_ptr()},
+      {RAG_V_OFF, rag_v_off.mutable_data_ptr()},
+      {RAG_LSE_OFF, rag_stats_off.mutable_data_ptr()},
+      {SEQ_LEN_Q, seqlen_q.mutable_data_ptr()},
+      {SEQ_LEN_KV, seqlen_kv.mutable_data_ptr()}};
+  if (dropout_probability != 0.0f) {
+    variant_pack[SEED] = _dropoutseed.mutable_data_ptr();
+    variant_pack[OFFSET] = _dropoutoffset.mutable_data_ptr();
+  }
+  TORCH_CHECK(
+      !attn_bias.has_value(),
+      "attn_bias not yet supported with cuDNN Attention and NestedTensor");
+
+  auto workspace_size = mha_graph.get_workspace_size();
+  auto workspace_ptr =
+      c10::cuda::CUDACachingAllocator::get()->allocate(workspace_size);
+  TORCH_CHECK(!workspace_size || workspace_ptr.get());
+  TORCH_CHECK(
+      mha_graph.execute(handle, variant_pack, workspace_ptr.get()).is_good());
+}
+
+} // namespace at::native
+
 #endif // USE_HIPDNN

--- a/aten/src/ATen/native/cudnn/hip/MHA.cpp
+++ b/aten/src/ATen/native/cudnn/hip/MHA.cpp
@@ -1,0 +1,115 @@
+#include <ATen/ATen.h>
+#include <ATen/Config.h>
+#include <ATen/cuda/CUDAConfig.h>
+
+#ifndef USE_HIPDNN
+namespace at {
+namespace native {
+
+void run_cudnn_SDP_fprop(
+    int64_t b,
+    int64_t h,
+    int64_t s_q,
+    int64_t s_kv,
+    int64_t d_qk,
+    int64_t d_v,
+    float scaling_factor,
+    bool isTraining,
+    bool is_causal,
+    double dropout_probability,
+    const Tensor& q,
+    const Tensor& k,
+    const Tensor& v,
+    const std::optional<Tensor>& attn_bias,
+    Tensor& softmaxstats,
+    Tensor& o,
+    Tensor& dropoutseed,
+    Tensor& dropoutoffset) {
+  TORCH_CHECK(false, "PyTorch was not compiled with hipDNN enabled!");
+}
+
+void run_cudnn_SDP_fprop_nestedtensor(
+    int64_t b,
+    int64_t h_q,
+    int64_t h_k,
+    int64_t h_v,
+    int64_t s_q,
+    int64_t s_kv,
+    int64_t d_qk,
+    int64_t d_v,
+    float scaling_factor,
+    bool return_softmaxstats,
+    bool is_causal,
+    double dropout_probability,
+    const Tensor& cum_seqlen_q,
+    const Tensor& cum_seqlen_kv,
+    const Tensor& q,
+    const Tensor& k,
+    const Tensor& v,
+    const std::optional<Tensor>& attn_bias,
+    Tensor& softmaxstats,
+    Tensor& o,
+    Tensor& dropoutseed,
+    Tensor& dropoutoffset) {
+  TORCH_CHECK(false, "PyTorch was not compiled with hipDNN enabled!");
+}
+
+void run_cudnn_SDP_bprop(
+    int64_t b,
+    int64_t h,
+    int64_t s_q,
+    int64_t s_kv,
+    int64_t d_qk,
+    int64_t d_v,
+    float scaling_factor,
+    bool is_causal,
+    float dropout_probability,
+    const Tensor& q,
+    const Tensor& k,
+    const Tensor& v,
+    const std::optional<Tensor>& attn_bias,
+    const Tensor& o,
+    const Tensor& dO,
+    const Tensor& softmaxstats,
+    Tensor& dQ,
+    Tensor& dK,
+    Tensor& dV,
+    const Tensor& dropoutseed,
+    const Tensor& dropoutoffset) {
+  TORCH_CHECK(false, "PyTorch was not compiled with hipDNN enabled!");
+}
+
+void run_cudnn_SDP_bprop_nestedtensor(
+    int64_t b,
+    int64_t h_q,
+    int64_t h_k,
+    int64_t h_v,
+    int64_t s_q,
+    int64_t s_kv,
+    int64_t d_qk,
+    int64_t d_v,
+
+    float scaling_factor,
+    bool is_causal,
+    float dropout_probability,
+    const Tensor& cum_seqlen_q,
+    const Tensor& cum_seqlen_kv,
+    const Tensor& q,
+    const Tensor& k,
+    const Tensor& v,
+    const std::optional<Tensor>& attn_bias,
+    const Tensor& o,
+    const Tensor& dO,
+    const Tensor& softmaxstats,
+    Tensor& dQ,
+    Tensor& dK,
+    Tensor& dV,
+    const Tensor& dropoutseed,
+    const Tensor& dropoutoffset) {
+  TORCH_CHECK(false, "PyTorch was not compiled with hipDNN enabled!");
+}
+
+} // namespace native
+} // namespace at
+
+#endif // USE_HIPDNN

--- a/aten/src/ATen/native/cudnn/hip/MHA.cpp
+++ b/aten/src/ATen/native/cudnn/hip/MHA.cpp
@@ -335,7 +335,6 @@ enum UIDS {
   V,
   O,
   BIAS,
-  SCALE,
   SEED,
   OFFSET,
   LSE,
@@ -352,20 +351,12 @@ static std::unique_ptr<fe::graph::Graph> build_graph_structure(
   auto mha_graph = std::make_unique<fe::graph::Graph>();
   mha_graph->set_intermediate_data_type(fe::DataType_t::FLOAT)
       .set_compute_data_type(fe::DataType_t::FLOAT);
-  auto attn_scale =
-      mha_graph->tensor(fe::graph::Tensor_attributes()
-                            .set_uid(SCALE)
-                            .set_name("Attn_scale")
-                            .set_dim({1, 1, 1, 1})
-                            .set_stride({1, 1, 1, 1})
-                            .set_value(params.scaling_factor)
-                            .set_data_type(fe::DataType_t::FLOAT));
   auto scaled_dot_product_flash_attention_options =
       fe::graph::SDPA_attributes()
           .set_name("HIPDNN_SDPA")
           .set_generate_stats(params.return_softmaxstats)
           .set_causal_mask(params.is_causal)
-          .set_attn_scale(attn_scale);
+          .set_attn_scale_value(params.scaling_factor);
   if (params.dropout_probability != 0.0f) {
     // Seed/offset dtype is hardcoded INT64 here, to match the allocation done
     // in 'attention.cu'.
@@ -454,18 +445,10 @@ static std::unique_ptr<fe::graph::Graph> build_graph_backward_structure(
   auto mha_graph = std::make_unique<fe::graph::Graph>();
   mha_graph->set_intermediate_data_type(fe::DataType_t::FLOAT)
       .set_compute_data_type(fe::DataType_t::FLOAT);
-  auto attn_scale =
-      mha_graph->tensor(fe::graph::Tensor_attributes()
-                            .set_uid(SCALE)
-                            .set_name("Attn_scale")
-                            .set_dim({1, 1, 1, 1})
-                            .set_stride({1, 1, 1, 1})
-                            .set_value(params.scaling_factor)
-                            .set_data_type(fe::DataType_t::FLOAT));
   auto sdpa_backward_options = fe::graph::SDPA_backward_attributes()
                                    .set_name("HIPDNN_SDPA_BACKWARD")
                                    .set_causal_mask(params.is_causal)
-                                   .set_attn_scale(attn_scale);
+                                   .set_attn_scale_value(params.scaling_factor);
 
   auto Q_ = mha_graph->tensor(
       fe::graph::Tensor_attributes()

--- a/aten/src/ATen/native/cudnn/hip/MHA.cpp
+++ b/aten/src/ATen/native/cudnn/hip/MHA.cpp
@@ -559,35 +559,35 @@ static std::unique_ptr<fe::graph::Graph> build_graph_backward(
 // TODO: cache the support result (and ideally the built graph) so we don't
 // rebuild it on every dispatch. Currently runs end-to-end graph build +
 // query for every can_use_cudnn_attention() call.
-bool check_cudnn_sdpa_support(
-    int64_t b,
-    int64_t h,
-    int64_t s_q,
-    int64_t s_kv,
-    int64_t d_qk,
-    int64_t d_v,
-    float scaling_factor,
-    bool return_softmaxstats,
-    bool is_causal,
-    double dropout_probability,
-    const Tensor& q,
-    const Tensor& k,
-    const Tensor& v,
-    const std::optional<Tensor>& attn_bias) {
+bool check_cudnn_sdpa_support(sdp::sdp_params const& params) {
+  const Tensor& q = params.query;
+  const Tensor& k = params.key;
+  const Tensor& v = params.value;
+  const int64_t b = q.size(0);
+  const int64_t h = q.size(1);
+  const int64_t s_q = q.size(2);
+  const int64_t s_kv = k.size(2);
+  const int64_t d_qk = q.size(3);
+  const int64_t d_v = v.size(3);
+  const float scaling_factor =
+      sdp::calculate_scale(q, params.scale).expect_float();
+  const bool return_softmaxstats = sdp::input_requires_grad(params);
+
   std::optional<Tensor> expanded_bias;
-  if (attn_bias.has_value()) {
+  if (params.attn_mask.has_value()) {
     // At this point we have the caller's original attention mask tensor, before
     // rank normalization (from 'attention.cu:_cudnn_attention_forward'), so we
     // need to mirror that logic here to determine what the actual metadata will
     // be at execution time.
-    const auto rank = attn_bias.value().dim();
+    const auto& bias = params.attn_mask.value();
+    const auto rank = bias.dim();
     TORCH_CHECK(
         rank == 2 || rank == 3 || rank == 4,
         "hipDNN SDPA expects either a 2D, 3D, or 4D attn_bias but got ",
         rank,
         "D");
-    const int64_t h_bias = rank == 4 ? attn_bias.value().size(1) : 1;
-    expanded_bias = attn_bias.value().expand({b, h_bias, s_q, s_kv});
+    const int64_t h_bias = rank == 4 ? bias.size(1) : 1;
+    expanded_bias = bias.expand({b, h_bias, s_q, s_kv});
   }
   MHAParams fwd_params;
   setMHAParams(
@@ -603,8 +603,8 @@ bool check_cudnn_sdpa_support(
       k,
       v,
       expanded_bias,
-      dropout_probability,
-      is_causal,
+      params.dropout,
+      params.is_causal,
       return_softmaxstats);
 
   hipdnnHandle_t handle = getHipdnnHandle();

--- a/aten/src/ATen/native/cudnn/hip/MHA.cpp
+++ b/aten/src/ATen/native/cudnn/hip/MHA.cpp
@@ -114,89 +114,68 @@ void run_cudnn_SDP_bprop_nestedtensor(
 
 #else // USE_HIPDNN
 
-#include <ATen/cudnn/Descriptors.h>
-#include <ATen/cudnn/Types.h>
-#include <ATen/cudnn/Utils.h>
+// TODO: drop this define once hipDNN exposes SDPA unconditionally and
+// pytorch's LoadHIP.cmake propagates hipdnn_frontend's
+// INTERFACE_COMPILE_DEFINITIONS.
+#define HIPDNN_ENABLE_SDPA
+#include <ATen/hipdnn/Exceptions.h>
+#include <ATen/hipdnn/Handle.h>
+#include <ATen/hipdnn/hipdnn-wrapper.h>
 #include <ATen/native/cudnn/MHA.h>
 #include <ATen/native/transformers/sdp_utils.h>
-
-#include <ATen/cuda/Exceptions.h>
 
 #include <ATen/TensorUtils.h>
 #include <ATen/native/utils/ParamsHash.h>
 
-#include <c10/cuda/CUDACachingAllocator.h>
-#include <cudnn.h>
-
-#include <iostream>
+#include <c10/hip/HIPCachingAllocator.h>
 
 namespace at::native {
 
-namespace fe = cudnn_frontend;
+namespace fe = hipdnn_frontend;
 
 constexpr uint8_t MAX_MHA_DIM = 4;
 
-// Whether we will use ragged offsets in the dense (non-nested) path
-// to avoid recompilation
-bool use_ragged_in_dense(
-    const Tensor& q,
-    const Tensor& k,
-    const Tensor& v,
-    const Tensor& o,
-    bool has_bias) {
-  static bool flag =
-      c10::utils::check_env("TORCH_CUDNN_SDPA_AVOID_RECOMPILE") == true;
-  if (!flag) {
-    return flag;
+static fe::DataType_t to_fe_data_type(c10::ScalarType t) {
+  switch (t) {
+    case kHalf:
+      return fe::DataType_t::HALF;
+    case kBFloat16:
+      return fe::DataType_t::BFLOAT16;
+    case kFloat:
+      return fe::DataType_t::FLOAT;
+    case kDouble:
+      return fe::DataType_t::DOUBLE;
+    default:
+      TORCH_CHECK(false, "hipDNN SDPA: unexpected tensor dtype ", t);
   }
-  TORCH_WARN_ONCE(
-      "TORCH_CUDNN_SDPA_AVOID_RECOMPILE=1 is currently experimental. "
-      "Please report any issues to https://github.com/pytorch/pytorch/issues.");
-  if (has_bias) {
-    TORCH_WARN_ONCE(
-        "TORCH_CUDNN_SDPA_AVOID_RECOMPILE=1 only works without bias."
-        "Consider using the is_causal hint instead of bias for causal masking."
-        "Falling back to regular dense case, which may trigger excessive recompilation.");
-    return !has_bias;
-  }
-  bool all_bshd = q.dim() == 4 && q.transpose(1, 2).is_contiguous() &&
-      k.dim() == 4 && k.transpose(1, 2).is_contiguous() && v.dim() == 4 &&
-      v.transpose(1, 2).is_contiguous() && o.dim() == 4 &&
-      o.transpose(1, 2).is_contiguous();
-  if (!all_bshd) {
-    TORCH_WARN_ONCE(
-        "TORCH_CUDNN_SDPA_AVOID_RECOMPILE=1 only works with Q, K, V, and output in BSHD memory layout,"
-        "e.g., Q, K, V must be allocated with torch.randn((B, S, H, D).transpose(1, 2)."
-        "Falling back to regular dense case, which may trigger excessive recompilation.");
-  }
-  return all_bshd;
 }
 
-int roundup_power2(int dim) {
-  if (!dim) {
-    return 1;
-  }
-  dim--;
-  dim |= dim >> 1;
-  dim |= dim >> 2;
-  dim |= dim >> 4;
-  dim |= dim >> 8;
-  dim |= dim >> 16;
-  dim++;
-  return dim;
+static void check_tensor_matches_graph(
+    const std::unordered_map<
+        int64_t,
+        std::shared_ptr<fe::graph::TensorAttributes>>& graph_tensors,
+    int64_t uid,
+    const Tensor& t) {
+  auto it = graph_tensors.find(uid);
+  TORCH_CHECK(it != graph_tensors.end());
+  const auto& attrs = it->second;
+  TORCH_CHECK(t.sizes() == IntArrayRef(attrs->get_dim()));
+  TORCH_CHECK(t.strides() == IntArrayRef(attrs->get_stride()));
+  TORCH_CHECK(to_fe_data_type(t.scalar_type()) == attrs->get_data_type());
 }
 
 struct MHAParams {
   c10::DeviceIndex device_id;
   fe::DataType_t dataType;
-  std::array<int, MAX_MHA_DIM> q_dim;
-  std::array<int, MAX_MHA_DIM> k_dim;
-  std::array<int, MAX_MHA_DIM> v_dim;
-  std::array<int, MAX_MHA_DIM> q_stride;
-  std::array<int, MAX_MHA_DIM> k_stride;
-  std::array<int, MAX_MHA_DIM> v_stride;
-  std::array<int, MAX_MHA_DIM> bias_dim;
-  std::array<int, MAX_MHA_DIM> bias_stride;
+  float scaling_factor;
+  std::array<int64_t, MAX_MHA_DIM> q_dim;
+  std::array<int64_t, MAX_MHA_DIM> k_dim;
+  std::array<int64_t, MAX_MHA_DIM> v_dim;
+  std::array<int64_t, MAX_MHA_DIM> q_stride;
+  std::array<int64_t, MAX_MHA_DIM> k_stride;
+  std::array<int64_t, MAX_MHA_DIM> v_stride;
+  std::array<int64_t, MAX_MHA_DIM> bias_dim;
+  std::array<int64_t, MAX_MHA_DIM> bias_stride;
   int64_t b;
   int64_t h;
   int64_t s_q;
@@ -206,13 +185,10 @@ struct MHAParams {
   double dropout_probability;
   bool is_causal;
   bool return_softmaxstats;
-  // might be redundant if we take 0 dim/stride
-  // as signaling no-bias
   bool has_attn_bias;
-  bool use_ragged;
 };
 
-void setMHAParams(
+static void setMHAParams(
     MHAParams& params,
     int64_t b,
     int64_t h,
@@ -220,20 +196,18 @@ void setMHAParams(
     int64_t s_kv,
     int64_t d_qk,
     int64_t d_v,
+    float scaling_factor,
     const Tensor& q,
     const Tensor& k,
     const Tensor& v,
     const std::optional<Tensor>& attn_bias,
     double dropout_probability,
     bool is_causal,
-    bool return_softmaxstats,
-    bool is_nested) {
+    bool return_softmaxstats) {
   memset(&params, 0, sizeof(MHAParams));
   params.device_id = at::cuda::current_device();
-  params.dataType = fe::DataType_t::HALF;
-  if (q.scalar_type() == kBFloat16) {
-    params.dataType = fe::DataType_t::BFLOAT16;
-  }
+  params.dataType = to_fe_data_type(q.scalar_type());
+  params.scaling_factor = scaling_factor;
   params.b = b;
   params.h = h;
   params.d_qk = d_qk;
@@ -244,45 +218,12 @@ void setMHAParams(
   params.is_causal = is_causal;
   params.return_softmaxstats = return_softmaxstats;
   params.has_attn_bias = attn_bias.has_value();
-  // Expect 4D dense tensor, 3D nested case (THD)
-  TORCH_INTERNAL_ASSERT(
-      q.sizes().size() == (uint8_t)(MAX_MHA_DIM - (uint8_t)is_nested),
-      "Q tensor has unexpected number of dims, please report a bug to PyTorch.");
-  TORCH_INTERNAL_ASSERT(
-      q.strides().size() == (uint8_t)(MAX_MHA_DIM - (uint8_t)is_nested),
-      "Q tensor has unexpected number of dims, please report a bug to PyTorch.");
-  TORCH_INTERNAL_ASSERT(
-      k.sizes().size() == (uint8_t)(MAX_MHA_DIM - (uint8_t)is_nested),
-      "K tensor has unexpected number of dims, please report a bug to PyTorch.");
-  TORCH_INTERNAL_ASSERT(
-      k.strides().size() == (uint8_t)(MAX_MHA_DIM - (uint8_t)is_nested),
-      "K tensor has unexpected number of dims, please report a bug to PyTorch.");
-  TORCH_INTERNAL_ASSERT(
-      v.sizes().size() == (uint8_t)(MAX_MHA_DIM - (uint8_t)is_nested),
-      "V tensor has unexpected number of dims, please report a bug to PyTorch.");
-  TORCH_INTERNAL_ASSERT(
-      v.strides().size() == (uint8_t)(MAX_MHA_DIM - (uint8_t)is_nested),
-      "V tensor has unexpected number of dims, please report a bug to PyTorch.");
   std::copy(q.sizes().begin(), q.sizes().end(), params.q_dim.begin());
   std::copy(q.strides().begin(), q.strides().end(), params.q_stride.begin());
   std::copy(k.sizes().begin(), k.sizes().end(), params.k_dim.begin());
   std::copy(k.strides().begin(), k.strides().end(), params.k_stride.begin());
   std::copy(v.sizes().begin(), v.sizes().end(), params.v_dim.begin());
   std::copy(v.strides().begin(), v.strides().end(), params.v_stride.begin());
-  bool use_ragged = use_ragged_in_dense(q, k, v, q, params.has_attn_bias);
-  params.use_ragged = use_ragged;
-  if (use_ragged) {
-    // ignore B - stride in BSHD (THD) avoid-recompile
-    params.q_stride[0] = INT_MAX;
-    params.k_stride[0] = INT_MAX;
-    params.v_stride[0] = INT_MAX;
-    // fix seqlen to rounded value
-    params.s_q = roundup_power2(params.s_q);
-    params.s_kv = roundup_power2(params.s_kv);
-    params.q_dim[2] = roundup_power2(params.q_dim[2]);
-    params.k_dim[2] = roundup_power2(params.k_dim[2]);
-    params.v_dim[2] = roundup_power2(params.v_dim[2]);
-  }
   // uninit is OK as the struct is memset 0'd
   if (params.has_attn_bias) {
     std::copy(
@@ -304,14 +245,14 @@ struct MHACacheKeyWrapper : ParamsWrapper<MHAParams> {
       int64_t s_kv,
       int64_t d_qk,
       int64_t d_v,
+      float scaling_factor,
       const Tensor& q,
       const Tensor& k,
       const Tensor& v,
       const std::optional<Tensor>& attn_bias,
       double dropout_probability,
       bool is_causal,
-      bool return_softmaxstats,
-      bool is_nested) {
+      bool return_softmaxstats) {
     setMHAParams(
         this->pod,
         b,
@@ -320,14 +261,14 @@ struct MHACacheKeyWrapper : ParamsWrapper<MHAParams> {
         s_kv,
         d_qk,
         d_v,
+        scaling_factor,
         q,
         k,
         v,
         attn_bias,
         dropout_probability,
         is_causal,
-        return_softmaxstats,
-        is_nested);
+        return_softmaxstats);
   }
 };
 
@@ -375,19 +316,15 @@ struct MHAGraphCache {
   }
 };
 
-// @eqy: use thread local caches as cuDNN Execution Plans are not guaranteed to
-// be thread safe across all engines see Limitations in
-// https://docs.nvidia.com/deeplearning/cudnn/backend/latest/release-notes.html
-// We also leak the caches to workaround potential teardown race issues.
-
-MHAGraphCache& getMHAGraphCache_() {
-  thread_local MHAGraphCache* instance{new MHAGraphCache()};
-  return *instance;
+// Use thread local caches to avoid potential thread safety issues.
+static MHAGraphCache& getMHAGraphCache_() {
+  thread_local MHAGraphCache instance;
+  return instance;
 }
 
-MHAGraphCache& getMHAGraphBackwardCache_() {
-  thread_local MHAGraphCache* instance{new MHAGraphCache()};
-  return *instance;
+static MHAGraphCache& getMHAGraphBackwardCache_() {
+  thread_local MHAGraphCache instance;
+  return instance;
 }
 
 namespace {
@@ -406,65 +343,14 @@ enum UIDS {
   DQ,
   DK,
   DV,
-  SEQ_LEN_Q,
-  SEQ_LEN_KV,
-  RAG_Q_OFF,
-  RAG_K_OFF,
-  RAG_V_OFF,
-  RAG_O_OFF,
-  RAG_LSE_OFF
 };
-
-// analogous to the same function in Descriptors.h for cuDNN Convolutions...
-auto fixSizeOneDimStrideSDPA(
-    const IntArrayRef sizes,
-    std::vector<int64_t> strides) {
-  int dims = sizes.size();
-  for (int d = 0; d < dims; d++) {
-    int64_t curr_stride = strides[d];
-    if (sizes[d] == 1 && !curr_stride) {
-      curr_stride = 1;
-      for (int d2 = d + 1; d2 < dims; d2++) {
-        curr_stride *= strides[d2];
-      }
-      strides[d] = curr_stride;
-    }
-  }
-  return strides;
-}
 
 } // namespace
 
-std::unique_ptr<fe::graph::Graph> build_graph(
-    int64_t b,
-    int64_t h,
-    int64_t s_q,
-    int64_t s_kv,
-    int64_t d_qk,
-    int64_t d_v,
-    float scaling_factor,
-    bool return_softmaxstats,
-    bool is_causal,
-    double dropout_probability,
-    const Tensor& q,
-    const Tensor& k,
-    const Tensor& v,
-    const std::optional<Tensor>& attn_bias,
-    Tensor& softmaxstats,
-    Tensor& o,
-    Tensor& dropoutseed,
-    Tensor& dropoutoffset,
-    cudnnHandle_t& handle) {
-  auto dtype = fe::DataType_t::HALF;
-  if (q.scalar_type() == kBFloat16) {
-    dtype = fe::DataType_t::BFLOAT16;
-  }
+static std::unique_ptr<fe::graph::Graph> build_graph_structure(
+    const MHAParams& params) {
   auto mha_graph = std::make_unique<fe::graph::Graph>();
-  // We're baking in float accumulation and scale types
-  // in theory the graph may support other types, but they
-  // have not been tested
-  mha_graph->set_io_data_type(dtype)
-      .set_intermediate_data_type(fe::DataType_t::FLOAT)
+  mha_graph->set_intermediate_data_type(fe::DataType_t::FLOAT)
       .set_compute_data_type(fe::DataType_t::FLOAT);
   auto attn_scale =
       mha_graph->tensor(fe::graph::Tensor_attributes()
@@ -472,177 +358,224 @@ std::unique_ptr<fe::graph::Graph> build_graph(
                             .set_name("Attn_scale")
                             .set_dim({1, 1, 1, 1})
                             .set_stride({1, 1, 1, 1})
-                            .set_is_pass_by_value(true)
+                            .set_value(params.scaling_factor)
                             .set_data_type(fe::DataType_t::FLOAT));
   auto scaled_dot_product_flash_attention_options =
       fe::graph::SDPA_attributes()
-          .set_name("CUDNN_SDPA")
-#if CUDNN_FRONTEND_VERSION <= 11200
-          .set_is_inference(!return_softmaxstats)
-#else
-          .set_generate_stats(return_softmaxstats)
-#endif
-          .set_causal_mask(is_causal)
+          .set_name("HIPDNN_SDPA")
+          .set_generate_stats(params.return_softmaxstats)
+          .set_causal_mask(params.is_causal)
           .set_attn_scale(attn_scale);
-  if (use_ragged_in_dense(q, k, v, o, attn_bias.has_value())) {
-    auto SEQ_LEN_Q_ =
-        mha_graph->tensor(fe::graph::Tensor_attributes()
-                              .set_uid(SEQ_LEN_Q)
-                              .set_name("Seq_q")
-                              .set_dim({b, 1, 1, 1})
-                              .set_stride({1, 1, 1, 1})
-                              .set_data_type(fe::DataType_t::INT32));
-    auto SEQ_LEN_KV_ =
-        mha_graph->tensor(fe::graph::Tensor_attributes()
-                              .set_uid(SEQ_LEN_KV)
-                              .set_name("Seq_kv")
-                              .set_dim({b, 1, 1, 1})
-                              .set_stride({1, 1, 1, 1})
-                              .set_data_type(fe::DataType_t::INT32));
-    scaled_dot_product_flash_attention_options.set_seq_len_q(SEQ_LEN_Q_)
-        .set_seq_len_kv(SEQ_LEN_KV_)
-        .set_padding_mask(true);
-  }
-  if (dropout_probability != 0.0f) {
+  if (params.dropout_probability != 0.0f) {
+    // Seed/offset dtype is hardcoded INT64 here, to match the allocation done
+    // in 'attention.cu'.
     auto seed = mha_graph->tensor(fe::graph::Tensor_attributes()
                                       .set_uid(SEED)
                                       .set_name("Seed")
                                       .set_dim({1, 1, 1, 1})
                                       .set_stride({1, 1, 1, 1})
-                                      .set_data_type(
-                                          dropoutseed.dtype() == kInt
-                                              ? fe::DataType_t::INT32
-                                              : fe::DataType_t::INT64));
+                                      .set_data_type(fe::DataType_t::INT64));
     auto offset = mha_graph->tensor(fe::graph::Tensor_attributes()
                                         .set_uid(OFFSET)
                                         .set_name("Offset")
                                         .set_dim({1, 1, 1, 1})
                                         .set_stride({1, 1, 1, 1})
-                                        .set_data_type(
-                                            dropoutoffset.dtype() == kInt
-                                                ? fe::DataType_t::INT32
-                                                : fe::DataType_t::INT64));
+                                        .set_data_type(fe::DataType_t::INT64));
     scaled_dot_product_flash_attention_options.set_dropout(
-        dropout_probability, seed, offset);
+        params.dropout_probability, seed, offset);
   }
   auto Q_ = mha_graph->tensor(
-      fe::graph::Tensor_attributes().set_uid(Q).set_name("Q"));
+      fe::graph::Tensor_attributes()
+          .set_uid(Q)
+          .set_name("Q")
+          .set_dim(std::vector(params.q_dim.begin(), params.q_dim.end()))
+          .set_stride(std::vector(params.q_stride.begin(), params.q_stride.end()))
+          .set_data_type(params.dataType));
   auto K_ = mha_graph->tensor(
-      fe::graph::Tensor_attributes().set_uid(K).set_name("K"));
+      fe::graph::Tensor_attributes()
+          .set_uid(K)
+          .set_name("K")
+          .set_dim(std::vector(params.k_dim.begin(), params.k_dim.end()))
+          .set_stride(std::vector(params.k_stride.begin(), params.k_stride.end()))
+          .set_data_type(params.dataType));
   auto V_ = mha_graph->tensor(
-      fe::graph::Tensor_attributes().set_uid(V).set_name("V"));
-  if (attn_bias.has_value()) {
-    scaled_dot_product_flash_attention_options.set_bias(
-        mha_graph->tensor(fe::graph::Tensor_attributes()
-                              .set_uid(BIAS)
-                              .set_name("bias")
-                              .set_dim(attn_bias.value().sizes().vec())
-                              .set_stride(attn_bias.value().strides().vec())));
+      fe::graph::Tensor_attributes()
+          .set_uid(V)
+          .set_name("V")
+          .set_dim(std::vector(params.v_dim.begin(), params.v_dim.end()))
+          .set_stride(std::vector(params.v_stride.begin(), params.v_stride.end()))
+          .set_data_type(params.dataType));
+  if (params.has_attn_bias) {
+    scaled_dot_product_flash_attention_options.set_bias(mha_graph->tensor(
+        fe::graph::Tensor_attributes()
+            .set_uid(BIAS)
+            .set_name("bias")
+            .set_dim(std::vector(params.bias_dim.begin(), params.bias_dim.end()))
+            .set_stride(std::vector(params.bias_stride.begin(), params.bias_stride.end()))
+            .set_data_type(params.dataType)));
   }
 
   auto [O_, Stats] =
       mha_graph->sdpa(Q_, K_, V_, scaled_dot_product_flash_attention_options);
-  O_->set_uid(O).set_output(true);
+
+  // Output metadata here matches the allocation done in 'run_cudnn_SDP_fprop'.
+  std::vector<int64_t> o_sizes = {params.b, params.h, params.s_q, params.d_v};
+  auto o_strides = compute_matching_strides(params.q_dim, params.q_stride, o_sizes);
+  O_->set_uid(O)
+      .set_output(true)
+      .set_data_type(params.dataType)
+      .set_dim(o_sizes)
+      .set_stride(o_strides);
   if (Stats) {
     Stats->set_uid(LSE)
         .set_output(true)
         .set_data_type(fe::DataType_t::FLOAT)
-        .set_stride(softmaxstats.strides().vec());
+        .set_dim({params.b, params.h, params.s_q, 1})
+        .set_stride({params.h * params.s_q, params.s_q, 1, 1});
   }
-  if (use_ragged_in_dense(q, k, v, o, attn_bias.has_value())) {
-    auto RAG_Q_OFF_ =
-        mha_graph->tensor(fe::graph::Tensor_attributes()
-                              .set_uid(RAG_Q_OFF)
-                              .set_name("cum_seq_q")
-                              .set_dim({b + 1, 1, 1, 1})
-                              .set_stride({1, 1, 1, 1})
-                              .set_data_type(fe::DataType_t::INT32));
-    auto RAG_K_OFF_ =
-        mha_graph->tensor(fe::graph::Tensor_attributes()
-                              .set_uid(RAG_K_OFF)
-                              .set_name("cum_seq_k")
-                              .set_dim({b + 1, 1, 1, 1})
-                              .set_stride({1, 1, 1, 1})
-                              .set_data_type(fe::DataType_t::INT32));
-    auto RAG_V_OFF_ =
-        mha_graph->tensor(fe::graph::Tensor_attributes()
-                              .set_uid(RAG_V_OFF)
-                              .set_name("cum_seq_v")
-                              .set_dim({b + 1, 1, 1, 1})
-                              .set_stride({1, 1, 1, 1})
-                              .set_data_type(fe::DataType_t::INT32));
-    auto RAG_O_OFF_ =
-        mha_graph->tensor(fe::graph::Tensor_attributes()
-                              .set_uid(RAG_O_OFF)
-                              .set_name("cum_seq_o")
-                              .set_dim({b + 1, 1, 1, 1})
-                              .set_stride({1, 1, 1, 1})
-                              .set_data_type(fe::DataType_t::INT32));
-    auto RAG_STATS_OFF_ =
-        mha_graph->tensor(fe::graph::Tensor_attributes()
-                              .set_uid(RAG_LSE_OFF)
-                              .set_name("cum_seq_stats")
-                              .set_dim({b + 1, 1, 1, 1})
-                              .set_stride({1, 1, 1, 1})
-                              .set_data_type(fe::DataType_t::INT32));
-    O_->set_ragged_offset(RAG_O_OFF_);
-    Q_->set_ragged_offset(RAG_Q_OFF_);
-    K_->set_ragged_offset(RAG_K_OFF_);
-    V_->set_ragged_offset(RAG_V_OFF_);
-    auto qsizevec = q.sizes().vec();
-    auto ksizevec = k.sizes().vec();
-    auto vsizevec = v.sizes().vec();
-    auto osizevec = o.sizes().vec();
-    qsizevec[2] = roundup_power2(qsizevec[2]);
-    ksizevec[2] = roundup_power2(ksizevec[2]);
-    vsizevec[2] = roundup_power2(vsizevec[2]);
-    osizevec[2] = roundup_power2(osizevec[2]);
-    // we checked for BSHD contig., set fake strides as cuDNN will complain
-    // if e.g., a ragged dim is smaller than a non-ragged one:
-    // consider HBSD tensor where H is 1
-    Q_->set_dim(qsizevec).set_stride(
-        {INT_MAX, qsizevec[3], qsizevec[1] * qsizevec[3], 1});
-    K_->set_dim(ksizevec).set_stride(
-        {INT_MAX, ksizevec[3], ksizevec[1] * ksizevec[3], 1});
-    V_->set_dim(vsizevec).set_stride(
-        {INT_MAX, vsizevec[3], vsizevec[1] * vsizevec[3], 1});
-    O_->set_dim(osizevec).set_stride(
-        {INT_MAX, osizevec[3], osizevec[1] * osizevec[3], 1});
-    if (Stats) {
-      Stats->set_ragged_offset(RAG_STATS_OFF_);
-      auto statssizevec = softmaxstats.sizes().vec();
-      statssizevec[2] = roundup_power2(statssizevec[2]);
-      Stats->set_dim(statssizevec);
-    }
-  } else {
-    Q_->set_dim(q.sizes().vec())
-        .set_stride(fixSizeOneDimStrideSDPA(q.sizes(), q.strides().vec()));
-    K_->set_dim(k.sizes().vec())
-        .set_stride(fixSizeOneDimStrideSDPA(k.sizes(), k.strides().vec()));
-    V_->set_dim(v.sizes().vec())
-        .set_stride(fixSizeOneDimStrideSDPA(v.sizes(), v.strides().vec()));
-    O_->set_dim(o.sizes().vec())
-        .set_stride(fixSizeOneDimStrideSDPA(o.sizes(), o.strides().vec()));
-    if (Stats) {
-      Stats->set_dim(softmaxstats.sizes().vec());
-    }
-  }
-
-  AT_CUDNN_FRONTEND_CHECK(mha_graph->validate());
-  AT_CUDNN_FRONTEND_CHECK(mha_graph->build_operation_graph(handle));
-  AT_CUDNN_FRONTEND_CHECK(
-      mha_graph->create_execution_plans({fe::HeurMode_t::A}));
-  AT_CUDNN_FRONTEND_CHECK(mha_graph->check_support(handle));
-  AT_CUDNN_FRONTEND_CHECK(mha_graph->build_plans(handle));
 
   return mha_graph;
 }
 
-std::unique_ptr<fe::graph::Graph> build_graph_nestedtensor(
+static std::unique_ptr<fe::graph::Graph> build_graph(
+    const MHAParams& params,
+    hipdnnHandle_t& handle) {
+  auto mha_graph = build_graph_structure(params);
+  HIPDNN_FE_CHECK(mha_graph->validate());
+  HIPDNN_FE_CHECK(mha_graph->build_operation_graph(handle));
+  HIPDNN_FE_CHECK(mha_graph->create_execution_plans({fe::HeurMode_t::FALLBACK}));
+  HIPDNN_FE_CHECK(mha_graph->check_support());
+  HIPDNN_FE_CHECK(mha_graph->build_plans());
+  return mha_graph;
+}
+
+static std::unique_ptr<fe::graph::Graph> build_graph_backward_structure(
+    const MHAParams& params) {
+  auto mha_graph = std::make_unique<fe::graph::Graph>();
+  mha_graph->set_intermediate_data_type(fe::DataType_t::FLOAT)
+      .set_compute_data_type(fe::DataType_t::FLOAT);
+  auto attn_scale =
+      mha_graph->tensor(fe::graph::Tensor_attributes()
+                            .set_uid(SCALE)
+                            .set_name("Attn_scale")
+                            .set_dim({1, 1, 1, 1})
+                            .set_stride({1, 1, 1, 1})
+                            .set_value(params.scaling_factor)
+                            .set_data_type(fe::DataType_t::FLOAT));
+  auto sdpa_backward_options = fe::graph::SDPA_backward_attributes()
+                                   .set_name("HIPDNN_SDPA_BACKWARD")
+                                   .set_causal_mask(params.is_causal)
+                                   .set_attn_scale(attn_scale);
+
+  auto Q_ = mha_graph->tensor(
+      fe::graph::Tensor_attributes()
+          .set_uid(Q)
+          .set_name("Q")
+          .set_dim(std::vector(params.q_dim.begin(), params.q_dim.end()))
+          .set_stride(std::vector(params.q_stride.begin(), params.q_stride.end()))
+          .set_data_type(params.dataType));
+  auto K_ = mha_graph->tensor(
+      fe::graph::Tensor_attributes()
+          .set_uid(K)
+          .set_name("K")
+          .set_dim(std::vector(params.k_dim.begin(), params.k_dim.end()))
+          .set_stride(std::vector(params.k_stride.begin(), params.k_stride.end()))
+          .set_data_type(params.dataType));
+  auto V_ = mha_graph->tensor(
+      fe::graph::Tensor_attributes()
+          .set_uid(V)
+          .set_name("V")
+          .set_dim(std::vector(params.v_dim.begin(), params.v_dim.end()))
+          .set_stride(std::vector(params.v_stride.begin(), params.v_stride.end()))
+          .set_data_type(params.dataType));
+  if (params.has_attn_bias) {
+    sdpa_backward_options.set_bias(mha_graph->tensor(
+        fe::graph::Tensor_attributes()
+            .set_uid(BIAS)
+            .set_name("bias")
+            .set_dim(std::vector(params.bias_dim.begin(), params.bias_dim.end()))
+            .set_stride(std::vector(params.bias_stride.begin(), params.bias_stride.end()))
+            .set_data_type(params.dataType)));
+  }
+
+  // Metadata for seed/offset/O/stats are hardcoded here, based on the
+  // allocation done during forward execution.
+  if (params.dropout_probability != 0.0f) {
+    auto seed = mha_graph->tensor(fe::graph::Tensor_attributes()
+                                      .set_uid(SEED)
+                                      .set_name("Seed")
+                                      .set_dim({1, 1, 1, 1})
+                                      .set_stride({1, 1, 1, 1})
+                                      .set_data_type(fe::DataType_t::INT64));
+    auto offset = mha_graph->tensor(fe::graph::Tensor_attributes()
+                                        .set_uid(OFFSET)
+                                        .set_name("Offset")
+                                        .set_dim({1, 1, 1, 1})
+                                        .set_stride({1, 1, 1, 1})
+                                        .set_data_type(fe::DataType_t::INT64));
+    sdpa_backward_options.set_dropout(params.dropout_probability, seed, offset);
+  }
+
+  std::vector<int64_t> o_sizes = {params.b, params.h, params.s_q, params.d_v};
+  auto o_strides =
+      compute_matching_strides(params.q_dim, params.q_stride, o_sizes);
+  auto O_ = mha_graph->tensor(
+      fe::graph::Tensor_attributes()
+          .set_uid(O)
+          .set_name("O")
+          .set_dim(o_sizes)
+          .set_stride(o_strides)
+          .set_data_type(params.dataType));
+  auto Stats = mha_graph->tensor(
+      fe::graph::Tensor_attributes()
+          .set_uid(LSE)
+          .set_name("Stats")
+          .set_dim({params.b, params.h, params.s_q, 1})
+          .set_stride({params.h * params.s_q, params.s_q, 1, 1})
+          .set_data_type(fe::DataType_t::FLOAT));
+  auto Do = mha_graph->tensor(
+      fe::graph::Tensor_attributes()
+          .set_uid(DO)
+          .set_name("DO")
+          .set_dim(o_sizes)
+          .set_stride(o_strides)
+          .set_data_type(params.dataType));
+  auto [Dq, Dk, Dv] = mha_graph->sdpa_backward(
+      Q_, K_, V_, O_, Do, Stats, sdpa_backward_options);
+  Dq->set_uid(DQ)
+      .set_output(true)
+      .set_data_type(params.dataType)
+      .set_dim(std::vector(params.q_dim.begin(), params.q_dim.end()))
+      .set_stride(std::vector(params.q_stride.begin(), params.q_stride.end()));
+  Dk->set_uid(DK)
+      .set_output(true)
+      .set_data_type(params.dataType)
+      .set_dim(std::vector(params.k_dim.begin(), params.k_dim.end()))
+      .set_stride(std::vector(params.k_stride.begin(), params.k_stride.end()));
+  Dv->set_uid(DV)
+      .set_output(true)
+      .set_data_type(params.dataType)
+      .set_dim(std::vector(params.v_dim.begin(), params.v_dim.end()))
+      .set_stride(std::vector(params.v_stride.begin(), params.v_stride.end()));
+
+  return mha_graph;
+}
+
+static std::unique_ptr<fe::graph::Graph> build_graph_backward(
+    const MHAParams& params,
+    hipdnnHandle_t& handle) {
+  auto mha_graph = build_graph_backward_structure(params);
+  HIPDNN_FE_CHECK(mha_graph->validate());
+  HIPDNN_FE_CHECK(mha_graph->build_operation_graph(handle));
+  HIPDNN_FE_CHECK(mha_graph->create_execution_plans({fe::HeurMode_t::FALLBACK}));
+  HIPDNN_FE_CHECK(mha_graph->check_support());
+  HIPDNN_FE_CHECK(mha_graph->build_plans());
+  return mha_graph;
+}
+
+bool check_cudnn_sdpa_support(
     int64_t b,
-    int64_t h_q,
-    int64_t h_k,
-    int64_t h_v,
+    int64_t h,
     int64_t s_q,
     int64_t s_kv,
     int64_t d_qk,
@@ -651,651 +584,59 @@ std::unique_ptr<fe::graph::Graph> build_graph_nestedtensor(
     bool return_softmaxstats,
     bool is_causal,
     double dropout_probability,
-    const Tensor& cum_seqlen_q,
-    const Tensor& cum_seqlen_kv,
     const Tensor& q,
     const Tensor& k,
     const Tensor& v,
-    const std::optional<Tensor>& attn_bias,
-    Tensor& softmaxstats,
-    Tensor& o,
-    Tensor& dropoutseed,
-    Tensor& dropoutoffset,
-    cudnnHandle_t& handle) {
-  auto dtype = fe::DataType_t::HALF;
-  if (q.scalar_type() == kBFloat16) {
-    dtype = fe::DataType_t::BFLOAT16;
-  }
-  auto mha_graph = std::make_unique<fe::graph::Graph>();
-  // We're baking in float accumulation and scale types
-  // in theory the graph may support other types, but they
-  // have not been tested
-  mha_graph->set_io_data_type(dtype)
-      .set_intermediate_data_type(fe::DataType_t::FLOAT)
-      .set_compute_data_type(fe::DataType_t::FLOAT);
-  auto attn_scale =
-      mha_graph->tensor(fe::graph::Tensor_attributes()
-                            .set_uid(SCALE)
-                            .set_name("Attn_scale")
-                            .set_dim({1, 1, 1, 1})
-                            .set_stride({1, 1, 1, 1})
-                            .set_is_pass_by_value(true)
-                            .set_data_type(fe::DataType_t::FLOAT));
-  auto SEQ_LEN_Q_ =
-      mha_graph->tensor(fe::graph::Tensor_attributes()
-                            .set_uid(SEQ_LEN_Q)
-                            .set_name("Seq_q")
-                            .set_dim({b, 1, 1, 1})
-                            .set_stride({1, 1, 1, 1})
-                            .set_data_type(fe::DataType_t::INT32));
-  auto SEQ_LEN_KV_ =
-      mha_graph->tensor(fe::graph::Tensor_attributes()
-                            .set_uid(SEQ_LEN_KV)
-                            .set_name("Seq_kv")
-                            .set_dim({b, 1, 1, 1})
-                            .set_stride({1, 1, 1, 1})
-                            .set_data_type(fe::DataType_t::INT32));
-
-  auto scaled_dot_product_flash_attention_options =
-      fe::graph::SDPA_attributes()
-          .set_name("CUDNN_SDPA_NESTEDTENSOR")
-#if CUDNN_FRONTEND_VERSION <= 11200
-          .set_is_inference(!return_softmaxstats)
-#else
-          .set_generate_stats(return_softmaxstats)
-#endif
-          .set_causal_mask(is_causal)
-          .set_attn_scale(attn_scale)
-          .set_seq_len_q(SEQ_LEN_Q_)
-          .set_seq_len_kv(SEQ_LEN_KV_)
-          .set_padding_mask(true);
-  if (dropout_probability != 0.0f) {
-    auto seed = mha_graph->tensor(fe::graph::Tensor_attributes()
-                                      .set_uid(SEED)
-                                      .set_name("Seed")
-                                      .set_dim({1, 1, 1, 1})
-                                      .set_stride({1, 1, 1, 1})
-                                      .set_data_type(
-                                          dropoutseed.dtype() == kInt
-                                              ? fe::DataType_t::INT32
-                                              : fe::DataType_t::INT64));
-    auto offset = mha_graph->tensor(fe::graph::Tensor_attributes()
-                                        .set_uid(OFFSET)
-                                        .set_name("Offset")
-                                        .set_dim({1, 1, 1, 1})
-                                        .set_stride({1, 1, 1, 1})
-                                        .set_data_type(
-                                            dropoutoffset.dtype() == kInt
-                                                ? fe::DataType_t::INT32
-                                                : fe::DataType_t::INT64));
-    scaled_dot_product_flash_attention_options.set_dropout(
-        dropout_probability, seed, offset);
-  }
-  // We hardcode BSHD to cuDNN even though the underlying layout is THD
-  auto q_strides = q.strides();
-  auto k_strides = k.strides();
-  auto v_strides = v.strides();
-  // NB: cuDNN API shape is transposed: we pass it nominally as HTD
-  constexpr int strideidx0 = 1;
-  constexpr int strideidx1 = 0;
-  constexpr int strideidx2 = 2;
-  auto Q_ = mha_graph->tensor(fe::graph::Tensor_attributes()
-                                  .set_uid(Q)
-                                  .set_name("Q")
-                                  .set_dim({b, h_q, s_q, d_qk})
-                                  .set_stride(
-                                      {INT_MAX,
-                                       q_strides[strideidx0],
-                                       q_strides[strideidx1],
-                                       q_strides[strideidx2]}));
-  auto K_ = mha_graph->tensor(fe::graph::Tensor_attributes()
-                                  .set_uid(K)
-                                  .set_name("K")
-                                  .set_dim({b, h_k, s_kv, d_qk})
-                                  .set_stride(
-                                      {INT_MAX,
-                                       k_strides[strideidx0],
-                                       k_strides[strideidx1],
-                                       k_strides[strideidx2]}));
-  auto V_ = mha_graph->tensor(fe::graph::Tensor_attributes()
-                                  .set_uid(V)
-                                  .set_name("V")
-                                  .set_dim({b, h_v, s_kv, d_v})
-                                  .set_stride(
-                                      {INT_MAX,
-                                       v_strides[strideidx0],
-                                       v_strides[strideidx1],
-                                       v_strides[strideidx2]}));
+    const std::optional<Tensor>& attn_bias) {
+  std::optional<Tensor> expanded_bias;
   if (attn_bias.has_value()) {
+    // At this point we have the caller's original attention mask tensor, before
+    // rank normalization (from 'attention.cu:_cudnn_attention_forward'), so we
+    // need to mirror that logic here to determine what the actual metadata will
+    // be at execution time.
+    const auto rank = attn_bias.value().dim();
     TORCH_CHECK(
-        false,
-        "attn_bias not yet supported with cuDNN Attention and NestedTensor");
-    scaled_dot_product_flash_attention_options.set_bias(
-        mha_graph->tensor(fe::graph::Tensor_attributes()
-                              .set_uid(BIAS)
-                              .set_name("bias")
-                              .set_dim(attn_bias.value().sizes().vec())
-                              .set_stride(attn_bias.value().strides().vec())));
+        rank == 2 || rank == 3 || rank == 4,
+        "hipDNN SDPA expects either a 2D, 3D, or 4D attn_bias but got ",
+        rank,
+        "D");
+    const int64_t h_bias = rank == 4 ? attn_bias.value().size(1) : 1;
+    expanded_bias = attn_bias.value().expand({b, h_bias, s_q, s_kv});
   }
-  auto RAG_Q_OFF_ =
-      mha_graph->tensor(fe::graph::Tensor_attributes()
-                            .set_uid(RAG_Q_OFF)
-                            .set_name("cum_seq_q")
-                            .set_dim({b + 1, 1, 1, 1})
-                            .set_stride({1, 1, 1, 1})
-                            .set_data_type(fe::DataType_t::INT32));
-  auto RAG_K_OFF_ =
-      mha_graph->tensor(fe::graph::Tensor_attributes()
-                            .set_uid(RAG_K_OFF)
-                            .set_name("cum_seq_k")
-                            .set_dim({b + 1, 1, 1, 1})
-                            .set_stride({1, 1, 1, 1})
-                            .set_data_type(fe::DataType_t::INT32));
-  auto RAG_V_OFF_ =
-      mha_graph->tensor(fe::graph::Tensor_attributes()
-                            .set_uid(RAG_V_OFF)
-                            .set_name("cum_seq_v")
-                            .set_dim({b + 1, 1, 1, 1})
-                            .set_stride({1, 1, 1, 1})
-                            .set_data_type(fe::DataType_t::INT32));
-  auto RAG_O_OFF_ =
-      mha_graph->tensor(fe::graph::Tensor_attributes()
-                            .set_uid(RAG_O_OFF)
-                            .set_name("cum_seq_o")
-                            .set_dim({b + 1, 1, 1, 1})
-                            .set_stride({1, 1, 1, 1})
-                            .set_data_type(fe::DataType_t::INT32));
-  Q_->set_ragged_offset(RAG_Q_OFF_);
-  K_->set_ragged_offset(RAG_K_OFF_);
-  V_->set_ragged_offset(RAG_V_OFF_);
-  auto [O_, Stats] =
-      mha_graph->sdpa(Q_, K_, V_, scaled_dot_product_flash_attention_options);
-  auto o_strides = o.strides();
-  O_->set_output(true)
-      .set_uid(O)
-      .set_dim({b, h_q, s_q, d_v})
-      .set_stride(
-          {INT_MAX,
-           o_strides[strideidx0],
-           o_strides[strideidx1],
-           o_strides[strideidx2]});
+  MHAParams fwd_params;
+  setMHAParams(
+      fwd_params,
+      b,
+      h,
+      s_q,
+      s_kv,
+      d_qk,
+      d_v,
+      scaling_factor,
+      q,
+      k,
+      v,
+      expanded_bias,
+      dropout_probability,
+      is_causal,
+      return_softmaxstats);
 
-  O_->set_ragged_offset(RAG_O_OFF_);
-  if (Stats) {
-    auto RAG_STATS_OFF =
-        mha_graph->tensor(fe::graph::Tensor_attributes()
-                              .set_uid(RAG_LSE_OFF)
-                              .set_name("cum_seq_stats")
-                              .set_dim({b + 1, 1, 1, 1})
-                              .set_stride({1, 1, 1, 1})
-                              .set_data_type(fe::DataType_t::INT32));
-    Stats->set_output(true)
-        .set_uid(LSE)
-        .set_data_type(fe::DataType_t::FLOAT)
-        .set_dim({b, h_q, s_q, 1})
-        .set_stride({h_q * s_q, 1, h_q, 1});
-    Stats->set_ragged_offset(RAG_STATS_OFF);
-  }
-  AT_CUDNN_FRONTEND_CHECK(mha_graph->validate());
-  AT_CUDNN_FRONTEND_CHECK(mha_graph->build_operation_graph(handle));
-  AT_CUDNN_FRONTEND_CHECK(
-      mha_graph->create_execution_plans({fe::HeurMode_t::A}));
-  AT_CUDNN_FRONTEND_CHECK(mha_graph->check_support(handle));
-  AT_CUDNN_FRONTEND_CHECK(mha_graph->build_plans(handle));
-  return mha_graph;
-}
+  hipdnnHandle_t handle = getHipdnnHandle();
+  std::unique_ptr<fe::graph::Graph> fwd_graph =
+      build_graph_structure(fwd_params);
+  if (!fwd_graph->is_supported_ext(handle).is_good())
+    return false;
 
-std::unique_ptr<fe::graph::Graph> build_graph_backward(
-    int64_t b,
-    int64_t h,
-    int64_t s_q,
-    int64_t s_kv,
-    int64_t d_qk,
-    int64_t d_v,
-    float scaling_factor,
-    bool is_causal,
-    float dropout_probability,
-    const Tensor& q,
-    const Tensor& k,
-    const Tensor& v,
-    const std::optional<Tensor>& attn_bias,
-    const Tensor& o,
-    const Tensor& dO,
-    const Tensor& softmaxstats,
-    Tensor& dQ,
-    Tensor& dK,
-    Tensor& dV,
-    const Tensor& dropoutseed,
-    const Tensor& dropoutoffset,
-    cudnnHandle_t& handle) {
-  auto dtype = fe::DataType_t::HALF;
-  if (q.scalar_type() == kBFloat16) {
-    dtype = fe::DataType_t::BFLOAT16;
-  }
-  auto mha_graph = std::make_unique<fe::graph::Graph>();
-  // We're baking in float accumulation and scale types
-  // in theory the graph may support other types, but they
-  // have not been tested
-  mha_graph->set_io_data_type(dtype)
-      .set_intermediate_data_type(fe::DataType_t::FLOAT)
-      .set_compute_data_type(fe::DataType_t::FLOAT);
-  auto attn_scale =
-      mha_graph->tensor(fe::graph::Tensor_attributes()
-                            .set_uid(SCALE)
-                            .set_name("Attn_scale")
-                            .set_dim({1, 1, 1, 1})
-                            .set_stride({1, 1, 1, 1})
-                            .set_is_pass_by_value(true)
-                            .set_data_type(fe::DataType_t::FLOAT));
-  auto sdpa_backward_options = fe::graph::SDPA_backward_attributes()
-                                   .set_name("CUDNN_SDPA_BACKWARD")
-                                   .set_causal_mask(is_causal)
-                                   .set_attn_scale(attn_scale);
-  if (use_ragged_in_dense(q, k, v, o, attn_bias.has_value())) {
-    auto SEQ_LEN_Q_ =
-        mha_graph->tensor(fe::graph::Tensor_attributes()
-                              .set_uid(SEQ_LEN_Q)
-                              .set_name("Seq_q")
-                              .set_dim({b, 1, 1, 1})
-                              .set_stride({1, 1, 1, 1})
-                              .set_data_type(fe::DataType_t::INT32));
-    auto SEQ_LEN_KV_ =
-        mha_graph->tensor(fe::graph::Tensor_attributes()
-                              .set_uid(SEQ_LEN_KV)
-                              .set_name("Seq_kv")
-                              .set_dim({b, 1, 1, 1})
-                              .set_stride({1, 1, 1, 1})
-                              .set_data_type(fe::DataType_t::INT32));
-    sdpa_backward_options.set_seq_len_q(SEQ_LEN_Q_)
-        .set_seq_len_kv(SEQ_LEN_KV_)
-        .set_padding_mask(true);
+  // Check that backwards is also supported here if it might be needed, since
+  // we'll be expected to handle it too if we accept the forward pass.
+  if (return_softmaxstats) {
+    std::unique_ptr<fe::graph::Graph> bwd_graph =
+        build_graph_backward_structure(fwd_params);
+    if (!bwd_graph->is_supported_ext(handle).is_good())
+      return false;
   }
 
-  auto Q_ = mha_graph->tensor(
-      fe::graph::Tensor_attributes().set_uid(Q).set_name("Q"));
-  auto K_ = mha_graph->tensor(
-      fe::graph::Tensor_attributes().set_uid(K).set_name("K"));
-  auto V_ = mha_graph->tensor(
-      fe::graph::Tensor_attributes().set_uid(V).set_name("V"));
-  if (attn_bias.has_value()) {
-    sdpa_backward_options.set_bias(
-        mha_graph->tensor(fe::graph::Tensor_attributes()
-                              .set_uid(BIAS)
-                              .set_name("bias")
-                              .set_dim(attn_bias.value().sizes().vec())
-                              .set_stride(attn_bias.value().strides().vec())));
-  }
-  if (dropout_probability != 0.0f) {
-    auto seed = mha_graph->tensor(fe::graph::Tensor_attributes()
-                                      .set_uid(SEED)
-                                      .set_name("Seed")
-                                      .set_dim({1, 1, 1, 1})
-                                      .set_stride({1, 1, 1, 1})
-                                      .set_data_type(
-                                          dropoutseed.dtype() == kInt
-                                              ? fe::DataType_t::INT32
-                                              : fe::DataType_t::INT64));
-    auto offset = mha_graph->tensor(fe::graph::Tensor_attributes()
-                                        .set_uid(OFFSET)
-                                        .set_name("Offset")
-                                        .set_dim({1, 1, 1, 1})
-                                        .set_stride({1, 1, 1, 1})
-                                        .set_data_type(
-                                            dropoutoffset.dtype() == kInt
-                                                ? fe::DataType_t::INT32
-                                                : fe::DataType_t::INT64));
-    sdpa_backward_options.set_dropout(dropout_probability, seed, offset);
-  }
-  auto O_ = mha_graph->tensor(
-      fe::graph::Tensor_attributes().set_uid(O).set_name("O"));
-  auto Stats = mha_graph->tensor(fe::graph::Tensor_attributes()
-                                     .set_uid(LSE)
-                                     .set_name("Stats")
-                                     .set_stride(softmaxstats.strides().vec())
-                                     .set_data_type(fe::DataType_t::FLOAT));
-  auto Do = mha_graph->tensor(
-      fe::graph::Tensor_attributes().set_uid(DO).set_name("DO"));
-  auto [Dq, Dk, Dv] = mha_graph->sdpa_backward(
-      Q_, K_, V_, O_, Do, Stats, sdpa_backward_options);
-  Dq->set_uid(DQ).set_output(true);
-  Dk->set_uid(DK).set_output(true);
-  Dv->set_uid(DV).set_output(true);
-  if (use_ragged_in_dense(q, k, v, o, attn_bias.has_value())) {
-    auto RAG_Q_OFF_ =
-        mha_graph->tensor(fe::graph::Tensor_attributes()
-                              .set_uid(RAG_Q_OFF)
-                              .set_name("cum_seq_q")
-                              .set_dim({b + 1, 1, 1, 1})
-                              .set_stride({1, 1, 1, 1})
-                              .set_data_type(fe::DataType_t::INT32));
-    auto RAG_K_OFF_ =
-        mha_graph->tensor(fe::graph::Tensor_attributes()
-                              .set_uid(RAG_K_OFF)
-                              .set_name("cum_seq_k")
-                              .set_dim({b + 1, 1, 1, 1})
-                              .set_stride({1, 1, 1, 1})
-                              .set_data_type(fe::DataType_t::INT32));
-    auto RAG_V_OFF_ =
-        mha_graph->tensor(fe::graph::Tensor_attributes()
-                              .set_uid(RAG_V_OFF)
-                              .set_name("cum_seq_v")
-                              .set_dim({b + 1, 1, 1, 1})
-                              .set_stride({1, 1, 1, 1})
-                              .set_data_type(fe::DataType_t::INT32));
-    auto RAG_O_OFF_ =
-        mha_graph->tensor(fe::graph::Tensor_attributes()
-                              .set_uid(RAG_O_OFF)
-                              .set_name("cum_seq_o")
-                              .set_dim({b + 1, 1, 1, 1})
-                              .set_stride({1, 1, 1, 1})
-                              .set_data_type(fe::DataType_t::INT32));
-    auto RAG_STATS_OFF_ =
-        mha_graph->tensor(fe::graph::Tensor_attributes()
-                              .set_uid(RAG_LSE_OFF)
-                              .set_name("cum_seq_stats")
-                              .set_dim({b + 1, 1, 1, 1})
-                              .set_stride({1, 1, 1, 1})
-                              .set_data_type(fe::DataType_t::INT32));
-    O_->set_ragged_offset(RAG_O_OFF_);
-    Q_->set_ragged_offset(RAG_Q_OFF_);
-    K_->set_ragged_offset(RAG_K_OFF_);
-    V_->set_ragged_offset(RAG_V_OFF_);
-    Dq->set_ragged_offset(RAG_Q_OFF_);
-    Dk->set_ragged_offset(RAG_K_OFF_);
-    Dv->set_ragged_offset(RAG_V_OFF_);
-    Do->set_ragged_offset(RAG_O_OFF_);
-    auto qsizevec = q.sizes().vec();
-    auto ksizevec = k.sizes().vec();
-    auto vsizevec = v.sizes().vec();
-    auto osizevec = o.sizes().vec();
-    qsizevec[2] = roundup_power2(qsizevec[2]);
-    ksizevec[2] = roundup_power2(ksizevec[2]);
-    vsizevec[2] = roundup_power2(vsizevec[2]);
-    osizevec[2] = roundup_power2(osizevec[2]);
-    // see corresponding section in the forward about the hardcoding
-    // of strides here
-    Q_->set_dim(qsizevec).set_stride(
-        {INT_MAX, qsizevec[3], qsizevec[1] * qsizevec[3], 1});
-    K_->set_dim(ksizevec).set_stride(
-        {INT_MAX, ksizevec[3], ksizevec[1] * ksizevec[3], 1});
-    V_->set_dim(vsizevec).set_stride(
-        {INT_MAX, vsizevec[3], vsizevec[1] * vsizevec[3], 1});
-    O_->set_dim(osizevec).set_stride(
-        {INT_MAX, osizevec[3], osizevec[1] * osizevec[3], 1});
-    // should be identical to their non-d counterparts
-    Dq->set_dim(qsizevec).set_stride(
-        {INT_MAX, qsizevec[3], qsizevec[1] * qsizevec[3], 1});
-    Dk->set_dim(ksizevec).set_stride(
-        {INT_MAX, ksizevec[3], ksizevec[1] * ksizevec[3], 1});
-    Dv->set_dim(vsizevec).set_stride(
-        {INT_MAX, vsizevec[3], vsizevec[1] * vsizevec[3], 1});
-    Do->set_dim(osizevec).set_stride(
-        {INT_MAX, osizevec[3], osizevec[1] * osizevec[3], 1});
-
-    Stats->set_ragged_offset(RAG_STATS_OFF_);
-    auto statssizevec = softmaxstats.sizes().vec();
-    statssizevec[2] = roundup_power2(statssizevec[2]);
-    Stats->set_dim(statssizevec);
-  } else {
-    O_->set_dim(o.sizes().vec()).set_stride(o.strides().vec());
-    Q_->set_dim(q.sizes().vec()).set_stride(q.strides().vec());
-    K_->set_dim(k.sizes().vec()).set_stride(k.strides().vec());
-    V_->set_dim(v.sizes().vec()).set_stride(v.strides().vec());
-    Dq->set_dim(dQ.sizes().vec()).set_stride(dQ.strides().vec());
-    Dk->set_dim(dK.sizes().vec()).set_stride(dK.strides().vec());
-    Dv->set_dim(dV.sizes().vec()).set_stride(dV.strides().vec());
-    Do->set_dim(dO.sizes().vec()).set_stride(dO.strides().vec());
-    Stats->set_dim(softmaxstats.sizes().vec());
-  }
-
-  AT_CUDNN_FRONTEND_CHECK(mha_graph->validate());
-  AT_CUDNN_FRONTEND_CHECK(mha_graph->build_operation_graph(handle));
-  AT_CUDNN_FRONTEND_CHECK(
-      mha_graph->create_execution_plans({fe::HeurMode_t::A}));
-  AT_CUDNN_FRONTEND_CHECK(mha_graph->check_support(handle));
-  AT_CUDNN_FRONTEND_CHECK(mha_graph->build_plans(handle));
-  return mha_graph;
-}
-
-std::unique_ptr<fe::graph::Graph> build_graph_backward_nestedtensor(
-    int64_t b,
-    int64_t h_q,
-    int64_t h_k,
-    int64_t h_v,
-    int64_t s_q,
-    int64_t s_kv,
-    int64_t d_qk,
-    int64_t d_v,
-    float scaling_factor,
-    bool is_causal,
-    float dropout_probability,
-    const Tensor& cum_seqlen_q,
-    const Tensor& cum_seqlen_kv,
-    const Tensor& q,
-    const Tensor& k,
-    const Tensor& v,
-    const std::optional<Tensor>& attn_bias,
-    const Tensor& o,
-    const Tensor& dO,
-    const Tensor& softmaxstats,
-    Tensor& dQ,
-    Tensor& dK,
-    Tensor& dV,
-    const Tensor& dropoutseed,
-    const Tensor& dropoutoffset,
-    cudnnHandle_t& handle) {
-  auto dtype = fe::DataType_t::HALF;
-  if (q.scalar_type() == kBFloat16) {
-    dtype = fe::DataType_t::BFLOAT16;
-  }
-  auto mha_graph = std::make_unique<fe::graph::Graph>();
-  // We're baking in float accumulation and scale types
-  // in theory the graph may support other types, but they
-  // have not been tested
-  mha_graph->set_io_data_type(dtype)
-      .set_intermediate_data_type(fe::DataType_t::FLOAT)
-      .set_compute_data_type(fe::DataType_t::FLOAT);
-  auto attn_scale =
-      mha_graph->tensor(fe::graph::Tensor_attributes()
-                            .set_uid(SCALE)
-                            .set_name("Attn_scale")
-                            .set_dim({1, 1, 1, 1})
-                            .set_stride({1, 1, 1, 1})
-                            .set_is_pass_by_value(true)
-                            .set_data_type(fe::DataType_t::FLOAT));
-
-  auto SEQ_LEN_Q_ =
-      mha_graph->tensor(fe::graph::Tensor_attributes()
-                            .set_uid(SEQ_LEN_Q)
-                            .set_name("Seq_q")
-                            .set_dim({b, 1, 1, 1})
-                            .set_stride({1, 1, 1, 1})
-                            .set_data_type(fe::DataType_t::INT32));
-  auto SEQ_LEN_KV_ =
-      mha_graph->tensor(fe::graph::Tensor_attributes()
-                            .set_uid(SEQ_LEN_KV)
-                            .set_name("Seq_kv")
-                            .set_dim({b, 1, 1, 1})
-                            .set_stride({1, 1, 1, 1})
-                            .set_data_type(fe::DataType_t::INT32));
-  auto sdpa_backward_options = fe::graph::SDPA_backward_attributes()
-                                   .set_name("CUDNN_SDPA_NESTEDTENSOR_BACKWARD")
-                                   .set_causal_mask(is_causal)
-                                   .set_attn_scale(attn_scale)
-                                   .set_seq_len_q(SEQ_LEN_Q_)
-                                   .set_seq_len_kv(SEQ_LEN_KV_)
-                                   .set_padding_mask(true);
-  if (dropout_probability != 0.0f) {
-    auto seed = mha_graph->tensor(fe::graph::Tensor_attributes()
-                                      .set_uid(SEED)
-                                      .set_name("Seed")
-                                      .set_dim({1, 1, 1, 1})
-                                      .set_stride({1, 1, 1, 1})
-                                      .set_data_type(
-                                          dropoutseed.dtype() == kInt
-                                              ? fe::DataType_t::INT32
-                                              : fe::DataType_t::INT64));
-    auto offset = mha_graph->tensor(fe::graph::Tensor_attributes()
-                                        .set_uid(OFFSET)
-                                        .set_name("Offset")
-                                        .set_dim({1, 1, 1, 1})
-                                        .set_stride({1, 1, 1, 1})
-                                        .set_data_type(
-                                            dropoutoffset.dtype() == kInt
-                                                ? fe::DataType_t::INT32
-                                                : fe::DataType_t::INT64));
-    sdpa_backward_options.set_dropout(dropout_probability, seed, offset);
-  }
-  auto q_strides = q.strides();
-  auto k_strides = k.strides();
-  auto v_strides = v.strides();
-  // NB: cuDNN API shape is transposed
-  constexpr int strideidx0 = 1;
-  constexpr int strideidx1 = 0;
-  constexpr int strideidx2 = 2;
-  auto Q_ = mha_graph->tensor(fe::graph::Tensor_attributes()
-                                  .set_uid(Q)
-                                  .set_name("Q")
-                                  .set_dim({b, h_q, s_q, d_qk})
-                                  .set_stride(
-                                      {INT_MAX,
-                                       q_strides[strideidx0],
-                                       q_strides[strideidx1],
-                                       q_strides[strideidx2]}));
-  auto K_ = mha_graph->tensor(fe::graph::Tensor_attributes()
-                                  .set_uid(K)
-                                  .set_name("K")
-                                  .set_dim({b, h_k, s_kv, d_qk})
-                                  .set_stride(
-                                      {INT_MAX,
-                                       k_strides[strideidx0],
-                                       k_strides[strideidx1],
-                                       k_strides[strideidx2]}));
-  auto V_ = mha_graph->tensor(fe::graph::Tensor_attributes()
-                                  .set_uid(V)
-                                  .set_name("V")
-                                  .set_dim({b, h_v, s_kv, d_v})
-                                  .set_stride(
-                                      {INT_MAX,
-                                       v_strides[strideidx0],
-                                       v_strides[strideidx1],
-                                       v_strides[strideidx2]}));
-  auto o_strides = o.strides();
-  auto O_ = mha_graph->tensor(fe::graph::Tensor_attributes()
-                                  .set_uid(O)
-                                  .set_name("O")
-                                  .set_dim({b, h_q, s_q, d_v})
-                                  .set_stride(
-                                      {INT_MAX,
-                                       o_strides[strideidx0],
-                                       o_strides[strideidx1],
-                                       o_strides[strideidx2]}));
-
-  if (attn_bias.has_value()) {
-    TORCH_CHECK(
-        false,
-        "attn_bias not yet supported with cuDNN Attention and NestedTensor");
-    sdpa_backward_options.set_bias(
-        mha_graph->tensor(fe::graph::Tensor_attributes()
-                              .set_uid(BIAS)
-                              .set_name("bias")
-                              .set_dim(attn_bias.value().sizes().vec())
-                              .set_stride(attn_bias.value().strides().vec())));
-  }
-  auto RAG_Q_OFF_ =
-      mha_graph->tensor(fe::graph::Tensor_attributes()
-                            .set_uid(RAG_Q_OFF)
-                            .set_name("cum_seq_q")
-                            .set_dim({b + 1, 1, 1, 1})
-                            .set_stride({1, 1, 1, 1})
-                            .set_data_type(fe::DataType_t::INT32));
-  auto RAG_K_OFF_ =
-      mha_graph->tensor(fe::graph::Tensor_attributes()
-                            .set_uid(RAG_K_OFF)
-                            .set_name("cum_seq_k")
-                            .set_dim({b + 1, 1, 1, 1})
-                            .set_stride({1, 1, 1, 1})
-                            .set_data_type(fe::DataType_t::INT32));
-  auto RAG_V_OFF_ =
-      mha_graph->tensor(fe::graph::Tensor_attributes()
-                            .set_uid(RAG_V_OFF)
-                            .set_name("cum_seq_v")
-                            .set_dim({b + 1, 1, 1, 1})
-                            .set_stride({1, 1, 1, 1})
-                            .set_data_type(fe::DataType_t::INT32));
-  auto RAG_O_OFF_ =
-      mha_graph->tensor(fe::graph::Tensor_attributes()
-                            .set_uid(RAG_O_OFF)
-                            .set_name("cum_seq_o")
-                            .set_dim({b + 1, 1, 1, 1})
-                            .set_stride({1, 1, 1, 1})
-                            .set_data_type(fe::DataType_t::INT32));
-  auto RAG_STATS_OFF_ =
-      mha_graph->tensor(fe::graph::Tensor_attributes()
-                            .set_uid(RAG_LSE_OFF)
-                            .set_name("cum_seq_stats")
-                            .set_dim({b + 1, 1, 1, 1})
-                            .set_stride({1, 1, 1, 1})
-                            .set_data_type(fe::DataType_t::INT32));
-  O_->set_ragged_offset(RAG_O_OFF_);
-  Q_->set_ragged_offset(RAG_Q_OFF_);
-  K_->set_ragged_offset(RAG_K_OFF_);
-  V_->set_ragged_offset(RAG_V_OFF_);
-  auto STATS = mha_graph->tensor(fe::graph::Tensor_attributes()
-                                     .set_uid(LSE)
-                                     .set_name("stats")
-                                     .set_dim({b, h_q, s_q, 1})
-                                     .set_stride({s_q * h_q, 1, h_q, 1})
-                                     .set_data_type(fe::DataType_t::FLOAT));
-  STATS->set_ragged_offset(RAG_STATS_OFF_);
-  auto do_strides = dO.strides();
-  auto DO_ = mha_graph->tensor(fe::graph::Tensor_attributes()
-                                   .set_ragged_offset(RAG_O_OFF_)
-                                   .set_uid(DO)
-                                   .set_name("DO")
-                                   .set_dim({b, h_q, s_q, d_v})
-                                   .set_stride(
-                                       {INT_MAX,
-                                        do_strides[strideidx0],
-                                        do_strides[strideidx1],
-                                        do_strides[strideidx2]}));
-  auto [Dq, Dk, Dv] = mha_graph->sdpa_backward(
-      Q_, K_, V_, O_, DO_, STATS, sdpa_backward_options);
-  Dq->set_output(true)
-      .set_uid(DQ)
-      .set_ragged_offset(RAG_Q_OFF_)
-      .set_dim({b, h_q, s_q, d_qk})
-      .set_stride(
-          {INT_MAX,
-           q_strides[strideidx0],
-           q_strides[strideidx1],
-           q_strides[strideidx2]});
-  Dk->set_output(true)
-      .set_uid(DK)
-      .set_ragged_offset(RAG_K_OFF_)
-      .set_dim({b, h_k, s_kv, d_qk})
-      .set_stride(
-          {INT_MAX,
-           k_strides[strideidx0],
-           k_strides[strideidx1],
-           k_strides[strideidx2]});
-  Dv->set_output(true)
-      .set_uid(DV)
-      .set_ragged_offset(RAG_V_OFF_)
-      .set_dim({b, h_v, s_kv, d_v})
-      .set_stride(
-          {INT_MAX,
-           v_strides[strideidx0],
-           v_strides[strideidx1],
-           v_strides[strideidx2]});
-
-  AT_CUDNN_FRONTEND_CHECK(mha_graph->validate());
-  AT_CUDNN_FRONTEND_CHECK(mha_graph->build_operation_graph(handle));
-  AT_CUDNN_FRONTEND_CHECK(
-      mha_graph->create_execution_plans({fe::HeurMode_t::A}));
-  AT_CUDNN_FRONTEND_CHECK(mha_graph->check_support(handle));
-  AT_CUDNN_FRONTEND_CHECK(mha_graph->build_plans(handle));
-  return mha_graph;
+  return true;
 }
 
 void run_cudnn_SDP_fprop(
@@ -1321,57 +662,20 @@ void run_cudnn_SDP_fprop(
   if (!q.numel() || !k.numel() || !v.numel()) {
     return;
   }
-  Tensor seqlen_q, seqlen_kv;
-  Tensor rag_off_q, rag_off_k, rag_off_v, rag_off_o, rag_off_lse;
 
-  if (!o.defined()) {
-    // q is passed to us in BHSD dim order
-    alloc_with_matching_layout(q, o, {b, h, s_q, d_v});
-  }
-  bool use_ragged = use_ragged_in_dense(q, k, v, o, attn_bias.has_value());
-  if (return_softmaxstats && !softmaxstats.defined()) {
-    // TODO(eqy): investigate why cuDNN doesn't like BSH layout softmaxstats
-    if (!use_ragged) {
-      softmaxstats = at::empty({b, h, s_q, 1}, q.options().dtype(kFloat));
-    } else {
-      softmaxstats =
-          at::empty({b, s_q, h, 1}, q.options().dtype(kFloat)).transpose(1, 2);
-    }
+  TORCH_CHECK(
+      !o.defined(), "hipDNN SDPA expects output tensor to be undefined");
+  // q is passed to us in BHSD dim order
+  alloc_with_matching_layout(q, o, {b, h, s_q, d_v});
+  TORCH_CHECK(
+      !softmaxstats.defined(),
+      "hipDNN SDPA expects softmaxstats tensor to be undefined");
+  if (return_softmaxstats) {
+    softmaxstats = at::empty({b, h, s_q, 1}, q.options().dtype(kFloat));
   }
 
-  if (use_ragged) {
-    seqlen_q = at::full({b, 1, 1, 1}, s_q, q.options().dtype(kInt));
-    seqlen_kv = at::full({b, 1, 1, 1}, s_kv, q.options().dtype(kInt));
-    auto cum_seqlen_q = at::full({b + 1, 1, 1, 1}, s_q, q.options().dtype(kInt))
-                            .cumsum(0, kInt)
-                            .add_(-s_q);
-    auto cum_seqlen_kv =
-        at::full({b + 1, 1, 1, 1}, s_kv, q.options().dtype(kInt))
-            .cumsum(0, kInt)
-            .add_(-s_kv);
-    rag_off_q = cum_seqlen_q.mul(q.stride(-2));
-    rag_off_k = cum_seqlen_kv.mul(k.stride(-2));
-    rag_off_v = cum_seqlen_kv.mul(v.stride(-2));
-    rag_off_o = cum_seqlen_q.mul(o.stride(-2));
-    if (return_softmaxstats) {
-      rag_off_lse = cum_seqlen_q.mul(softmaxstats.stride(-2));
-    }
-  }
+  hipdnnHandle_t handle = getHipdnnHandle();
 
-  const auto dprops = at::cuda::getCurrentDeviceProperties();
-  auto _dropoutseed = dropoutseed;
-  auto _dropoutoffset = dropoutoffset;
-  // cuDNN dropout bug requires these to be in int64
-  if (dprops->major == 10 && dprops->minor == 0) {
-    _dropoutseed = dropoutseed.to(kLong);
-    _dropoutoffset = dropoutoffset.to(kLong);
-  }
-
-  cudnnHandle_t handle = getCudnnHandle();
-
-  // NB: The key initialization will round up sequence length, stride data etc.
-  // if use_ragged_in_dense is enabled (to allow multiple sequence lengths to
-  // reuse the same cached value/graph)
   MHACacheKeyWrapper key(
       b,
       h,
@@ -1379,43 +683,42 @@ void run_cudnn_SDP_fprop(
       s_kv,
       d_qk,
       d_v,
+      scaling_factor,
       q,
       k,
       v,
       attn_bias,
       dropout_probability,
       is_causal,
-      return_softmaxstats,
-      false);
-  auto [cache_it, not_found] = getMHAGraphCache_().try_emplace(key, nullptr);
-  if (not_found) {
-    cache_it->second = build_graph(
-        b,
-        h,
-        s_q,
-        s_kv,
-        d_qk,
-        d_v,
-        scaling_factor,
-        return_softmaxstats,
-        is_causal,
-        dropout_probability,
-        q,
-        k,
-        v,
-        attn_bias,
-        softmaxstats,
-        o,
-        _dropoutseed,
-        _dropoutoffset,
-        handle);
+      return_softmaxstats);
+  auto [cache_it, _] = getMHAGraphCache_().try_emplace(key, nullptr);
+  if (cache_it->second == nullptr) {
+    cache_it->second = build_graph(key.pod, handle);
   }
   const fe::graph::Graph& mha_graph = *cache_it->second;
+  // Graph construction makes some assumptions based on constraints checked
+  // earlier. Validate they hold by comparing metadata against tensors now that
+  // they're available.
+  auto graph_tensors = mha_graph.getTensorsByUid();
+  check_tensor_matches_graph(graph_tensors, Q, q);
+  check_tensor_matches_graph(graph_tensors, K, k);
+  check_tensor_matches_graph(graph_tensors, V, v);
+  check_tensor_matches_graph(graph_tensors, O, o);
+  if (return_softmaxstats) {
+    check_tensor_matches_graph(graph_tensors, LSE, softmaxstats);
+  }
+  if (attn_bias.has_value()) {
+    check_tensor_matches_graph(graph_tensors, BIAS, attn_bias.value());
+  }
+  if (dropout_probability != 0.0f) {
+    check_tensor_matches_graph(graph_tensors, SEED, dropoutseed);
+    check_tensor_matches_graph(graph_tensors, OFFSET, dropoutoffset);
+  }
+
   std::unordered_map<int64_t, void*> variant_pack = {
       {Q, q.mutable_data_ptr()},
       {K, k.mutable_data_ptr()},
       {V, v.mutable_data_ptr()},
-      {SCALE, &scaling_factor},
       {O, o.mutable_data_ptr()}};
   if (return_softmaxstats) {
     variant_pack[LSE] = softmaxstats.mutable_data_ptr();
@@ -1424,21 +727,11 @@ void run_cudnn_SDP_fprop(
     variant_pack[BIAS] = attn_bias.value().mutable_data_ptr();
   }
   if (dropout_probability != 0.0f) {
-    variant_pack[SEED] = _dropoutseed.mutable_data_ptr();
-    variant_pack[OFFSET] = _dropoutoffset.mutable_data_ptr();
+    variant_pack[SEED] = dropoutseed.mutable_data_ptr();
+    variant_pack[OFFSET] = dropoutoffset.mutable_data_ptr();
   }
-  if (use_ragged_in_dense(q, k, v, o, attn_bias.has_value())) {
-    variant_pack[SEQ_LEN_Q] = seqlen_q.mutable_data_ptr();
-    variant_pack[SEQ_LEN_KV] = seqlen_kv.mutable_data_ptr();
-    variant_pack[RAG_Q_OFF] = rag_off_q.mutable_data_ptr();
-    variant_pack[RAG_K_OFF] = rag_off_k.mutable_data_ptr();
-    variant_pack[RAG_V_OFF] = rag_off_v.mutable_data_ptr();
-    variant_pack[RAG_O_OFF] = rag_off_o.mutable_data_ptr();
-    if (return_softmaxstats) {
-      variant_pack[RAG_LSE_OFF] = rag_off_lse.mutable_data_ptr();
-    }
-  }
-  auto workspace_size = mha_graph.get_workspace_size();
+  int64_t workspace_size = 0;
+  HIPDNN_FE_CHECK(mha_graph.get_workspace_size(workspace_size));
   auto workspace_ptr =
       c10::cuda::CUDACachingAllocator::get()->allocate(workspace_size);
   TORCH_CHECK(
@@ -1468,103 +761,7 @@ void run_cudnn_SDP_fprop_nestedtensor(
     Tensor& o,
     Tensor& dropoutseed,
     Tensor& dropoutoffset) {
-  cudnnHandle_t handle = getCudnnHandle();
-  // do nothing if we got 0-element tensors
-  if (!q.numel() || !k.numel() || !v.numel()) {
-    return;
-  }
-
-  if (!o.defined()) {
-    o = at::empty({q.size(0), h_q, d_v}, q.options());
-  }
-
-  if (return_softmaxstats && !softmaxstats.defined()) {
-    softmaxstats = at::empty({q.size(0), h_q, 1}, q.options().dtype(kFloat));
-  }
-
-  MHACacheKeyWrapper key(
-      b,
-      h_q,
-      s_q, // max-seqlen-q
-      s_kv, // max-seqlen-kv
-      d_qk,
-      d_v,
-      q,
-      k,
-      v,
-      attn_bias,
-      dropout_probability,
-      is_causal,
-      return_softmaxstats,
-      true);
-
-  MHAGraphCache& cache = getMHAGraphCache_();
-  auto cache_it = cache.find(key);
-  std::unique_ptr<fe::graph::Graph> mha_graph_storage;
-  if (cache_it == cache.end()) {
-    mha_graph_storage = build_graph_nestedtensor(
-        b,
-        h_q,
-        h_k,
-        h_v,
-        s_q,
-        s_kv,
-        d_qk,
-        d_v,
-        scaling_factor,
-        return_softmaxstats,
-        is_causal,
-        dropout_probability,
-        cum_seqlen_q,
-        cum_seqlen_kv,
-        q,
-        k,
-        v,
-        attn_bias,
-        softmaxstats,
-        o,
-        dropoutseed,
-        dropoutoffset,
-        handle);
-  }
-  const fe::graph::Graph& mha_graph =
-      mha_graph_storage ? *mha_graph_storage : *cache_it->second;
-
-  auto seqlen_q = at::diff(cum_seqlen_q, 1, 0);
-  auto seqlen_kv = at::diff(cum_seqlen_kv, 1, 0);
-  auto rag_q_off = cum_seqlen_q.mul(q.stride(-3));
-  auto rag_k_off = cum_seqlen_kv.mul(k.stride(-3));
-  auto rag_v_off = cum_seqlen_kv.mul(v.stride(-3));
-  auto rag_o_off = cum_seqlen_q.mul(o.stride(-3));
-  auto rag_stats_off = cum_seqlen_q.mul(h_q);
-  std::unordered_map<int64_t, void*> variant_pack = {
-      {Q, q.mutable_data_ptr()},
-      {K, k.mutable_data_ptr()},
-      {V, v.mutable_data_ptr()},
-      {SCALE, &scaling_factor},
-      {O, o.mutable_data_ptr()},
-      {RAG_Q_OFF, rag_q_off.mutable_data_ptr()},
-      {RAG_O_OFF, rag_o_off.mutable_data_ptr()},
-      {RAG_K_OFF, rag_k_off.mutable_data_ptr()},
-      {RAG_V_OFF, rag_v_off.mutable_data_ptr()},
-      {SEQ_LEN_Q, seqlen_q.mutable_data_ptr()},
-      {SEQ_LEN_KV, seqlen_kv.mutable_data_ptr()}};
-  if (return_softmaxstats) {
-    variant_pack[LSE] = softmaxstats.mutable_data_ptr();
-    variant_pack[RAG_LSE_OFF] = rag_stats_off.mutable_data_ptr();
-  }
-  if (dropout_probability != 0.0f) {
-    variant_pack[SEED] = dropoutseed.mutable_data_ptr();
-    variant_pack[OFFSET] = dropoutoffset.mutable_data_ptr();
-  }
-  if (attn_bias.has_value()) {
-    TORCH_CHECK(false, "bias not supported with nestedtensor");
-  }
-  auto workspace_size = mha_graph.get_workspace_size();
-  auto workspace_ptr =
-      c10::cuda::CUDACachingAllocator::get()->allocate(workspace_size);
-  TORCH_CHECK(
-      mha_graph.execute(handle, variant_pack, workspace_ptr.get()).is_good());
+  TORCH_CHECK(false, "hipDNN SDPA does not support nested tensors");
 }
 
 void run_cudnn_SDP_bprop(
@@ -1594,58 +791,8 @@ void run_cudnn_SDP_bprop(
       !softmaxstats.numel()) {
     return;
   }
-  Tensor seqlen_q, seqlen_kv;
-  Tensor rag_off_q, rag_off_k, rag_off_v, rag_off_o, rag_off_lse;
 
-  auto dprops = at::cuda::getCurrentDeviceProperties();
-  auto _dropoutseed = dropoutseed;
-  auto _dropoutoffset = dropoutoffset;
-  // cuDNN dropout bug requires these to be in int64
-  if (dprops->major == 10 && dprops->minor == 0) {
-    _dropoutseed = dropoutseed.to(kLong);
-    _dropoutoffset = dropoutoffset.to(kLong);
-  }
-
-  Tensor dO_ = dO;
-// cuDNN < 9.5.1 assumes gradOutput has same strides as Output
-#if defined(CUDNN_VERSION) && CUDNN_VERSION < 90501
-  if (!same_strides(o, dO)) {
-    TORCH_WARN_ONCE(
-        "cuDNN SDPA backward got grad_output.strides() != output.strides(), "
-        "attempting to materialize a grad_output with matching strides."
-        "Consider upgrading cuDNN v9.5.1+ to avoid this warning.");
-    permute_to_matching_layout(o, dO_);
-  }
-  TORCH_INTERNAL_ASSERT(
-      same_strides(o, dO_),
-      "cuDNN SDPA expected grad_output.strides() == output.strides(), "
-      "the previous step probably failed to materialize a grad_output "
-      "with matching strides...");
-#else
-  const auto innermost_dO_stride = dO.strides()[dO.strides().size() - 1];
-  if (innermost_dO_stride != 1 ||
-      use_ragged_in_dense(q, k, v, o, attn_bias.has_value())) {
-    permute_to_matching_layout(o, dO_);
-  }
-#endif
-  if (use_ragged_in_dense(q, k, v, o, attn_bias.has_value())) {
-    seqlen_q = at::full({b, 1, 1, 1}, s_q, q.options().dtype(kInt));
-    seqlen_kv = at::full({b, 1, 1, 1}, s_kv, q.options().dtype(kInt));
-    auto cum_seqlen_q = at::full({b + 1, 1, 1, 1}, s_q, q.options().dtype(kInt))
-                            .cumsum(0, kInt)
-                            .add_(-s_q);
-    auto cum_seqlen_kv =
-        at::full({b + 1, 1, 1, 1}, s_kv, q.options().dtype(kInt))
-            .cumsum(0, kInt)
-            .add_(-s_kv);
-    rag_off_q = cum_seqlen_q.mul(q.stride(-2));
-    rag_off_k = cum_seqlen_kv.mul(k.stride(-2));
-    rag_off_v = cum_seqlen_kv.mul(v.stride(-2));
-    rag_off_o = cum_seqlen_q.mul(o.stride(-2));
-    rag_off_lse = cum_seqlen_q.mul(softmaxstats.stride(-2));
-  }
-
-  cudnnHandle_t handle = getCudnnHandle();
+  hipdnnHandle_t handle = getHipdnnHandle();
   MHACacheKeyWrapper key(
       b,
       h,
@@ -1653,42 +800,39 @@ void run_cudnn_SDP_bprop(
       s_kv,
       d_qk,
       d_v,
+      scaling_factor,
       q,
       k,
       v,
       attn_bias,
       dropout_probability,
       is_causal,
-      true,
-      false);
-  auto [cache_it, not_found] =
-      getMHAGraphBackwardCache_().try_emplace(key, nullptr);
-  if (not_found) {
-    cache_it->second = build_graph_backward(
-        b,
-        h,
-        s_q,
-        s_kv,
-        d_qk,
-        d_v,
-        scaling_factor,
-        is_causal,
-        dropout_probability,
-        q,
-        k,
-        v,
-        attn_bias,
-        o,
-        dO_,
-        softmaxstats,
-        dQ,
-        dK,
-        dV,
-        _dropoutseed,
-        _dropoutoffset,
-        handle);
+      /*return_softmaxstats=*/true);
+  auto [cache_it, _] = getMHAGraphBackwardCache_().try_emplace(key, nullptr);
+  if (cache_it->second == nullptr) {
+    cache_it->second = build_graph_backward(key.pod, handle);
   }
   const fe::graph::Graph& mha_graph = *cache_it->second;
+  // Graph construction makes some assumptions based on constraints checked
+  // earlier. Validate they hold by comparing metadata against tensors now that
+  // they're available.
+  auto graph_tensors = mha_graph.getTensorsByUid();
+  check_tensor_matches_graph(graph_tensors, Q, q);
+  check_tensor_matches_graph(graph_tensors, K, k);
+  check_tensor_matches_graph(graph_tensors, V, v);
+  check_tensor_matches_graph(graph_tensors, O, o);
+  check_tensor_matches_graph(graph_tensors, DO, dO);
+  check_tensor_matches_graph(graph_tensors, LSE, softmaxstats);
+  check_tensor_matches_graph(graph_tensors, DQ, dQ);
+  check_tensor_matches_graph(graph_tensors, DK, dK);
+  check_tensor_matches_graph(graph_tensors, DV, dV);
+  if (attn_bias.has_value()) {
+    check_tensor_matches_graph(graph_tensors, BIAS, attn_bias.value());
+  }
+  if (dropout_probability != 0.0f) {
+    check_tensor_matches_graph(graph_tensors, SEED, dropoutseed);
+    check_tensor_matches_graph(graph_tensors, OFFSET, dropoutoffset);
+  }
 
   std::unordered_map<int64_t, void*> variant_pack = {
       // inputs
@@ -1696,31 +840,22 @@ void run_cudnn_SDP_bprop(
       {K, k.mutable_data_ptr()},
       {V, v.mutable_data_ptr()},
       {O, o.mutable_data_ptr()},
-      {DO, dO_.mutable_data_ptr()},
+      {DO, dO.mutable_data_ptr()},
       {LSE, softmaxstats.mutable_data_ptr()},
       // outputs
       {DQ, dQ.mutable_data_ptr()},
       {DK, dK.mutable_data_ptr()},
-      {DV, dV.mutable_data_ptr()},
-      {SCALE, &scaling_factor}};
+      {DV, dV.mutable_data_ptr()}};
   if (dropout_probability != 0.0f) {
-    variant_pack[SEED] = _dropoutseed.mutable_data_ptr();
-    variant_pack[OFFSET] = _dropoutoffset.mutable_data_ptr();
+    variant_pack[SEED] = dropoutseed.mutable_data_ptr();
+    variant_pack[OFFSET] = dropoutoffset.mutable_data_ptr();
   }
   if (attn_bias.has_value()) {
     variant_pack[BIAS] = attn_bias.value().mutable_data_ptr();
   }
-  if (use_ragged_in_dense(q, k, v, o, attn_bias.has_value())) {
-    variant_pack[SEQ_LEN_Q] = seqlen_q.mutable_data_ptr();
-    variant_pack[SEQ_LEN_KV] = seqlen_kv.mutable_data_ptr();
-    variant_pack[RAG_Q_OFF] = rag_off_q.mutable_data_ptr();
-    variant_pack[RAG_K_OFF] = rag_off_k.mutable_data_ptr();
-    variant_pack[RAG_V_OFF] = rag_off_v.mutable_data_ptr();
-    variant_pack[RAG_O_OFF] = rag_off_o.mutable_data_ptr();
-    variant_pack[RAG_LSE_OFF] = rag_off_lse.mutable_data_ptr();
-  }
 
-  auto workspace_size = mha_graph.get_workspace_size();
+  int64_t workspace_size;
+  HIPDNN_FE_CHECK(mha_graph.get_workspace_size(workspace_size));
   auto workspace_ptr =
       c10::cuda::CUDACachingAllocator::get()->allocate(workspace_size);
   TORCH_CHECK(!workspace_size || workspace_ptr.get());
@@ -1754,122 +889,7 @@ void run_cudnn_SDP_bprop_nestedtensor(
     Tensor& dV,
     const Tensor& dropoutseed,
     const Tensor& dropoutoffset) {
-  // do nothing if we got 0-element tensors
-  if (!q.numel() || !k.numel() || !v.numel() || !o.numel() || !dO.numel() ||
-      !softmaxstats.numel()) {
-    return;
-  }
-
-  Tensor dO_ = dO;
-  const auto innermost_dO_stride = dO.strides()[dO.strides().size() - 1];
-  if (innermost_dO_stride != 1) {
-    permute_to_matching_layout(o, dO_);
-  }
-
-  auto seqlen_q = at::diff(cum_seqlen_q, 1, 0);
-  auto seqlen_kv = at::diff(cum_seqlen_kv, 1, 0);
-  auto rag_q_off = cum_seqlen_q.mul(q.stride(-3));
-  auto rag_k_off = cum_seqlen_kv.mul(k.stride(-3));
-  auto rag_v_off = cum_seqlen_kv.mul(v.stride(-3));
-  auto rag_o_off = cum_seqlen_q.mul(o.stride(-3));
-  auto rag_stats_off = cum_seqlen_q.mul(h_q);
-
-  auto dprops = at::cuda::getCurrentDeviceProperties();
-  auto _dropoutseed = dropoutseed;
-  auto _dropoutoffset = dropoutoffset;
-  // cuDNN dropout bug requires these to be in int64
-  if (dprops->major == 10 && dprops->minor == 0) {
-    _dropoutseed = dropoutseed.to(kLong);
-    _dropoutoffset = dropoutoffset.to(kLong);
-  }
-
-  cudnnHandle_t handle = getCudnnHandle();
-
-  MHACacheKeyWrapper key(
-      b,
-      h_q,
-      s_q, // max-seqlen-q
-      s_kv, // max-seqlen-kv
-      d_qk,
-      d_v,
-      q,
-      k,
-      v,
-      attn_bias,
-      dropout_probability,
-      is_causal,
-      true,
-      true);
-
-  MHAGraphCache& cache = getMHAGraphCache_();
-  auto cache_it = cache.find(key);
-  std::unique_ptr<fe::graph::Graph> mha_graph_storage;
-  if (cache_it == cache.end()) {
-    mha_graph_storage = build_graph_backward_nestedtensor(
-        b,
-        h_q,
-        h_k,
-        h_v,
-        s_q,
-        s_kv,
-        d_qk,
-        d_v,
-        scaling_factor,
-        is_causal,
-        dropout_probability,
-        cum_seqlen_q,
-        cum_seqlen_kv,
-        q,
-        k,
-        v,
-        attn_bias,
-        o,
-        dO_,
-        softmaxstats,
-        dQ,
-        dK,
-        dV,
-        dropoutseed,
-        dropoutoffset,
-        handle);
-  }
-  const fe::graph::Graph& mha_graph =
-      mha_graph_storage ? *mha_graph_storage : *cache_it->second;
-
-  std::unordered_map<int64_t, void*> variant_pack = {
-      // inputs
-      {Q, q.mutable_data_ptr()},
-      {K, k.mutable_data_ptr()},
-      {V, v.mutable_data_ptr()},
-      {O, o.mutable_data_ptr()},
-      {DO, dO_.mutable_data_ptr()},
-      {LSE, softmaxstats.mutable_data_ptr()},
-      // outputs
-      {DQ, dQ.mutable_data_ptr()},
-      {DK, dK.mutable_data_ptr()},
-      {DV, dV.mutable_data_ptr()},
-      {SCALE, &scaling_factor},
-      {RAG_Q_OFF, rag_q_off.mutable_data_ptr()},
-      {RAG_O_OFF, rag_o_off.mutable_data_ptr()},
-      {RAG_K_OFF, rag_k_off.mutable_data_ptr()},
-      {RAG_V_OFF, rag_v_off.mutable_data_ptr()},
-      {RAG_LSE_OFF, rag_stats_off.mutable_data_ptr()},
-      {SEQ_LEN_Q, seqlen_q.mutable_data_ptr()},
-      {SEQ_LEN_KV, seqlen_kv.mutable_data_ptr()}};
-  if (dropout_probability != 0.0f) {
-    variant_pack[SEED] = _dropoutseed.mutable_data_ptr();
-    variant_pack[OFFSET] = _dropoutoffset.mutable_data_ptr();
-  }
-  TORCH_CHECK(
-      !attn_bias.has_value(),
-      "attn_bias not yet supported with cuDNN Attention and NestedTensor");
-
-  auto workspace_size = mha_graph.get_workspace_size();
-  auto workspace_ptr =
-      c10::cuda::CUDACachingAllocator::get()->allocate(workspace_size);
-  TORCH_CHECK(!workspace_size || workspace_ptr.get());
-  TORCH_CHECK(
-      mha_graph.execute(handle, variant_pack, workspace_ptr.get()).is_good());
+  TORCH_CHECK(false, "hipDNN SDPA does not support nested tensors");
 }
 
 } // namespace at::native

--- a/aten/src/ATen/native/cudnn/hip/MHA.cpp
+++ b/aten/src/ATen/native/cudnn/hip/MHA.cpp
@@ -274,9 +274,32 @@ struct MHACacheKeyWrapper : ParamsWrapper<MHAParams> {
   }
 };
 
+// Lazily-populated state for a single graph configuration.
+class MHAGraphCacheEntry {
+  std::optional<bool> is_supported_;
+  bool is_built_ = false;
+public:
+  std::unique_ptr<fe::graph::Graph> graph;
+
+  bool is_supported(hipdnnHandle_t handle) {
+    if (!is_supported_.has_value()) {
+      is_supported_ = graph->is_supported_ext(handle).is_good();
+    }
+    return *is_supported_;
+  }
+
+  const fe::graph::Graph& get_built_graph(hipdnnHandle_t handle) {
+    if (!is_built_) {
+      HIPDNN_FE_CHECK(graph->build(handle));
+      is_built_ = true;
+    }
+    return *graph;
+  }
+};
+
 struct MHAGraphCache {
   using KeyType = MHACacheKeyWrapper;
-  using ValueType = std::unique_ptr<fe::graph::Graph>;
+  using ValueType = MHAGraphCacheEntry;
   using MapType =
       std::unordered_map<KeyType, ValueType, ParamsWrapperHash<KeyType>>;
   using iterator = typename MapType::iterator;
@@ -316,16 +339,6 @@ struct MHAGraphCache {
   }
 };
 
-// Use thread local caches to avoid potential thread safety issues.
-static MHAGraphCache& getMHAGraphCache_() {
-  thread_local MHAGraphCache instance;
-  return instance;
-}
-
-static MHAGraphCache& getMHAGraphBackwardCache_() {
-  thread_local MHAGraphCache instance;
-  return instance;
-}
 
 namespace {
 
@@ -346,7 +359,7 @@ enum UIDS {
 
 } // namespace
 
-static std::unique_ptr<fe::graph::Graph> build_graph_structure(
+static std::unique_ptr<fe::graph::Graph> build_graph(
     const MHAParams& params) {
   auto mha_graph = std::make_unique<fe::graph::Graph>();
   mha_graph->set_intermediate_data_type(fe::DataType_t::FLOAT)
@@ -428,19 +441,7 @@ static std::unique_ptr<fe::graph::Graph> build_graph_structure(
   return mha_graph;
 }
 
-static std::unique_ptr<fe::graph::Graph> build_graph(
-    const MHAParams& params,
-    hipdnnHandle_t& handle) {
-  auto mha_graph = build_graph_structure(params);
-  HIPDNN_FE_CHECK(mha_graph->validate());
-  HIPDNN_FE_CHECK(mha_graph->build_operation_graph(handle));
-  HIPDNN_FE_CHECK(mha_graph->create_execution_plans({fe::HeurMode_t::FALLBACK}));
-  HIPDNN_FE_CHECK(mha_graph->check_support());
-  HIPDNN_FE_CHECK(mha_graph->build_plans());
-  return mha_graph;
-}
-
-static std::unique_ptr<fe::graph::Graph> build_graph_backward_structure(
+static std::unique_ptr<fe::graph::Graph> build_graph_backward(
     const MHAParams& params) {
   auto mha_graph = std::make_unique<fe::graph::Graph>();
   mha_graph->set_intermediate_data_type(fe::DataType_t::FLOAT)
@@ -544,21 +545,26 @@ static std::unique_ptr<fe::graph::Graph> build_graph_backward_structure(
   return mha_graph;
 }
 
-static std::unique_ptr<fe::graph::Graph> build_graph_backward(
-    const MHAParams& params,
-    hipdnnHandle_t& handle) {
-  auto mha_graph = build_graph_backward_structure(params);
-  HIPDNN_FE_CHECK(mha_graph->validate());
-  HIPDNN_FE_CHECK(mha_graph->build_operation_graph(handle));
-  HIPDNN_FE_CHECK(mha_graph->create_execution_plans({fe::HeurMode_t::FALLBACK}));
-  HIPDNN_FE_CHECK(mha_graph->check_support());
-  HIPDNN_FE_CHECK(mha_graph->build_plans());
-  return mha_graph;
+// Use thread local caches to avoid potential thread safety issues.
+static MHAGraphCacheEntry& getMHAGraphEntry_(const MHACacheKeyWrapper& key) {
+  thread_local MHAGraphCache instance;
+  MHAGraphCacheEntry& entry = instance.try_emplace(key).first->second;
+  if (!entry.graph) {
+    entry.graph = build_graph(key.pod);
+  }
+  return entry;
 }
 
-// TODO: cache the support result (and ideally the built graph) so we don't
-// rebuild it on every dispatch. Currently runs end-to-end graph build +
-// query for every can_use_cudnn_attention() call.
+static MHAGraphCacheEntry& getMHAGraphBackwardEntry_(
+    const MHACacheKeyWrapper& key) {
+  thread_local MHAGraphCache instance;
+  MHAGraphCacheEntry& entry = instance.try_emplace(key).first->second;
+  if (!entry.graph) {
+    entry.graph = build_graph_backward(key.pod);
+  }
+  return entry;
+}
+
 bool check_cudnn_sdpa_support(sdp::sdp_params const& params) {
   const Tensor& q = params.query;
   const Tensor& k = params.key;
@@ -589,9 +595,7 @@ bool check_cudnn_sdpa_support(sdp::sdp_params const& params) {
     const int64_t h_bias = rank == 4 ? bias.size(1) : 1;
     expanded_bias = bias.expand({b, h_bias, s_q, s_kv});
   }
-  MHAParams fwd_params;
-  setMHAParams(
-      fwd_params,
+  MHACacheKeyWrapper key(
       b,
       h,
       s_q,
@@ -608,18 +612,16 @@ bool check_cudnn_sdpa_support(sdp::sdp_params const& params) {
       return_softmaxstats);
 
   hipdnnHandle_t handle = getHipdnnHandle();
-  std::unique_ptr<fe::graph::Graph> fwd_graph =
-      build_graph_structure(fwd_params);
-  if (!fwd_graph->is_supported_ext(handle).is_good())
+  if (!getMHAGraphEntry_(key).is_supported(handle)) {
     return false;
+  }
 
   // Check that backwards is also supported here if it might be needed, since
   // we'll be expected to handle it too if we accept the forward pass.
   if (return_softmaxstats) {
-    std::unique_ptr<fe::graph::Graph> bwd_graph =
-        build_graph_backward_structure(fwd_params);
-    if (!bwd_graph->is_supported_ext(handle).is_good())
+    if (!getMHAGraphBackwardEntry_(key).is_supported(handle)) {
       return false;
+    }
   }
 
   return true;
@@ -677,11 +679,8 @@ void run_cudnn_SDP_fprop(
       dropout_probability,
       is_causal,
       return_softmaxstats);
-  auto [cache_it, _] = getMHAGraphCache_().try_emplace(key, nullptr);
-  if (cache_it->second == nullptr) {
-    cache_it->second = build_graph(key.pod, handle);
-  }
-  const fe::graph::Graph& mha_graph = *cache_it->second;
+  const fe::graph::Graph& mha_graph =
+      getMHAGraphEntry_(key).get_built_graph(handle);
   // Graph construction makes some assumptions based on constraints checked
   // earlier. Validate they hold by comparing metadata against tensors now that
   // they're available.
@@ -796,11 +795,8 @@ void run_cudnn_SDP_bprop(
       dropout_probability,
       is_causal,
       /*return_softmaxstats=*/true);
-  auto [cache_it, _] = getMHAGraphBackwardCache_().try_emplace(key, nullptr);
-  if (cache_it->second == nullptr) {
-    cache_it->second = build_graph_backward(key.pod, handle);
-  }
-  const fe::graph::Graph& mha_graph = *cache_it->second;
+  const fe::graph::Graph& mha_graph =
+      getMHAGraphBackwardEntry_(key).get_built_graph(handle);
   // Graph construction makes some assumptions based on constraints checked
   // earlier. Validate they hold by comparing metadata against tensors now that
   // they're available.

--- a/aten/src/ATen/native/cudnn/hip/MHA.cpp
+++ b/aten/src/ATen/native/cudnn/hip/MHA.cpp
@@ -135,6 +135,7 @@ namespace fe = hipdnn_frontend;
 
 constexpr uint8_t MAX_MHA_DIM = 4;
 
+// TODO: replace with shared hipDNN dtype util once one exists.
 static fe::DataType_t to_fe_data_type(c10::ScalarType t) {
   switch (t) {
     case kHalf:
@@ -237,6 +238,7 @@ static void setMHAParams(
   }
 }
 
+// TODO: lift to a shared hipDNN graph cache utility.
 struct MHACacheKeyWrapper : ParamsWrapper<MHAParams> {
   MHACacheKeyWrapper(
       int64_t b,
@@ -284,9 +286,7 @@ struct MHAGraphCache {
   int count = 0;
   int hits = 0;
 
-  // no mutexes here as caches are now thread local for v8, can also return a
-  // pointer to the Execution Plan if we know it will not be invalidated by
-  // another thread
+  // No mutexes — the cache is thread-local (see getMHAGraphCache_).
   iterator find(const KeyType& key) {
     static bool flag =
         c10::utils::check_env("TORCH_CUDNN_SDPA_CACHE_DEBUG") == true;
@@ -556,6 +556,9 @@ static std::unique_ptr<fe::graph::Graph> build_graph_backward(
   return mha_graph;
 }
 
+// TODO: cache the support result (and ideally the built graph) so we don't
+// rebuild it on every dispatch. Currently runs end-to-end graph build +
+// query for every can_use_cudnn_attention() call.
 bool check_cudnn_sdpa_support(
     int64_t b,
     int64_t h,
@@ -713,6 +716,8 @@ void run_cudnn_SDP_fprop(
     variant_pack[SEED] = dropoutseed.mutable_data_ptr();
     variant_pack[OFFSET] = dropoutoffset.mutable_data_ptr();
   }
+  // TODO: lift workspace allocation + execute to a shared util that takes a
+  // graph and variant_pack.
   int64_t workspace_size = 0;
   HIPDNN_FE_CHECK(mha_graph.get_workspace_size(workspace_size));
   auto workspace_ptr =

--- a/aten/src/ATen/native/mkldnn/xpu/Attention.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/Attention.cpp
@@ -262,7 +262,7 @@ int64_t _fused_sdp_choice_xpu(
     std::optional<double> scale,
     bool enable_gqa) {
   sdp::sdp_params kernel_params{
-      query_, key, value, attn_mask_, dropout_p, is_causal, enable_gqa};
+      query_, key, value, attn_mask_, dropout_p, is_causal, enable_gqa, scale};
   auto backend = select_sdp_backend_xpu(kernel_params);
 
   if (backend == sdp::SDPBackend::error) {

--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -432,7 +432,7 @@ std::tuple<Tensor, Tensor> native_multi_head_attention_cpu(
 
 int64_t _fused_sdp_choice_cpp(const Tensor& query_, const Tensor& key, const Tensor& value,
         const std::optional<Tensor>& attn_mask_, double dropout_p, bool is_causal, std::optional<double> scale, bool enable_gqa){
-  sdp::sdp_params kernel_params{query_, key, value, attn_mask_, dropout_p, is_causal, enable_gqa};
+  sdp::sdp_params kernel_params{query_, key, value, attn_mask_, dropout_p, is_causal, enable_gqa, scale};
   auto backend = sdp::select_sdp_backend_cpp(kernel_params);
   if (backend == sdp::SDPBackend::error) {
     TORCH_CHECK(

--- a/aten/src/ATen/native/transformers/cuda/attention.cu
+++ b/aten/src/ATen/native/transformers/cuda/attention.cu
@@ -784,7 +784,7 @@ std::tuple<Tensor, Tensor> native_multi_head_attention_cuda(
     auto k = key.view({key.size(0), -1, num_head, dim_per_head}).transpose(1, 2);
     auto v = value.view({value.size(0), -1, num_head, dim_per_head}).transpose(1, 2);
 
-    sdp::sdp_params kernel_params{q, k, v, mask, 0.0, false, false};
+    sdp::sdp_params kernel_params{q, k, v, mask, 0.0, false, false, /*scale=*/std::nullopt};
     auto backend = select_sdp_backend(kernel_params);
     // strides from packed projection for nested tensors when seq_len is 1 will be
     // and will trigger a contiguous call in the kernel, so we prevent this
@@ -1276,7 +1276,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor> _scaled_dot_product_efficient_attenti
 
 int64_t _fused_sdp_choice_cuda(const Tensor& query_, const Tensor& key, const Tensor& value,
         const std::optional<Tensor>& attn_mask_, double dropout_p, bool is_causal, std::optional<double> scale, bool enable_gqa){
-  sdp::sdp_params kernel_params{query_, key, value, attn_mask_, dropout_p, is_causal, enable_gqa};
+  sdp::sdp_params kernel_params{query_, key, value, attn_mask_, dropout_p, is_causal, enable_gqa, scale};
   auto backend = select_sdp_backend(kernel_params);
   if (backend == sdp::SDPBackend::error) {
     TORCH_CHECK(

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -764,18 +764,14 @@ bool can_use_cudnn_attention(const sdp_params& params, bool debug) {
   }
   return false;
 #else
+  // Honor torch.backends.cuda.enable_cudnn_sdp(False): users disable the cuDNN
+  // backend through the cuDNN flag, so opt-out applies to hipDNN as well.
   if (!check_runtime_disabled_cudnn(params, debug)) {
     return false;
   }
   if (!at::globalContext().userEnabledHipdnn()) {
     if (debug) {
       TORCH_WARN("hipDNN is not enabled. Set torch.backends.hipdnn.enabled = True");
-    }
-    return false;
-  }
-  if (!at::detail::getCUDAHooks().compiledWithHipDNN()) {
-    if (debug) {
-      TORCH_WARN("Not compiled with hipDNN.");
     }
     return false;
   }

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -815,22 +815,7 @@ bool can_use_cudnn_attention(const sdp_params& params, bool debug) {
     return false;
   }
   // Query hipDNN for engine availability.
-  const auto scale = sdp::calculate_scale(params.query, std::nullopt).expect_float();
-  bool supported = at::native::check_cudnn_sdpa_support(
-      params.query.size(0),
-      params.query.size(1),
-      params.query.size(2),
-      params.key.size(2),
-      params.query.size(3),
-      params.value.size(3),
-      scale,
-      input_requires_grad(params),
-      params.is_causal,
-      params.dropout,
-      params.query,
-      params.key,
-      params.value,
-      params.attn_mask);
+  const bool supported = at::native::check_cudnn_sdpa_support(params);
   if (!supported && debug) {
     TORCH_WARN("hipDNN SDPA: no engine available for the given input configuration. "
                "Set HIPDNN_LOG_LEVEL=info for details.");

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -30,6 +30,9 @@
 #include <aotriton/flash.h>
 #define USE_ROCM_ATTENTION 1
 #endif
+#if defined(USE_HIPDNN)
+#include <ATen/native/cudnn/MHA.h>
+#endif
 #else
 #define USE_ROCM_ATTENTION 0
 #endif
@@ -76,6 +79,10 @@ bool priority_order_init_ = false;
 // TODO(eqy): more benchmarking to determine whether this should include sm86/89
 // Needs to be kept in-sync with test_fused_chocie in test_transformers.py
 bool check_prefer_cudnn_attention() {
+  static const bool force_prefer = c10::utils::check_env("TORCH_CUDNN_SDPA_PREFERRED") == true;
+  if (force_prefer) {
+    return true;
+  }
   static const bool prefer_cudnn = c10::utils::check_env("TORCH_CUDNN_SDPA_DEPRIORITIZED") != true;
   if (!prefer_cudnn) {
     return false;
@@ -111,6 +118,17 @@ std::array<SDPBackend, num_backends> priority_order(sdp_params const& params) {
                                                   static_cast<int64_t>(at::SDPBackend::math)};
         at::globalContext().setSDPPriorityOrder(cudnn_order);
     }
+#if USE_ROCM
+    else {
+      // On ROCm, default to hipDNN above math fallback.
+      const std::vector<int64_t> rocm_order = {static_cast<int64_t>(at::SDPBackend::flash_attention),
+                                               static_cast<int64_t>(at::SDPBackend::efficient_attention),
+                                               static_cast<int64_t>(at::SDPBackend::cudnn_attention),
+                                               static_cast<int64_t>(at::SDPBackend::math),
+                                               static_cast<int64_t>(at::SDPBackend::overrideable)};
+      at::globalContext().setSDPPriorityOrder(rocm_order);
+    }
+#endif
   }
   return at::globalContext().sDPPriorityOrder();
 }
@@ -738,7 +756,94 @@ bool check_cudnn_deterministic(const sdp_params& params, bool debug) {
 } // namespace
 
 bool can_use_cudnn_attention(const sdp_params& params, bool debug) {
-#if defined(USE_ROCM) || !AT_CUDNN_ENABLED() || !defined(CUDNN_VERSION)
+#if defined(USE_ROCM)
+  // --- hipDNN path: PyTorch-level guards then delegate to graph-based check ---
+#if !defined(USE_HIPDNN)
+  if (debug) {
+    TORCH_WARN("Torch was not compiled with hipDNN.");
+  }
+  return false;
+#else
+  if (!check_runtime_disabled_cudnn(params, debug)) {
+    return false;
+  }
+  if (!at::globalContext().userEnabledHipdnn()) {
+    if (debug) {
+      TORCH_WARN("hipDNN is not enabled. Set torch.backends.hipdnn.enabled = True");
+    }
+    return false;
+  }
+  if (!at::detail::getCUDAHooks().compiledWithHipDNN()) {
+    if (debug) {
+      TORCH_WARN("Not compiled with hipDNN.");
+    }
+    return false;
+  }
+  if (has_for_nested_inputs(params)) {
+    if (debug) {
+      TORCH_WARN("hipDNN SDPA does not support nested tensors.");
+    }
+    return false;
+  }
+  if (!check_all_tensors_on_device(params, debug)) {
+    return false;
+  }
+  // Validate assumptions used in the translation to hipDNN.
+  constexpr auto hipdnn_dtypes =
+      c10::array_of<at::ScalarType>(at::kHalf, at::kBFloat16, at::kFloat, at::kDouble);
+  if (!check_tensor_dtype(params, hipdnn_dtypes, debug) ||
+      !check_tensor_shapes(params, debug)) {
+    return false;
+  }
+  // hipDNN doesn't currently have a way to query for deterministic support.
+  if (!check_cudnn_deterministic(params, debug)) {
+    return false;
+  }
+  // Constraint from 'attention.cu's _scaled_dot_product_cudnn_attention_cuda kernel
+  if (!check_attn_mask_shape(params, debug)) {
+    return false;
+  }
+  // Enforces enable_gqa=False: rejects mismatched h_q/h_k/h_v unless the user opted in.
+  // hipDNN infers GQA from head counts, so this must be checked here.
+  if (!check_batch_size_and_num_heads_dense<true /*supports_gqa*/, false /*requires_same_num_heads*/>(params, debug)) {
+    return false;
+  }
+
+  // We need concrete sizes to query availability, so bail out on symbolic shapes.
+  if (params.query.unsafeGetTensorImpl()->has_symbolic_sizes_strides() ||
+      params.key.unsafeGetTensorImpl()->has_symbolic_sizes_strides() ||
+      params.value.unsafeGetTensorImpl()->has_symbolic_sizes_strides()) {
+    if (debug) {
+      TORCH_WARN("hipDNN SDPA: static shapes are required");
+    }
+    return false;
+  }
+  // Query hipDNN for engine availability.
+  const auto scale = sdp::calculate_scale(params.query, std::nullopt).expect_float();
+  bool supported = at::native::check_cudnn_sdpa_support(
+      params.query.size(0),
+      params.query.size(1),
+      params.query.size(2),
+      params.key.size(2),
+      params.query.size(3),
+      params.value.size(3),
+      scale,
+      input_requires_grad(params),
+      params.is_causal,
+      params.dropout,
+      params.query,
+      params.key,
+      params.value,
+      params.attn_mask);
+  if (!supported && debug) {
+    TORCH_WARN("hipDNN SDPA: no engine available for the given input configuration. "
+               "Set HIPDNN_LOG_LEVEL=info for details.");
+  }
+  return supported;
+#endif // USE_HIPDNN
+
+#else // !USE_ROCM — cuDNN path
+#if !AT_CUDNN_ENABLED() || !defined(CUDNN_VERSION)
   if (debug) {
     TORCH_WARN("Torch was not compiled with cuDNN attention.");
   }
@@ -794,6 +899,7 @@ bool can_use_cudnn_attention(const sdp_params& params, bool debug) {
     }
   }
   return true;
+#endif // !USE_ROCM
 }
 
 bool is_flash_attention_available() {

--- a/aten/src/ATen/native/transformers/sdp_utils.h
+++ b/aten/src/ATen/native/transformers/sdp_utils.h
@@ -1,8 +1,42 @@
 #pragma once
 #include <ATen/ATen.h>
+#include <ATen/ExpandUtils.h>
 #include <ATen/core/Tensor.h>
 
 namespace at::native {
+
+// Compute dense strides that preserve the dimension ordering of ref_strides
+// for the given shape. When ref_sizes == shape, uses infer_dense_strides to
+// match empty_like's behavior (compacting non-dense gaps).
+inline std::vector<int64_t> compute_matching_strides(
+    IntArrayRef ref_sizes,
+    IntArrayRef ref_strides,
+    IntArrayRef shape) {
+  if (ref_sizes.equals(shape)) {
+    return infer_dense_strides(ref_sizes, ref_strides);
+  }
+
+  // get the "fill order," which is just an argsort on the strides
+  std::vector<int> fill_order(shape.size());
+  std::iota(fill_order.begin(), fill_order.end(), 0);
+  // note: why INT64_MAX instead of 1.
+  // When Q's strides include 0, e.g. (0, 0, 128, 1), mapping stride 0 to 1 leads to
+  // fill_order of [0, 1, 3, 2], i.e. the output strides are [1, 8, 1024, 16].
+  // To match output strides with Q, use INT64_MAx so that broadcast dims come last in fill_order.
+  std::stable_sort(
+      fill_order.begin(), fill_order.end(), [&ref_strides](int idx1, int idx2) {
+        int64_t s1 = ref_strides[idx1] ? ref_strides[idx1] : INT64_MAX;
+        int64_t s2 = ref_strides[idx2] ? ref_strides[idx2] : INT64_MAX;
+        return s1 < s2;
+      });
+  std::vector<int64_t> ordered_strides(shape.size());
+  int64_t current_stride = 1;
+  for (const int dim_idx : fill_order) {
+    ordered_strides[dim_idx] = current_stride;
+    current_stride *= shape[dim_idx];
+  }
+  return ordered_strides;
+}
 
 void alloc_with_matching_layout(
     const Tensor& q,
@@ -12,32 +46,8 @@ void alloc_with_matching_layout(
       shape.size() == q.sizes().size(),
       "SDPA alloc_with_matching_layout got requested shape ndim != q ndim");
 
-  if (std::equal(q.sizes().begin(), q.sizes().end(), shape.begin())) {
-    output = at::empty_like(q);
-    return;
-  }
-
-  // get the "fill order," which is just an argsort on the strides
-  std::vector<int> fill_order(shape.size());
-  std::iota(fill_order.begin(), fill_order.end(), 0);
-  const auto q_strides = q.strides();
-  // note: why INT64_MAX instead of 1.
-  // When Q's strides include 0, e.g. (0, 0, 128, 1), mapping stride 0 to 1 leads to
-  // fill_order of [0, 1, 3, 2], i.e. the output strides are [1, 8, 1024, 16].
-  // To match output strides with Q, use INT64_MAx so that broadcast dims come last in fill_order.
-  std::stable_sort(
-      fill_order.begin(), fill_order.end(), [&q_strides](int idx1, int idx2) {
-        int64_t s1 = q_strides[idx1] ? q_strides[idx1] : INT64_MAX;
-        int64_t s2 = q_strides[idx2] ? q_strides[idx2] : INT64_MAX;
-        return s1 < s2;
-      });
-  std::vector<int64_t> ordered_strides(shape.size());
-  int64_t current_stride = 1;
-  for (const int dim_idx : fill_order) {
-    ordered_strides[dim_idx] = current_stride;
-    current_stride *= shape[dim_idx];
-  }
-  output = at::empty_strided(at::IntArrayRef(shape), at::IntArrayRef(ordered_strides), q.options());
+  auto strides = compute_matching_strides(q.sizes(), q.strides(), shape);
+  output = at::empty_strided(shape, strides, q.options());
 }
 
 void permute_to_matching_layout(const Tensor& output, Tensor& grad_output) {

--- a/aten/src/ATen/native/transformers/sdp_utils_cpp.h
+++ b/aten/src/ATen/native/transformers/sdp_utils_cpp.h
@@ -42,6 +42,7 @@ struct sdp_params {
   double dropout;
   bool is_causal;
   bool enable_gqa;
+  std::optional<double> scale;
 };
 
 SDPBackend select_sdp_backend_cpp(sdp_params const& kernel_params);

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -62,6 +62,10 @@ from torch.testing._internal.common_xpu import PLATFORM_SUPPORTS_FLASH_ATTENTION
 if TEST_FAIRSEQ:
     import fairseq.models.transformer as fairseq_transformer
 
+# hipDNN is currently disabled by default. Force enable in tests for now.
+if torch.backends.hipdnn.is_available():
+    torch.backends.hipdnn.set_flags(True)
+
 SdpaShape = namedtuple('Sdpa_Shape', ['batch', 'num_heads', 'seq_len', 'head_dim'])
 Tolerances = namedtuple('Tolerances', ['atol', 'rtol'])
 
@@ -1694,7 +1698,10 @@ class TestSDPAFailureModes(NNTestCase):
             size = SdpaShape(2, 2, 8, 8)
             q, k, v = make_tensor(size), make_tensor(size), make_tensor(size)
             q.as_strided_(size, [2, 2, 2, 2])
-            with self.assertWarnsRegex(UserWarning, "All fused kernels require the last dimension of the input to have stride 1."):
+            expected_warning = "All fused kernels require the last dimension of the input to have stride 1."
+            if kernel == SDPBackend.CUDNN_ATTENTION and TEST_WITH_ROCM:
+                expected_warning = "hipDNN SDPA: no engine available for the given input configuration."
+            with self.assertWarnsRegex(UserWarning, expected_warning):
                 self.assertRaises(RuntimeError, lambda: torch.nn.functional.scaled_dot_product_attention(
                     q, k, v, None, 0.0, False))
 
@@ -1768,8 +1775,13 @@ class TestSDPAFailureModes(NNTestCase):
             size = SdpaShape(2, 2, 3, 16)
             make_tensor = partial(torch.rand, device=device, dtype=torch.float64)
             q, k, v = make_tensor(size), make_tensor(size), make_tensor(size)
-            self.assertRaises(RuntimeError, lambda: torch.nn.functional.scaled_dot_product_attention(
-                q, k, v, None, 0.0, False))
+            run_fn = lambda: torch.nn.functional.scaled_dot_product_attention(q, k, v, None, 0.0, False)
+            if kernel == SDPBackend.CUDNN_ATTENTION and TEST_WITH_ROCM:
+                # hipDNN accepts f64 inputs
+                run_fn()
+            else:
+                self.assertRaises(RuntimeError, run_fn)
+
 
     @onlyCUDA
     @unittest.skipIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Does not support flash attention")
@@ -3043,7 +3055,10 @@ class TestSDPACudaOnly(NNTestCase):
         out_ref = F.scaled_dot_product_attention(
             q_bc.contiguous(), k_bc.contiguous(), v_bc.contiguous(), is_causal=True
         )
-        torch.testing.assert_close(out, out_ref, atol=3e-3, rtol=3e-3)
+        atol, rtol = 3e-3, 3e-3
+        if TEST_WITH_ROCM and dtype == torch.bfloat16:
+            atol, rtol = 2e-2, 2e-2
+        torch.testing.assert_close(out, out_ref, atol=atol, rtol=rtol)
 
     @unittest.skipIf(not PLATFORM_SUPPORTS_CUDNN_ATTENTION, "cudnn Attention is not supported on this system")
     @unittest.skipIf(
@@ -3112,6 +3127,7 @@ class TestSDPACudaOnly(NNTestCase):
             out = torch.nn.functional.scaled_dot_product_attention(q, q, q, dropout_p=0.5)
             out.backward(grad)
 
+    @skipIfRocm # This tests cudnn-specific rounding behaviour, skip on ROCM
     @unittest.skipIf(not PLATFORM_SUPPORTS_CUDNN_ATTENTION, "cudnn Attention is not supported on this system")
     def test_cudnn_attention_low_dropout(self):
         q = torch.randn(2, 8, 128, 128, dtype=torch.half, device='cuda')
@@ -3578,10 +3594,14 @@ class TestSDPACudaOnly(NNTestCase):
         if "cuda" in str(device):
             device_capability = torch.cuda.get_device_capability()
         prefer_cudnn = "TORCH_CUDNN_SDPA_PREFERRED" not in os.environ or bool(os.environ["TORCH_CUDNN_SDPA_PREFERRED"])
-        # cuDNN prioritization requires cuDNN > 9.15.0 (91500) per sdp_utils.cpp:83
-        cudnn_version = torch.backends.cudnn.version() if torch.backends.cudnn.is_available() else 0
-        is_hopper_or_newer = device_capability and (device_capability[0] == 9 or device_capability[0] == 10)
-        prefer_cudnn = prefer_cudnn and is_hopper_or_newer and cudnn_version > 91500
+        if TEST_WITH_ROCM:
+            # hipDNN is not prioritized
+            prefer_cudnn = False
+        else:
+            # cuDNN prioritization requires cuDNN > 9.15.0 (91500) per sdp_utils.cpp:83
+            cudnn_version = torch.backends.cudnn.version() if torch.backends.cudnn.is_available() else 0
+            is_hopper_or_newer = device_capability and (device_capability[0] == 9 or device_capability[0] == 10)
+            prefer_cudnn = prefer_cudnn and is_hopper_or_newer and cudnn_version > 91500
 
         # cuDNN is enabled by default on SM 9.0/10.0 with cuDNN > 9.15.0 (per #169849)
         # For older cuDNN versions or other architectures, Flash Attention is preferred
@@ -3659,8 +3679,11 @@ class TestSDPACudaOnly(NNTestCase):
             times.append(t1 - t0)
         self.assertTrue(times[0] < times[1], "expected cuDNN SDPA to be faster than Math backend.")
         self.assertTrue(times[1] > times[2], "expected Eff Attn backend to faster than Math backend.")
-        self.assertTrue(times[3] < times[2], "expected Flash Attn backend to faster than Math backend.")
-        self.assertTrue(times[0] < times[2], "expected cuDNN Attn backend to faster than Eff Attn backend.")
+        if not TEST_WITH_ROCM:
+            # Skip some checks on ROCM. hipDNN is currently slower than Eff Attn,
+            # and Flash/Eff are roughly equal.
+            self.assertTrue(times[3] < times[2], "expected Flash Attn backend to faster than Eff Attn backend.")
+            self.assertTrue(times[0] < times[2], "expected cuDNN Attn backend to faster than Eff Attn backend.")
         reset_order = torch._C._get_sdp_priority_order()
         self.assertEqual(default_order, reset_order, "expected SDPA context manager to reset priority order.")
 

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -3247,6 +3247,24 @@ class TestSDPACudaOnly(NNTestCase):
         with sdpa_kernel([SDPBackend.MATH]):
             self.assertFalse(torch.backends.cuda.can_use_cudnn_attention(params))
 
+    @unittest.skipIf(not PLATFORM_SUPPORTS_FUSED_ATTENTION, "Fused SDPA was not built for this system")
+    @parametrize("kernel", PLATFORM_SPECIFIC_SDPA)
+    def test_fused_attention_custom_scale(self, device, kernel: SDPBackend):
+        dtype = torch.bfloat16
+        make_tensor = partial(torch.rand, device=device, dtype=dtype)
+        size = SdpaShape(2, 4, 128, 64)
+        query, key, value = make_tensor(size), make_tensor(size), make_tensor(size)
+        # Custom scale that differs from the default 1/sqrt(head_dim).
+        scale = 0.05
+
+        with sdpa_kernel(backends=[SDPBackend.MATH]):
+            math_ref = F.scaled_dot_product_attention(query, key, value, scale=scale)
+
+        with sdpa_kernel(backends=[kernel]):
+            actual = F.scaled_dot_product_attention(query, key, value, scale=scale)
+
+        self.assertEqual(actual, math_ref, atol=2e-2, rtol=2e-2)
+
     @unittest.skipIf(not PLATFORM_SUPPORTS_MEM_EFF_ATTENTION, "Fused SDPA was not built for this system")
     @parametrize("mask_dim", [1, 2, 3, 4])
     def test_mem_efficient_attention_mask_variants(self, device, mask_dim: list[int]):

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -3222,6 +3222,15 @@ class TestSDPACudaOnly(NNTestCase):
             )
         self.assertEqual(attn_output_math, attn_output_cudnn, atol=5e-3, rtol=3e-3)
 
+    @unittest.skipIf(not PLATFORM_SUPPORTS_CUDNN_ATTENTION, "cuDNN Attention is not supported on this system")
+    def test_cudnn_attention_runtime_disabled(self, device):
+        q = torch.empty(2, 8, 128, 64, dtype=torch.bfloat16, device=device)
+        params = torch.backends.cuda.SDPAParams(q, q, q, None, 0.0, False, False)
+        with sdpa_kernel([SDPBackend.CUDNN_ATTENTION]):
+            self.assertTrue(torch.backends.cuda.can_use_cudnn_attention(params))
+        with sdpa_kernel([SDPBackend.MATH]):
+            self.assertFalse(torch.backends.cuda.can_use_cudnn_attention(params))
+
     @unittest.skipIf(not PLATFORM_SUPPORTS_MEM_EFF_ATTENTION, "Fused SDPA was not built for this system")
     @parametrize("mask_dim", [1, 2, 3, 4])
     def test_mem_efficient_attention_mask_variants(self, device, mask_dim: list[int]):

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -53,6 +53,7 @@ from torch.testing._internal.common_cuda import (
     PLATFORM_SUPPORTS_FUSED_ATTENTION,
     PLATFORM_SUPPORTS_CUDNN_ATTENTION,
     PLATFORM_SUPPORTS_CK_SDPA,
+    TEST_HIPDNN,
     tf32_on_and_off,
     tf32_enabled,
 )
@@ -62,7 +63,7 @@ from torch.testing._internal.common_xpu import PLATFORM_SUPPORTS_FLASH_ATTENTION
 if TEST_FAIRSEQ:
     import fairseq.models.transformer as fairseq_transformer
 
-# hipDNN is currently disabled by default. Force enable in tests for now.
+# TODO: drop once an env-var toggle replaces the Python-level enable.
 if torch.backends.hipdnn.is_available():
     torch.backends.hipdnn.set_flags(True)
 
@@ -1699,7 +1700,7 @@ class TestSDPAFailureModes(NNTestCase):
             q, k, v = make_tensor(size), make_tensor(size), make_tensor(size)
             q.as_strided_(size, [2, 2, 2, 2])
             expected_warning = "All fused kernels require the last dimension of the input to have stride 1."
-            if kernel == SDPBackend.CUDNN_ATTENTION and TEST_WITH_ROCM:
+            if kernel == SDPBackend.CUDNN_ATTENTION and TEST_HIPDNN:
                 expected_warning = "hipDNN SDPA: no engine available for the given input configuration."
             with self.assertWarnsRegex(UserWarning, expected_warning):
                 self.assertRaises(RuntimeError, lambda: torch.nn.functional.scaled_dot_product_attention(

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -2673,7 +2673,8 @@ Call this whenever a new thread is created in order to propagate values from
                        std::optional<at::Tensor> attn_mask,
                        double dropout,
                        bool is_causal,
-                       bool enable_gqa) {
+                       bool enable_gqa,
+                       std::optional<double> scale) {
         return sdp::sdp_params{
             query,
             key,
@@ -2681,15 +2682,25 @@ Call this whenever a new thread is created in order to propagate values from
             std::move(attn_mask),
             dropout,
             is_causal,
-            enable_gqa};
-      }))
+            enable_gqa,
+            scale};
+      }),
+          py::arg("query"),
+          py::arg("key"),
+          py::arg("value"),
+          py::arg("attn_mask"),
+          py::arg("dropout"),
+          py::arg("is_causal"),
+          py::arg("enable_gqa"),
+          py::arg("scale") = std::nullopt)
       .def_readonly("query", &sdp::sdp_params::query)
       .def_readonly("key", &sdp::sdp_params::key)
       .def_readonly("value", &sdp::sdp_params::value)
       .def_readonly("attn_mask", &sdp::sdp_params::attn_mask)
       .def_readonly("dropout", &sdp::sdp_params::dropout)
       .def_readonly("is_causal", &sdp::sdp_params::is_causal)
-      .def_readonly("enable_gqa", &sdp::sdp_params::enable_gqa);
+      .def_readonly("enable_gqa", &sdp::sdp_params::enable_gqa)
+      .def_readonly("scale", &sdp::sdp_params::scale);
 
   py::enum_<sdp::SDPBackend>(
       py_module,

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -101,7 +101,9 @@ def evaluate_platform_supports_efficient_attention():
     return False
 
 def evaluate_platform_supports_cudnn_attention():
-    return (not TEST_WITH_ROCM) and SM80OrLater and (TEST_CUDNN_VERSION >= 90000)
+    if TEST_WITH_ROCM:
+        return TEST_HIPDNN
+    return SM80OrLater and (TEST_CUDNN_VERSION >= 90000)
 
 def evaluate_platform_supports_green_context():
     if IS_WINDOWS:


### PR DESCRIPTION
This PR adds hipDNN as a supported backend for SDPA.

The approach taken here is to re-use the existing `CUDNN_ATTENTION` backend, adding support for it by routing through hipDNN when compiled for ROCm. i.e. `torch.nn.attention.SDPBackend.CUDNN_ATTENTION` and `aten::_scaled_dot_product_cudnn_attention` now work on ROCm.

The primary change here is adding `cudnn/hip/MHA.cpp`, which is a "fork" of `cudnn/MHA.cpp`, modified to use hipDNN instead of cuDNN. There's various differences between the implementations that made it simpler to just fork the entire file rather than trying to keep both implementations in the same file/rely on hipify for translation:
- various minor API differences between cuDNN/hipDNN which made it difficult to re-use code directly
- differences in feature support: hipDNN doesn't support nested tensors which simplifies a lot of code, however it *is* more flexible in other aspects e.g. dtypes. 

Additionally, since hipDNN provides an API for querying engine support for a graph, during backend selection `sdp::can_use_cudnn_attention` calls the newly added `at::native::check_cudnn_sdpa_support`, which constructs the hipDNN graph for both forwards and backwards (if potentially needed) to query support. This is *not* cached, as it's assumed construction + querying support is implemented efficiently. The sequence of hipDNN calls:
```
                SELECTION
                ─────────
       sdp::can_use_cudnn_attention()
                    │
                    ▼
    at::native::check_cudnn_sdpa_support()
                    │
                    ▼
     fe::graph::Graph::is_supported_ext()
                    │
                    ▼
                   bool
    
                EXECUTION
                ─────────
  at::native::run_cudnn_SDP_{fprop,bprop}()
                    │
                    ▼
           MHAGraphCache lookup
                    │
               ┌────┴────┐
               ▼         ▼
             HIT:      MISS:
             reuse       │
             cached      ▼
             graph     fe::graph::Graph::validate()
               │       fe::graph::Graph::build_operation_graph()
               │       fe::graph::Graph::create_execution_plans()
               │       fe::graph::Graph::check_support()
               │       fe::graph::Graph::build_plans()
               │         │
               └────┬────┘
                    ▼
         fe::graph::Graph::execute()

```

Both backends still share the same `attention.cu` kernel (hipDNN uses the hipified version).


This is separated into a stack of PRs for easier review:
- PR 1/3: [[ROCm] Stop hipifying native/cudnn/ and native/quantized/cudnn/ files](https://github.com/ROCm/pytorch/pull/3196)
    - Various cudnn files are being hipified at the moment, with no functional purpose (it just results in code that's `ifdef`'d out. This disables the hipification rules and fixes up includes/directives so the CUDA files compile cleanly on ROCM. The primary motivation here is to stop generating `cudnn/hip/MHA.cpp`; the following changes add this file back with the hipDNN backend implementation.

- **PR 2/3: [[ROCm] Integrate hipDNN as an SDPA backend](https://github.com/ROCm/pytorch/pull/3197) (this PR)**
  - I'd recommend reviewing the individual commits here:
    - `Add aotriton.images/ to .gitignore` - NFC change
    - `Extract compute_matching_strides from alloc_with_matching_layout` - NFC change
    - `Split cudnn/MHA.cpp into separate cuDNN and hipDNN files`
    - `Copy cuDNN MHA implementation verbatim into hipDNN MHA`
      - This is just to make it easier to review the next commit, as it shows the diff between cuDNN and hipDNN.
    - `[ROCm] Add hipDNN SDPA backend dispatch`
      - Primary implementation, looking at this commit will likely be the easiest way to review the hipDNN specific changes.
    - `Update tests to reflect cudnn backend being available on ROCM.`
      - `CUDNN_ATTENTION` tests can now be run on ROCm.

- PR 3/3: [[ROCm] Pass bool attention masks directly to hipDNN](https://github.com/ROCm/pytorch/pull/3198)
    - hipDNN supports boolean attention masks more efficiently than float masks. This skips the float->bool conversion that's normally done, and passes the original mask directly to hipDNN.

Open questions for reviewers:
- Reusing the `CUDNN_ATTENTION` backend was done due to API similarities, though this could potentially be confusing. Would it be preferrable to completely separate hipDNN by adding a new backend?
- Would additional code-sharing between the cuDNN and hipDNN `MHA.cpp` files be recommended?
