### PR TITLE
[ROCm][CI] Ensure pip is installed in conda env

### DIFF
--- a/.ci/docker/common/install_conda.sh
+++ b/.ci/docker/common/install_conda.sh
@@ -49,19 +49,24 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
     export SYSROOT_DEP="sysroot_linux-64=2.17"
   fi
 
-# Install correct Python version
-# Also ensure sysroot is using a modern GLIBC to match system compilers
+  # Install correct Python version
+  # Also ensure sysroot is using a modern GLIBC to match system compilers
+  # NB: pip is no longer pulled in transitively by conda-forge's python
+  # package, so request it explicitly. Without it, `python3 -m pip` in the
+  # env fails and `conda run -n env pip` silently falls back to base.
 if [ "$ANACONDA_PYTHON_VERSION" = "3.14" ]; then
   as_jenkins conda create -n py_$ANACONDA_PYTHON_VERSION -y\
              python="3.14.0" \
              ${SYSROOT_DEP} \
+             pip \
              -c conda-forge
 else
   # Install correct Python version
   # Also ensure sysroot is using a modern GLIBC to match system compilers
   as_jenkins conda create -n py_$ANACONDA_PYTHON_VERSION -y\
              python="$ANACONDA_PYTHON_VERSION" \
-             ${SYSROOT_DEP}
+             ${SYSROOT_DEP} \
+             pip
 fi
   # libstdcxx from conda default channels are too old, we need GLIBCXX_3.4.30
   # which is provided in libstdcxx 12 and up.

--- a/.ci/docker/common/install_rocm_drm.sh
+++ b/.ci/docker/common/install_rocm_drm.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 # Script used only in CD pipeline
 
+set -ex
+
+PREFIX="$1"
+
 ###########################
 ### prereqs
 ###########################


### PR DESCRIPTION
Superseded by https://github.com/ROCm/pytorch/pull/3205.

This PR targeted `rocm71_nightly_patch_1` and used a personal fork branch. The replacement PR targets `rocm7.0_internal_testing` from a branch hosted directly on `ROCm/pytorch`.
