### PR TITLE
[ROCm] Pass bool attention masks directly to hipDNN

### DIFF
--- a/aten/src/ATen/native/cudnn/hip/MHA.cpp
+++ b/aten/src/ATen/native/cudnn/hip/MHA.cpp
@@ -146,6 +146,8 @@ static fe::DataType_t to_fe_data_type(c10::ScalarType t) {
       return fe::DataType_t::FLOAT;
     case kDouble:
       return fe::DataType_t::DOUBLE;
+    case kBool:
+      return fe::DataType_t::BOOLEAN;
     default:
       TORCH_CHECK(false, "hipDNN SDPA: unexpected tensor dtype ", t);
   }
@@ -168,6 +170,7 @@ static void check_tensor_matches_graph(
 struct MHAParams {
   c10::DeviceIndex device_id;
   fe::DataType_t dataType;
+  fe::DataType_t bias_dtype;
   float scaling_factor;
   std::array<int64_t, MAX_MHA_DIM> q_dim;
   std::array<int64_t, MAX_MHA_DIM> k_dim;
@@ -227,6 +230,7 @@ static void setMHAParams(
   std::copy(v.strides().begin(), v.strides().end(), params.v_stride.begin());
   // uninit is OK as the struct is memset 0'd
   if (params.has_attn_bias) {
+    params.bias_dtype = to_fe_data_type(attn_bias.value().scalar_type());
     std::copy(
         attn_bias.value().sizes().begin(),
         attn_bias.value().sizes().end(),
@@ -416,7 +420,7 @@ static std::unique_ptr<fe::graph::Graph> build_graph(
             .set_name("bias")
             .set_dim(std::vector(params.bias_dim.begin(), params.bias_dim.end()))
             .set_stride(std::vector(params.bias_stride.begin(), params.bias_stride.end()))
-            .set_data_type(params.dataType)));
+            .set_data_type(params.bias_dtype)));
   }
 
   auto [O_, Stats] =
@@ -479,7 +483,7 @@ static std::unique_ptr<fe::graph::Graph> build_graph_backward(
             .set_name("bias")
             .set_dim(std::vector(params.bias_dim.begin(), params.bias_dim.end()))
             .set_stride(std::vector(params.bias_stride.begin(), params.bias_stride.end()))
-            .set_data_type(params.dataType)));
+            .set_data_type(params.bias_dtype)));
   }
 
   // Metadata for seed/offset/O/stats are hardcoded here, based on the

--- a/aten/src/ATen/native/cudnn/hip/MHA.cpp
+++ b/aten/src/ATen/native/cudnn/hip/MHA.cpp
@@ -145,6 +145,8 @@ static fe::DataType_t to_fe_data_type(c10::ScalarType t) {
       return fe::DataType_t::FLOAT;
     case kDouble:
       return fe::DataType_t::DOUBLE;
+    case kBool:
+      return fe::DataType_t::BOOLEAN;
     default:
       TORCH_CHECK(false, "hipDNN SDPA: unexpected tensor dtype ", t);
   }
@@ -167,6 +169,7 @@ static void check_tensor_matches_graph(
 struct MHAParams {
   c10::DeviceIndex device_id;
   fe::DataType_t dataType;
+  fe::DataType_t bias_dtype;
   float scaling_factor;
   std::array<int64_t, MAX_MHA_DIM> q_dim;
   std::array<int64_t, MAX_MHA_DIM> k_dim;
@@ -226,6 +229,7 @@ static void setMHAParams(
   std::copy(v.strides().begin(), v.strides().end(), params.v_stride.begin());
   // uninit is OK as the struct is memset 0'd
   if (params.has_attn_bias) {
+    params.bias_dtype = to_fe_data_type(attn_bias.value().scalar_type());
     std::copy(
         attn_bias.value().sizes().begin(),
         attn_bias.value().sizes().end(),
@@ -412,7 +416,7 @@ static std::unique_ptr<fe::graph::Graph> build_graph_structure(
             .set_name("bias")
             .set_dim(std::vector(params.bias_dim.begin(), params.bias_dim.end()))
             .set_stride(std::vector(params.bias_stride.begin(), params.bias_stride.end()))
-            .set_data_type(params.dataType)));
+            .set_data_type(params.bias_dtype)));
   }
 
   auto [O_, Stats] =
@@ -495,7 +499,7 @@ static std::unique_ptr<fe::graph::Graph> build_graph_backward_structure(
             .set_name("bias")
             .set_dim(std::vector(params.bias_dim.begin(), params.bias_dim.end()))
             .set_stride(std::vector(params.bias_stride.begin(), params.bias_stride.end()))
-            .set_data_type(params.dataType)));
+            .set_data_type(params.bias_dtype)));
   }
 
   // Metadata for seed/offset/O/stats are hardcoded here, based on the

--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -751,9 +751,15 @@ Tensor scaled_dot_product_attention(
   }
   const auto query_device_type = query_.device().type();
   const auto backend = static_cast<SDPBackend>(choice_int);
-  auto attn_mask = convert_boolean_attn_mask(attn_mask_, query_.dtype());
   switch (backend) {
     case SDPBackend::cudnn_attention: {
+      // Skip the bool attention mask conversion on ROCm, as hipDNN handles
+      // bool masks itself.
+#if defined(USE_ROCM)
+      auto attn_mask = attn_mask_;
+#else
+      auto attn_mask = convert_boolean_attn_mask(attn_mask_, query_.dtype());
+#endif
       bool compute_logsumexp = should_compute_logsumexp(query_, key, value);
       auto out_lse_softmax = at::_scaled_dot_product_cudnn_attention(
           query_, key, value, attn_mask, compute_logsumexp, dropout_p, is_causal, false /*return_debug_mask*/, scale);
@@ -774,10 +780,12 @@ Tensor scaled_dot_product_attention(
         return post_process_flash_output(std::get<0>(out_lse_softmax), og_size);
       }
       // For the CPU case we do not need to pad the last dim
+      auto attn_mask = convert_boolean_attn_mask(attn_mask_, query_.dtype());
       return std::get<0>(at::_scaled_dot_product_flash_attention_for_cpu(
           query_, key, value, dropout_p, is_causal, attn_mask, scale));
     }
     case SDPBackend::efficient_attention: {
+      auto attn_mask = convert_boolean_attn_mask(attn_mask_, query_.dtype());
       bool compute_logsumexp = should_compute_logsumexp(query_, key, value);
       if (attn_mask.has_value()) {
         attn_mask.value() = preprocess_mask(attn_mask.value(), query_, key, value);;
@@ -787,11 +795,13 @@ Tensor scaled_dot_product_attention(
       return std::get<0>(out_and_lse);
     }
     case SDPBackend::overrideable: {
+      auto attn_mask = convert_boolean_attn_mask(attn_mask_, query_.dtype());
       auto out_lse_softmax = at::_scaled_dot_product_fused_attention_overrideable(
           query_, key, value, attn_mask, dropout_p, is_causal, false /*return_debug_mask*/, scale);
       return std::get<0>(out_lse_softmax);
     }
     case SDPBackend::math: {
+      auto attn_mask = convert_boolean_attn_mask(attn_mask_, query_.dtype());
       const bool any_inputs_require_grad = query_.requires_grad() || key.requires_grad() || value.requires_grad();
       if (query_device_type == c10::kMPS && !(at::GradMode::is_enabled() && any_inputs_require_grad)) {
         return std::get<0>(at::_scaled_dot_product_attention_math_for_mps(

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -3161,6 +3161,43 @@ class TestSDPACudaOnly(NNTestCase):
             self.assertFalse(dk.isnan().any())
             self.assertFalse(dv.isnan().any())
 
+    @unittest.skipIf(not PLATFORM_SUPPORTS_CUDNN_ATTENTION, "cudnn Attention is not supported on this system")
+    def test_cudnn_attention_bool_mask(self):
+        # Simple bool attn_mask test.
+        q = torch.randn(2, 4, 8, 16, dtype=torch.bfloat16, device='cuda')
+        k = torch.randn(2, 4, 8, 16, dtype=torch.bfloat16, device='cuda')
+        v = torch.randn(2, 4, 8, 16, dtype=torch.bfloat16, device='cuda')
+
+        attn_mask = torch.tril(torch.ones(8, 8, dtype=torch.bool, device='cuda'))
+
+        with sdpa_kernel(SDPBackend.MATH):
+            out_math = torch.nn.functional.scaled_dot_product_attention(
+                q, k, v, attn_mask=attn_mask)
+        with sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
+            out_cudnn = torch.nn.functional.scaled_dot_product_attention(
+                q, k, v, attn_mask=attn_mask)
+
+        self.assertEqual(out_math, out_cudnn, atol=5e-3, rtol=3e-3)
+
+    @unittest.skipIf(not PLATFORM_SUPPORTS_CUDNN_ATTENTION, "cudnn Attention is not supported on this system")
+    def test_cudnn_attention_mismatched_mask_dtype(self):
+        # Float attn_mask with a dtype different from Q (bf16 Q, fp32 mask).
+        q = torch.randn(2, 4, 8, 16, dtype=torch.bfloat16, device='cuda')
+        k = torch.randn(2, 4, 8, 16, dtype=torch.bfloat16, device='cuda')
+        v = torch.randn(2, 4, 8, 16, dtype=torch.bfloat16, device='cuda')
+
+        bool_mask = torch.tril(torch.ones(8, 8, dtype=torch.bool, device='cuda'))
+        attn_mask = torch.where(bool_mask, 0.0, float('-inf')).to(torch.float32)
+
+        with sdpa_kernel(SDPBackend.MATH):
+            out_math = torch.nn.functional.scaled_dot_product_attention(
+                q, k, v, attn_mask=attn_mask)
+        with sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
+            out_cudnn = torch.nn.functional.scaled_dot_product_attention(
+                q, k, v, attn_mask=attn_mask)
+
+        self.assertEqual(out_math, out_cudnn, atol=5e-3, rtol=3e-3)
+
     @skipIfRocm
     @unittest.skipIf(not PLATFORM_SUPPORTS_CUDNN_ATTENTION, "cudnn Attention is not supported on this system")
     def test_cudnn_attention_mask_broken_177842(self):

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -3162,6 +3162,43 @@ class TestSDPACudaOnly(NNTestCase):
             self.assertFalse(dk.isnan().any())
             self.assertFalse(dv.isnan().any())
 
+    @unittest.skipIf(not PLATFORM_SUPPORTS_CUDNN_ATTENTION, "cudnn Attention is not supported on this system")
+    def test_cudnn_attention_bool_mask(self):
+        # Simple bool attn_mask test.
+        q = torch.randn(2, 4, 8, 16, dtype=torch.bfloat16, device='cuda')
+        k = torch.randn(2, 4, 8, 16, dtype=torch.bfloat16, device='cuda')
+        v = torch.randn(2, 4, 8, 16, dtype=torch.bfloat16, device='cuda')
+
+        attn_mask = torch.tril(torch.ones(8, 8, dtype=torch.bool, device='cuda'))
+
+        with sdpa_kernel(SDPBackend.MATH):
+            out_math = torch.nn.functional.scaled_dot_product_attention(
+                q, k, v, attn_mask=attn_mask)
+        with sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
+            out_cudnn = torch.nn.functional.scaled_dot_product_attention(
+                q, k, v, attn_mask=attn_mask)
+
+        self.assertEqual(out_math, out_cudnn, atol=5e-3, rtol=3e-3)
+
+    @unittest.skipIf(not PLATFORM_SUPPORTS_CUDNN_ATTENTION, "cudnn Attention is not supported on this system")
+    def test_cudnn_attention_mismatched_mask_dtype(self):
+        # Float attn_mask with a dtype different from Q (bf16 Q, fp32 mask).
+        q = torch.randn(2, 4, 8, 16, dtype=torch.bfloat16, device='cuda')
+        k = torch.randn(2, 4, 8, 16, dtype=torch.bfloat16, device='cuda')
+        v = torch.randn(2, 4, 8, 16, dtype=torch.bfloat16, device='cuda')
+
+        bool_mask = torch.tril(torch.ones(8, 8, dtype=torch.bool, device='cuda'))
+        attn_mask = torch.where(bool_mask, 0.0, float('-inf')).to(torch.float32)
+
+        with sdpa_kernel(SDPBackend.MATH):
+            out_math = torch.nn.functional.scaled_dot_product_attention(
+                q, k, v, attn_mask=attn_mask)
+        with sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
+            out_cudnn = torch.nn.functional.scaled_dot_product_attention(
+                q, k, v, attn_mask=attn_mask)
+
+        self.assertEqual(out_math, out_cudnn, atol=5e-3, rtol=3e-3)
+
     @skipIfRocm
     @unittest.skipIf(not PLATFORM_SUPPORTS_CUDNN_ATTENTION, "cudnn Attention is not supported on this system")
     def test_cudnn_attention_mask_broken_177842(self):


### PR DESCRIPTION
This PR adds hipDNN as a supported backend for SDPA.

The approach taken here is to re-use the existing `CUDNN_ATTENTION` backend, adding support for it by routing through hipDNN when compiled for ROCm. i.e. `torch.nn.attention.SDPBackend.CUDNN_ATTENTION` and `aten::_scaled_dot_product_cudnn_attention` now work on ROCm.

The primary change here is adding `cudnn/hip/MHA.cpp`, which is a "fork" of `cudnn/MHA.cpp`, modified to use hipDNN instead of cuDNN. There's various differences between the implementations that made it simpler to just fork the entire file rather than trying to keep both implementations in the same file/rely on hipify for translation:
- various minor API differences between cuDNN/hipDNN which made it difficult to re-use code directly
- differences in feature support: hipDNN doesn't support nested tensors which simplifies a lot of code, however it *is* more flexible in other aspects e.g. dtypes. 

Additionally, since hipDNN provides an API for querying engine support for a graph, during backend selection `sdp::can_use_cudnn_attention` calls the newly added `at::native::check_cudnn_sdpa_support`, which constructs the hipDNN graph for both forwards and backwards (if potentially needed) to query support. This is *not* cached, as it's assumed construction + querying support is implemented efficiently. The sequence of hipDNN calls:
```
                SELECTION
                ─────────
       sdp::can_use_cudnn_attention()
                    │
                    ▼
    at::native::check_cudnn_sdpa_support()
                    │
                    ▼
     fe::graph::Graph::is_supported_ext()
                    │
                    ▼
                   bool
    
                EXECUTION
                ─────────
  at::native::run_cudnn_SDP_{fprop,bprop}()
                    │
                    ▼
           MHAGraphCache lookup
                    │
               ┌────┴────┐
               ▼         ▼
             HIT:      MISS:
             reuse       │
             cached      ▼
             graph     fe::graph::Graph::validate()
               │       fe::graph::Graph::build_operation_graph()
               │       fe::graph::Graph::create_execution_plans()
               │       fe::graph::Graph::check_support()
               │       fe::graph::Graph::build_plans()
               │         │
               └────┬────┘
                    ▼
         fe::graph::Graph::execute()

```

Both backends still share the same `attention.cu` kernel (hipDNN uses the hipified version).


This is separated into a stack of PRs for easier review:
- PR 1/3: [[ROCm] Stop hipifying native/cudnn/ and native/quantized/cudnn/ files](https://github.com/ROCm/pytorch/pull/3196)
    - Various cudnn files are being hipified at the moment, with no functional purpose (it just results in code that's `ifdef`'d out. This disables the hipification rules and fixes up includes/directives so the CUDA files compile cleanly on ROCM. The primary motivation here is to stop generating `cudnn/hip/MHA.cpp`; the following changes add this file back with the hipDNN backend implementation.

- PR 2/3: [[ROCm] Integrate hipDNN as an SDPA backend](https://github.com/ROCm/pytorch/pull/3197):
  - I'd recommend reviewing the individual commits here:
    - `Add aotriton.images/ to .gitignore` - NFC change
    - `Extract compute_matching_strides from alloc_with_matching_layout` - NFC change
    - `Split cudnn/MHA.cpp into separate cuDNN and hipDNN files`
    - `Copy cuDNN MHA implementation verbatim into hipDNN MHA`
      - This is just to make it easier to review the next commit, as it shows the diff between cuDNN and hipDNN.
    - `[ROCm] Add hipDNN SDPA backend dispatch`
      - Primary implementation, looking at this commit will likely be the easiest way to review the hipDNN specific changes.
    - `Update tests to reflect cudnn backend being available on ROCM.`
      - `CUDNN_ATTENTION` tests can now be run on ROCm.

- **PR 3/3: [[ROCm] Pass bool attention masks directly to hipDNN](https://github.com/ROCm/pytorch/pull/3198) (this PR)**
    - hipDNN supports boolean attention masks more efficiently than float masks. This skips the float->bool conversion that's normally done, and passes the original mask directly to hipDNN.

Open questions for reviewers:
- Reusing the `CUDNN_ATTENTION` backend was done due to API similarities, though this could potentially be confusing. Would it be preferrable to completely separate hipDNN by adding a new backend?
- Would additional code-sharing between the cuDNN and hipDNN `MHA.cpp` files be recommended?
