### PR TITLE
[inductor] Make experimental benchmarker parameters configurable via env vars

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -465,6 +465,23 @@ use_experimental_benchmarker: bool = Config(
     justknob="pytorch/inductor:use_experimental_benchmarker",
 )
 
+# Number of iterations to run the callable during runtime estimation in the experimental benchmarker
+inductor_experimental_benchmarker_estimation_iters: int = int(
+    os.environ.get("TORCHINDUCTOR_EXPERIMENTAL_BENCHMARKER_ESTIMATION_ITERS", 5)
+)
+# Number of iterations to flush the L2 cache before starting benchmarking in the experimental benchmarker
+inductor_experimental_benchmarker_memory_warmup_iters: int = int(
+    os.environ.get("TORCHINDUCTOR_EXPERIMENTAL_BENCHMARKER_MEMORY_WARMUP_ITERS", 100)
+)
+# Number of iterations to run the callable during the benchmarking in the experimental benchmarker
+inductor_experimental_benchmarker_benchmark_iters: int = int(
+    os.environ.get("TORCHINDUCTOR_EXPERIMENTAL_BENCHMARKER_BENCHMARK_ITERS", 100)
+)
+# Maximum duration of the benchmarking in milliseconds in the experimental benchmarker
+inductor_experimental_benchmarker_max_duration: int = int(
+    os.environ.get("TORCHINDUCTOR_EXPERIMENTAL_BENCHMARKER_MAX_DURATION", 25)
+)
+
 # Enable distributed autotuning. When this is enabled we will distribute the
 # autotuning across distributed ranks in the same program group - so instead of
 # each rank autotuning every kernel they only autotune 1/world size kernels and

--- a/torch/_inductor/runtime/benchmarking.py
+++ b/torch/_inductor/runtime/benchmarking.py
@@ -203,6 +203,13 @@ class Benchmarker:
             # TODO(nmacchioni): For non-CPU functions we default to using the GPU-specific benchmarking
             # implementation which was written specifically with CUDA devices in mind, we may want to
             # explore alternate implementations for other device types.
+
+            if use_experimental_benchmarker:
+                kwargs.setdefault("estimation_iters", inductor_config.inductor_experimental_benchmarker_estimation_iters)
+                kwargs.setdefault("memory_warmup_iters", inductor_config.inductor_experimental_benchmarker_memory_warmup_iters)
+                kwargs.setdefault("benchmark_iters", inductor_config.inductor_experimental_benchmarker_benchmark_iters)
+                kwargs.setdefault("max_benchmark_duration", inductor_config.inductor_experimental_benchmarker_max_duration)
+
             return self.benchmark_gpu(_callable, warmup=warmup, rep=rep, **kwargs)
 
     @time_and_count


### PR DESCRIPTION
## 💡 Summary
The experimental benchmarker currently hardcodes parameters like `estimation_iters` and `memory_warmup_iters`. This PR makes them configurable via environment variables to allow easier tuning for different hardware and workloads without modifying source code.
Added environment variables:
- `TORCHINDUCTOR_EXPERIMENTAL_BENCHMARKER_ESTIMATION_ITERS` (default: 5)
- `TORCHINDUCTOR_EXPERIMENTAL_BENCHMARKER_MEMORY_WARMUP_ITERS` (default: 100)
- `TORCHINDUCTOR_EXPERIMENTAL_BENCHMARKER_BENCHMARK_ITERS` (default: 100)
- `TORCHINDUCTOR_EXPERIMENTAL_BENCHMARKER_MAX_DURATION` (default: 25)
