### PR TITLE
download_testlogs: select CUDA test artifact kind dynamically

### DIFF
--- a/.automation_scripts/pytorch-unit-test-scripts/download_testlogs
+++ b/.automation_scripts/pytorch-unit-test-scripts/download_testlogs
@@ -710,7 +710,6 @@ def main():
         trunk_wf = None
         all_cuda_jobs = []
         cuda_test_jobs = []
-        cuda_test_job_kind = "test-osdc"
 
         trunk_runs = []
         params = {'per_page': 10}

--- a/.automation_scripts/pytorch-unit-test-scripts/download_testlogs
+++ b/.automation_scripts/pytorch-unit-test-scripts/download_testlogs
@@ -150,6 +150,17 @@ def get_cuda_test_jobs(jobs, cuda_job_prefix):
             return test_kind, test_jobs
     return "test-osdc", []
 
+def get_cuda_inductor_test_jobs(jobs):
+    """Return the CUDA inductor test kind and jobs for either main or PR CI layouts."""
+    for test_kind in ("test-osdc", "test"):
+        test_jobs = [
+            j for j in jobs
+            if f"unit-test / inductor-test / {test_kind} (inductor," in j['name']
+        ]
+        if test_jobs:
+            return test_kind, test_jobs
+    return "test-osdc", []
+
 def download_logs(wf, test_log_list, test_folder, jobs=None):
     if wf is None: 
         raise Exception("wf is None!")
@@ -827,31 +838,29 @@ def main():
             print(f"Using workflow '{CUDAWorkflowNames['inductor']}' with id:{inductor_wf_cuda['id']} for CUDA inductor")
 
             inductor_cuda_jobs = get_workflow_jobs(inductor_wf_cuda)
-            cuda_inductor_test_jobs = [
-                j for j in inductor_cuda_jobs
-                if "unit-test / inductor-test / test-osdc (inductor," in j['name']
-            ]
+            cuda_inductor_test_job_kind, cuda_inductor_test_jobs = get_cuda_inductor_test_jobs(inductor_cuda_jobs)
             cuda_inductor_job_ids = [str(j['id']) for j in cuda_inductor_test_jobs]
             cuda_inductor_artifact_substrings = (
                 [f"_{jid}" for jid in cuda_inductor_job_ids]
                 if cuda_inductor_job_ids
                 else None
             )
