### PR TITLE
[Inductor] Fix flaky epilogue fusion tests by adding missing tearDown…

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -4149,6 +4149,11 @@ class TestPrologueFusion(TestCase):
             )
         )
 
+    @classmethod
+    def tearDownClass(cls):
+        cls._stack.close()
+        super().tearDownClass()
+
     def check_code(self, code_str, num_kernels, num_allocs, num_deallocs):
         FileCheck().check(get_func_call()).check_count(
             get_kernel_launch(),
@@ -4641,6 +4646,11 @@ class TestEpilogueFusionStaticAnalysis(TestCase):
                 }
             )
         )
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._stack.close()
+        super().tearDownClass()
 
     @contextlib.contextmanager
     def get_common_patches(


### PR DESCRIPTION
…Class (#180736)

TestPrologueFusion and TestEpilogueFusionStaticAnalysis both use ExitStack in setUpClass to apply config.patch(), but neither defined tearDownClass to close the stack. When TestPrologueFusion runs before TestEpilogueFusionStaticAnalysis in the same process, config values like max_autotune_gemm_backends="TRITON" leak through, removing the aten kernel choice from autotuning and causing test failures.

Fixes #179693

Pull Request resolved: https://github.com/pytorch/pytorch/pull/180736
Approved by: https://github.com/Skylion007

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.


Cherry-picked to release/2.10 branch via https://github.com/ROCm/pytorch/pull/3249

Cherry-picked to release/2.9 branch via https://github.com/ROCm/pytorch/pull/3250