### PR TITLE
[ROCm][CI] Ensure pip is installed in conda env

### DIFF
--- a/.ci/docker/common/install_conda.sh
+++ b/.ci/docker/common/install_conda.sh
@@ -64,9 +64,13 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
 
   # Install correct Python version
   # Also ensure sysroot is using a modern GLIBC to match system compilers
+  # NB: pip is no longer pulled in transitively by conda-forge's python
+  # package, so request it explicitly. Without it, `python3 -m pip` in the
+  # env fails and `conda run -n env pip` silently falls back to base.
   as_jenkins conda create -n py_$ANACONDA_PYTHON_VERSION -y\
              python="$ANACONDA_PYTHON_VERSION" \
-             ${SYSROOT_DEP}
+             ${SYSROOT_DEP} \
+             pip
 
   # libstdcxx from conda default channels are too old, we need GLIBCXX_3.4.30
   # which is provided in libstdcxx 12 and up.

--- a/.ci/docker/common/install_rocm_drm.sh
+++ b/.ci/docker/common/install_rocm_drm.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 # Script used only in CD pipeline
 
+set -ex
+
+PREFIX="$1"
+
 ###########################
 ### prereqs
 ###########################


### PR DESCRIPTION
## Summary

Ports the upstream Docker rebuild fix from https://github.com/pytorch/pytorch/pull/182616 to `rocm7.0_internal_testing` for ROCM-24125.

The CentOS 9 / Python 3.9 Docker build creates a conda environment where `pip` is no longer guaranteed to be installed by the Python package. Without explicitly requesting `pip`, `conda run -n py_3.9 pip install -r requirements-ci.txt` can fall back to base instead of installing into `py_3.9`, leaving build dependencies such as `setuptools` missing when Triton runs `python setup.py bdist_wheel`.

This PR fixes that by:

- Adding `pip` to the `conda create` command for the target Python environment.
- Adding `set -ex` to `install_rocm_drm.sh` so failures are surfaced immediately.

## Validation

- `bash -n .ci/docker/common/install_conda.sh`
- `bash -n .ci/docker/common/install_rocm_drm.sh`
- `git diff --check`
https://rocm-ci.amd.com/view/Release-7.0/job/framework-pytorch-internal-cs9-ci_rel-7.0/64/