### PR TITLE
Update Github token used for parity.yml

### DIFF
--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -135,7 +135,7 @@ jobs:
       - name: Download artifacts
         working-directory: .automation_scripts/pytorch-unit-test-scripts
         env:
-          GITHUB_TOKEN: ${{ secrets.IFU_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PARITY_GITHUB_TOKEN }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |


### PR DESCRIPTION
## Motivation

Old IFU_GITHUB_TOKEN [seems to have expired](https://github.com/ROCm/pytorch/actions/runs/25856299592/job/75974982737)

## Technical Details

Replace with PARITY_GITHUB_TOKEN (meant specifically for this workflow)

## Test Plan

Run parity.yml with this PR branch and see if it still gives credential error.

## Test Result

"Download artifacts" step succeeded in https://github.com/ROCm/pytorch/actions/runs/25857211908/job/75978008711

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
