### PR TITLE
[CI] Handle large parity summary CSV fields

### DIFF
--- a/.automation_scripts/pytorch-unit-test-scripts/generate_summary.py
+++ b/.automation_scripts/pytorch-unit-test-scripts/generate_summary.py
@@ -12,6 +12,29 @@ TEST_CONFIG_DISPLAY = {
     'distributed': 'TEST DISTRIBUTED',
     'inductor': 'TEST INDUCTOR',
 }
+MAX_DIAGNOSTIC_FIELD_CHARS = 20_000
+DIAGNOSTIC_FIELDS = {
+    'comments',
+    'message_cuda',
+    'message_rocm',
+    'message_set1',
+    'message_set2',
+    'reason',
+    'skip_reason',
+}
+
+
+def _configure_csv_field_limit():
+    limit = sys.maxsize
+    while True:
+        try:
+            csv.field_size_limit(limit)
+            return
+        except OverflowError:
+            limit //= 10
+
+
+_configure_csv_field_limit()
 
 
 def parse_args():
@@ -49,7 +72,19 @@ def parse_args():
 
 def load_csv(filepath):
     with open(filepath, newline='') as f:
-        return list(csv.DictReader(f))
+        return [_truncate_diagnostic_fields(row) for row in csv.DictReader(f)]
+
+
+def _truncate_diagnostic_fields(row):
+    for field in DIAGNOSTIC_FIELDS:
+        value = row.get(field, '')
+        if len(value) > MAX_DIAGNOSTIC_FIELD_CHARS:
+            omitted = len(value) - MAX_DIAGNOSTIC_FIELD_CHARS
+            row[field] = (
+                value[:MAX_DIAGNOSTIC_FIELD_CHARS]
+                + f'\n...[truncated {omitted:,} chars by generate_summary.py]'
+            )
+    return row
 
 
 def detect_columns(headers, set1_name, set2_name):


### PR DESCRIPTION
## Summary
- Raise the Python CSV parser field limit in `generate_summary.py` so large parity CSV diagnostic fields can be read.
- Truncate oversized diagnostic text fields while loading rows so long failure/skip messages do not make summary generation or output unwieldy.
- Preserve test identity, status, timing, and shard fields used by the parity report tables.

## Root Cause
A parity run failed in the `summarize` job when Python's default CSV field limit rejected a generated-code assertion message larger than 131,072 bytes:
https://github.com/ROCm/pytorch/actions/runs/26168276671/job/76979094769

The first offending row was `inductor.test_torchinductor_codegen_dynamic_shapes::DynamicShapesCodegenGPUTests::test_vmap_dot_decomposes_bmm_dynamic_shapes_cuda`, where `message_rocm` was 145,748 bytes.

## Test plan
- `python3 -m py_compile .automation_scripts/pytorch-unit-test-scripts/generate_summary.py`
- Re-ran `generate_summary.py` locally against the artifact from the failed run:
  - Input: `20260520_all_tests_status_mi355.csv` from run `26168276671`
  - Output: summary CSV and markdown generated successfully instead of failing with `_csv.Error: field larger than field limit (131072)`.
- Triggered `parity.yml` on this branch with the same upstream commit and arch as the failing run:
  - SHA: `27f2e80e30fb950bc455c777a5e8079e9657a157`
  - Arch: `mi355`
  - Validation run: https://github.com/ROCm/pytorch/actions/runs/26175417191
  - Result: `setup-matrix`, `generate-parity (mi355)`, and `summarize` all completed successfully.
  - The summarize log shows `CSV written to 27f2e80e30fb950bc455c777a5e8079e9657a157_summary.csv` and `Markdown written to 27f2e80e30fb950bc455c777a5e8079e9657a157_summary.md`.