### PR TITLE
[release/2.9] [ROCm] Re-add gfx110X and gfx115X to preferred hipBLASLt backend 

### DIFF
--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -468,7 +468,10 @@ at::BlasBackend Context::blasPreferredBackend() {
       static const std::vector<std::string> archs = {
           "gfx90a", "gfx942",
 #if ROCM_VERSION >= 60300
-          "gfx1200", "gfx1201",
+          "gfx1100", "gfx1101", "gfx1102", "gfx1200", "gfx1201",
+#endif
+#if ROCM_VERSION >= 60402
+          "gfx1150", "gfx1151",
 #endif
 #if ROCM_VERSION >= 60500
           "gfx950"


### PR DESCRIPTION
Backport of the hipblaslt_preferred arch list from release/2.10, re-adding gfx1100/1101/1102 (>= ROCm 6.3) and gfx1150/1151 (>= ROCm 6.4.2) which were reverted in #2876 due to previous performance regressions in ROCm 6.x

Without this, blasPreferredBackend() returns hipBLAS for RDNA3 GPUs, causing failures in downstream libraries such as apex whose hipBLAS fallback paths for fused GEMM+bias operations are non-functional. This fixes a part of the [ROCM-21536] ticket. In that ticket, tests were failing because apex library hit a path that used hipblas library (because it used whatever torch is using), and that path is not implemented correctly in apex, so by making torch prefere hipblaslt, apex is also using it and tests are working correctly that way.




[ROCM-21536]: https://amd-hub.atlassian.net/browse/ROCM-21536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