### PR TITLE
[release/2.11][UP][ROCm][inductor] Use hipModuleLoadData in StaticCudaLauncher

### DIFF
--- a/torch/csrc/inductor/static_launcher/cuda.cpp
+++ b/torch/csrc/inductor/static_launcher/cuda.cpp
@@ -12,6 +12,9 @@
 
 #if defined(USE_ROCM)
 #include <hip/hip_runtime_api.h>
+#include <fstream>
+#include <iterator>
+#include <vector>
 #endif
 
 /**
@@ -101,6 +104,19 @@ CUdeviceptr getPointer(PyObject* obj) {
 
 #define SHARED_MEM_STATIC_MAX 49152 // 48 KB
 
+#if defined(USE_ROCM)
+std::vector<char> readKernelImage(const std::string& filePath) {
+  std::ifstream file(filePath, std::ios::binary);
+  TORCH_CHECK(file, "Failed to open kernel image: ", filePath);
+
+  auto begin = std::istreambuf_iterator<char>(file);
+  auto end = std::istreambuf_iterator<char>();
+  std::vector<char> image(begin, end);
+  TORCH_CHECK(!image.empty(), "Kernel image is empty: ", filePath);
+  return image;
+}
+#endif
+
 CUfunction loadKernel(
     std::string filePath,
     const std::string& funcName,
@@ -116,7 +132,10 @@ CUfunction loadKernel(
   CUfunction func = nullptr;
 
 #if defined(USE_ROCM)
-  AT_CUDA_DRIVER_CHECK(hipModuleLoad(&mod, filePath.c_str()));
+  // Unlike cuModuleLoad, hipModuleLoad keeps a file descriptor for the loaded
+  // HSACO. Load from memory to avoid retaining one FD per static launcher.
+  auto image = readKernelImage(filePath);
+  AT_CUDA_DRIVER_CHECK(hipModuleLoadData(&mod, image.data()));
   AT_CUDA_DRIVER_CHECK(hipModuleGetFunction(&func, mod, funcName.c_str()));
   int shared_optin = 0;
   AT_CUDA_DRIVER_CHECK(hipDeviceGetAttribute(


### PR DESCRIPTION
## Summary
- Backports upstream PyTorch PR pytorch/pytorch#183926 to ROCm release/2.11.
- Resolves Jira https://amd-hub.atlassian.net/browse/ROCM-24659, https://amd-hub.atlassian.net/browse/ROCM-24664
- Uses `hipModuleLoadData` for ROCm static launcher module loading to avoid retaining open HSACO file descriptors.
- Leaves the CUDA/NVIDIA path unchanged.

## Test plan
- Built successfully with `/home/niromero/docker_workspace/framework_scripts/pytorch/build.sh`.


Made with [Cursor](https://cursor.com)