-            print(f"Found {len(cuda_inductor_test_jobs)} CUDA inductor OSDC test jobs")
+            print(f"Using CUDA inductor test job kind: {cuda_inductor_test_job_kind}")
+            print(f"Found {len(cuda_inductor_test_jobs)} CUDA inductor test jobs")
 
             folder_list = get_or_create_test_folder(inductor_wf_cuda)
 
             # Download logs
             if not args.artifacts_only:
               test_log_list_cuda_inductor = [
-                ["cuda_inductor1.txt", "unit-test / inductor-test / test-osdc (inductor, 1, 2"],
-                ["cuda_inductor2.txt", "unit-test / inductor-test / test-osdc (inductor, 2, 2"],
+                ["cuda_inductor1.txt", f"unit-test / inductor-test / {cuda_inductor_test_job_kind} (inductor, 1, 2"],
+                ["cuda_inductor2.txt", f"unit-test / inductor-test / {cuda_inductor_test_job_kind} (inductor, 2, 2"],
               ]
               download_logs(inductor_wf_cuda, test_log_list_cuda_inductor, folder_list[0], jobs=inductor_cuda_jobs)
 
             test_artifacts_list_cuda_inductor = [
-              "test-reports-test-osdc-inductor-1-2",
-              "test-reports-test-osdc-inductor-2-2"
+              f"test-reports-{cuda_inductor_test_job_kind}-inductor-1-2",
+              f"test-reports-{cuda_inductor_test_job_kind}-inductor-2-2"
             ]
             download_artifacts(
                 inductor_wf_cuda,

--- a/.automation_scripts/pytorch-unit-test-scripts/download_testlogs
+++ b/.automation_scripts/pytorch-unit-test-scripts/download_testlogs
@@ -134,6 +134,22 @@ def get_job_ids_by_prefix(wf, prefix):
     jobs = get_workflow_jobs(wf)
     return [str(j['id']) for j in jobs if prefix in j['name']]
 
+def matches_job_prefix(job_name, prefix):
+    """Match the exact CUDA job family without also matching -debug/-sm86 jobs."""
+    return job_name.startswith(f"{prefix} / ")
+
+def get_cuda_test_jobs(jobs, cuda_job_prefix):
+    """Return the CUDA test kind and jobs for either main or PR CI layouts."""
+    for test_kind in ("test-osdc", "test"):
+        test_jobs = [
+            j for j in jobs
+            if matches_job_prefix(j['name'], cuda_job_prefix)
+            and f"/ {test_kind} (" in j['name']
+        ]
+        if test_jobs:
+            return test_kind, test_jobs
+    return "test-osdc", []
+
 def download_logs(wf, test_log_list, test_folder, jobs=None):
     if wf is None: 
         raise Exception("wf is None!")
@@ -673,7 +689,6 @@ def main():
 
     if not args.no_cuda:
         cuda_job_prefix = "linux-jammy-cuda13.0-py3.10-gcc11"
-        cuda_test_job_kind = "test-osdc"
         print("==========================================")
         print(f"Finding CUDA tests in workflow '{CUDAWorkflowNames['default']}' by sha: {sha}")
         print("==========================================")
@@ -684,6 +699,7 @@ def main():
         trunk_wf = None
         all_cuda_jobs = []
         cuda_test_jobs = []
+        cuda_test_job_kind = "test-osdc"
 
         trunk_runs = []
         params = {'per_page': 10}
@@ -698,14 +714,12 @@ def main():
 
         for run in trunk_runs:
             jobs = get_workflow_jobs(run)
-            test_jobs = [
-                j for j in jobs
-                if cuda_job_prefix in j['name'] and f'/ {cuda_test_job_kind} (' in j['name']
-            ]
+            test_kind, test_jobs = get_cuda_test_jobs(jobs, cuda_job_prefix)
             if test_jobs:
                 trunk_wf = run
                 all_cuda_jobs = jobs
                 cuda_test_jobs = test_jobs
+                cuda_test_job_kind = test_kind
                 print(f"Found CUDA test jobs in trunk run {run['id']}")
                 break
 
@@ -714,7 +728,7 @@ def main():
             # by the jobs API. Use check-runs API to find the actual run.
             print("No CUDA test jobs in any trunk run's jobs API, trying check-runs API...")
             check_runs = get_check_runs_for_commit(sha, cuda_job_prefix)
-            cuda_test_jobs = [cr for cr in check_runs if f'/ {cuda_test_job_kind} (' in cr['name']]
+            cuda_test_job_kind, cuda_test_jobs = get_cuda_test_jobs(check_runs, cuda_job_prefix)
             if cuda_test_jobs:
                 # Extract the actual workflow run ID from the check-run details URL
                 import re as _re
@@ -745,6 +759,7 @@ def main():
         cuda_job_ids = [str(j['id']) for j in cuda_test_jobs]
         cuda_artifact_substrings = [f"_{jid}" for jid in cuda_job_ids] if cuda_job_ids else ["nvidia.gpu"]
         print(f"Using CUDA job prefix: {cuda_job_prefix}")
+        print(f"Using CUDA test job kind: {cuda_test_job_kind}")
         print(f"Found {len(cuda_test_jobs)} CUDA test jobs matching prefix")
 
         folder_list = get_or_create_test_folder(trunk_wf)
@@ -771,11 +786,11 @@ def main():
 
         # Download artifacts
         test_artifacts_list_cuda_default = [
-          "test-reports-test-osdc-default-1-5",
-          "test-reports-test-osdc-default-2-5",
-          "test-reports-test-osdc-default-3-5",
-          "test-reports-test-osdc-default-4-5",
-          "test-reports-test-osdc-default-5-5",
+          f"test-reports-{cuda_test_job_kind}-default-1-5",
+          f"test-reports-{cuda_test_job_kind}-default-2-5",
+          f"test-reports-{cuda_test_job_kind}-default-3-5",
+          f"test-reports-{cuda_test_job_kind}-default-4-5",
+          f"test-reports-{cuda_test_job_kind}-default-5-5",
         ]
 
         test_artifacts_list_cuda = []
@@ -784,9 +799,9 @@ def main():
 
         if not args.exclude_distributed:
             test_artifacts_list_cuda_distributed = [
-              "test-reports-test-osdc-distributed-1-3",
-              "test-reports-test-osdc-distributed-2-3",
-              "test-reports-test-osdc-distributed-3-3",
+              f"test-reports-{cuda_test_job_kind}-distributed-1-3",
+              f"test-reports-{cuda_test_job_kind}-distributed-2-3",
+              f"test-reports-{cuda_test_job_kind}-distributed-3-3",
             ]
             test_artifacts_list_cuda += test_artifacts_list_cuda_distributed
 

--- a/.automation_scripts/pytorch-unit-test-scripts/generate_summary.py
+++ b/.automation_scripts/pytorch-unit-test-scripts/generate_summary.py
@@ -479,7 +479,7 @@ def build_rows(args, archs, arch_data):
                 has_set2=has_set2,
             )
         for key in wf_keys:
-            out.append((key, [arch_stats[a][key] for a in archs]))
+            out.append((key, [arch_stats[a].get(key, 0) for a in archs]))
 
     out.append(('__section__', 'OVERALL'))
     ov_keys = overall_stats_keys(args.set1_name, args.set2_name, has_set2=any_has_set2)
@@ -493,7 +493,7 @@ def build_rows(args, archs, arch_data):
             args.set1_name, args.set2_name, has_set2=has_set2,
         )
     for key in ov_keys:
-        out.append((key, [arch_overall[a][key] for a in archs]))
+        out.append((key, [arch_overall[a].get(key, 0) for a in archs]))
     return out
 
 


### PR DESCRIPTION
## Summary
- Select the CUDA test artifact kind from the jobs present for the target SHA.
- Detect whether the target SHA uses test-osdc or legacy test CUDA jobs, then use the detected kind when building log keys and artifact prefixes.
- Apply the same dynamic selection to CUDA inductor jobs.
- Treat missing per-arch summary buckets as zero so mixed ROCm/CUDA coverage does not crash report generation.

## Validation
- PR/ciflow case: dispatched `Parity Report` on this branch with `sha=386f38175e3aaee2dadb36b5c364deff0869664d` and `arch=mi355, mi300, mi200, navi31`. CUDA default/distributed and inductor selected `test`.
  - Run: https://github.com/ROCm/pytorch/actions/runs/25866762885
- Main branch case: dispatched `Parity Report` on this branch with `sha=f38b1ec280bafa2ad11f6e767558e73e9eb508a6`, `arch=mi300`, `skip_rocm=true`, and `exclude_distributed=true`. CUDA default and inductor selected `test-osdc`.
  - Run: https://github.com/ROCm/pytorch/actions/runs/25867046276
- Local syntax check: `python3 -m py_compile .automation_scripts/pytorch-unit-test-scripts/download_testlogs .automation_scripts/pytorch-unit-test-scripts/generate_summary.py`.
