### PR TITLE
[release/2.12] [ROCm] fix triu/tril for 64-bit indexing for large matrices

### DIFF
--- a/aten/src/ATen/native/cuda/TriangularOps.cu
+++ b/aten/src/ATen/native/cuda/TriangularOps.cu
@@ -44,67 +44,138 @@ __global__ void triu_tril_kernel(
     const int64_t k,
     const int64_t N_padded,
     const IndexType last_dim_padded) {
+#if !defined(USE_ROCM)
   int64_t linear_idx = (((int64_t)blockIdx.x) * blockDim.x + threadIdx.x) * elements_per_thread;
   if (linear_idx >= N_padded) {
     return;
   }
+#else
+  // ROCm limits the total number of threads at 2^32 - use a strided loop to stay within this limit
+  for (int64_t linear_idx_retained = (((int64_t) blockIdx.x) * blockDim.x + threadIdx.x) * elements_per_thread;
+       linear_idx_retained < N_padded;
+       linear_idx_retained += blockDim.x * gridDim.x * elements_per_thread)
+  {
+    int64_t linear_idx { linear_idx_retained }; // linear_idx_retained persists for the next iteration
+#endif // !defined(USE_ROCM)
 
-  auto dims = self_info.dims;
+    auto dims = self_info.dims;
 
-  // Compute column index amd row index
-  IndexType col = linear_idx % last_dim_padded;
-  linear_idx /= last_dim_padded;
-  IndexType row = linear_idx % self_info.sizes[dims - 2];
+    // Compute column index and row index
+    IndexType col = linear_idx % last_dim_padded;
+    linear_idx /= last_dim_padded;
+    IndexType row = linear_idx % self_info.sizes[dims - 2];
 
-  if constexpr (inplace) {
-    bool mask_all_true = upper ? (col - row >= k) : (col + elements_per_thread - row <= k);
-    if (mask_all_true)
-      return;
-  }
-
-  // Compute offset
-  IndexType self_offset = 0, result_offset = 0;
-  self_offset += self_info.strides[dims - 1] * col;
-  result_offset += result_info.strides[dims - 1] * col;
-  linear_idx /= self_info.sizes[dims - 2];
-  self_offset += self_info.strides[dims - 2] * row;
-  result_offset += result_info.strides[dims - 2] * row;
-
-  // Compute remaining offsets
-  IndexType running_index;
-  #pragma unroll
-  for (IndexType i = dims - 3; i >= 0; --i) {
-    running_index = linear_idx % self_info.sizes[i];
-    linear_idx /= self_info.sizes[i];
-    self_offset += running_index * self_info.strides[i];
-    result_offset += running_index * result_info.strides[i];
-  }
-
-  if constexpr (inplace) {
-    #pragma unroll
-    for (int i = 0; i < elements_per_thread && col + i < self_info.sizes[dims - 1]; i++) {
-      bool mask = upper ? (col + i - row >= k) : (col + i - row <= k);
-      if (!mask)
-        result_info.data[result_offset + i * result_info.strides[dims - 1]] = scalar_t(0);
+    if constexpr (inplace) {
+      bool mask_all_true = upper ? (col - row >= k) : (col + elements_per_thread - row <= k);
+      if (mask_all_true)
+#if !defined(USE_ROCM)
+        return;
+#else
+        // The strided loop must proceed on ROCm
+        continue;
+#endif
     }
-  } else {
-    scalar_t frag[elements_per_thread] = {};
-    bool has_mask = (upper && col + elements_per_thread - row >= k) || (!upper && col - row <= k);
-    if (has_mask) {
+
+    // Compute offset
+    IndexType self_offset = 0, result_offset = 0;
+    self_offset += self_info.strides[dims - 1] * col;
+    result_offset += result_info.strides[dims - 1] * col;
+    linear_idx /= self_info.sizes[dims - 2];
+    self_offset += self_info.strides[dims - 2] * row;
+    result_offset += result_info.strides[dims - 2] * row;
+
+    // Compute remaining offsets
+    IndexType running_index;
+    #pragma unroll
+    for (IndexType i = dims - 3; i >= 0; --i) {
+      running_index = linear_idx % self_info.sizes[i];
+      linear_idx /= self_info.sizes[i];
+      self_offset += running_index * self_info.strides[i];
+      result_offset += running_index * result_info.strides[i];
+    }
+
+    if constexpr (inplace) {
+      #pragma unroll
+      for (int i = 0; i < elements_per_thread && col + i < self_info.sizes[dims - 1]; i++) {
+        bool mask = upper ? (col + i - row >= k) : (col + i - row <= k);
+        if (!mask)
+          result_info.data[result_offset + i * result_info.strides[dims - 1]] = scalar_t(0);
+      }
+    } else {
+      scalar_t frag[elements_per_thread] = {};
+      bool has_mask = (upper && col + elements_per_thread - row >= k) || (!upper && col - row <= k);
+      if (has_mask) {
+        #pragma unroll
+        for (int i = 0; i < elements_per_thread && col + i < self_info.sizes[dims - 1]; i++)
+          frag[i] = self_info.data[self_offset + i * self_info.strides[dims - 1]];
+
+        #pragma unroll
+        for (int i = 0; i < elements_per_thread; i++) {
+          bool mask = upper ? (col + i - row >= k) : (col + i - row <= k);
+          frag[i] = mask ? frag[i] : scalar_t(0);
+        }
+      }
+
       #pragma unroll
       for (int i = 0; i < elements_per_thread && col + i < self_info.sizes[dims - 1]; i++)
-        frag[i] = self_info.data[self_offset + i * self_info.strides[dims - 1]];
-
-      #pragma unroll
-      for (int i = 0; i < elements_per_thread; i++) {
-        bool mask = upper ? (col + i - row >= k) : (col + i - row <= k);
-        frag[i] = mask ? frag[i] : scalar_t(0);
-      }
+        result_info.data[result_offset + i * result_info.strides[dims - 1]] = frag[i];
     }
+#if defined(USE_ROCM)
+  } // end of the strided loop on ROCm
+#endif // !defined(USE_ROCM)
+}
 
-    #pragma unroll
-    for (int i = 0; i < elements_per_thread && col + i < self_info.sizes[dims - 1]; i++)
-      result_info.data[result_offset + i * result_info.strides[dims - 1]] = frag[i];
+// Helper extracted from the AT_DISPATCH lambda below. The USE_ROCM
+// preprocessor branches must live outside the AT_DISPATCH macro expansion;
+// MSVC's traditional preprocessor does not accept #if/#else/#endif inside a
+// macro argument and the Windows build would otherwise fail.
+template <bool upper, typename scalar_t>
+void launch_triu_tril_kernel(const Tensor& result, const Tensor& self, int64_t k) {
+#if !defined(USE_ROCM)
+  constexpr int elements_per_thread = sizeof(scalar_t) < 8 ? 8 / sizeof(scalar_t) : 1;
+#else
+  // Pair smaller scalars with more elements per thread so the bounded grid
+  // (see dim_grid below) still covers the full output via the kernel's
+  // strided loop.
+  constexpr int elements_per_thread =
+    sizeof(scalar_t) <= 2 ? 4 :
+    sizeof(scalar_t) <= 8 ? 2 : 1;
+#endif
+  auto sizes = self.sizes();
+  int64_t last_dim_padded = round_up<int64_t>(sizes.back(), elements_per_thread);
+  int64_t N_padded = c10::multiply_integers(sizes.begin(), sizes.end() - 1) * last_dim_padded;
+  dim3 dim_block = block_size;
+
+#if !defined(USE_ROCM)
+  dim3 dim_grid((N_padded / elements_per_thread + dim_block.x - 1) / dim_block.x);
+#else
+  // ROCm caps total threads (grid * block) at 2^32; bound the grid here and
+  // let the kernel walk the remainder via a strided loop so large matrices
+  // with 64-bit indexing produce correct results instead of silently
+  // truncating.
+  const int num_mp = at::cuda::getCurrentDeviceProperties()->multiProcessorCount;
+  constexpr int grid_multiplier = sizeof(scalar_t) <= 2 ? 16 : 32;
+  dim3 dim_grid(num_mp * grid_multiplier);
+#endif
+
+  if (cuda::detail::canUse32BitIndexMath(result) && cuda::detail::canUse32BitIndexMath(self)) {
+    auto result_info = cuda::detail::getTensorInfo<scalar_t, int32_t>(result);
+    auto self_info = cuda::detail::getTensorInfo<const scalar_t, int32_t>(self);
+    BOOL_SWITCH(self.is_same(result), inplace, [&] {
+      triu_tril_kernel<scalar_t, int32_t, upper, elements_per_thread, inplace>
+        <<<dim_grid, dim_block, 0, at::cuda::getCurrentCUDAStream()>>>(
+          result_info, self_info, k, N_padded, last_dim_padded);
+    });
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+  } else {
+    auto result_info = cuda::detail::getTensorInfo<scalar_t, int64_t>(result);
+    auto self_info = cuda::detail::getTensorInfo<const scalar_t, int64_t>(self);
+    BOOL_SWITCH(self.is_same(result), inplace, [&] {
+      triu_tril_kernel<scalar_t, int64_t, upper, elements_per_thread, inplace>
+        <<<dim_grid, dim_block, 0, at::cuda::getCurrentCUDAStream()>>>(
+          result_info, self_info, k, N_padded, last_dim_padded);
+    });
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
   }
 }
 
@@ -116,31 +187,7 @@ void triu_tril_cuda_template(const Tensor& result, const Tensor& self, int64_t k
       at::ScalarType::BFloat16,
       at::ScalarType::Bool,
       self.scalar_type(), "triu_tril_cuda_template", [&] {
-    constexpr int elements_per_thread = sizeof(scalar_t) < 8 ? 8 / sizeof(scalar_t) : 1;
-    auto sizes = self.sizes();
-    int64_t last_dim_padded = round_up<int64_t>(sizes.back(), elements_per_thread);
-    int64_t N_padded = c10::multiply_integers(sizes.begin(), sizes.end() - 1) * last_dim_padded;
-    dim3 dim_block = block_size;
-    dim3 dim_grid((N_padded / elements_per_thread + dim_block.x - 1) / dim_block.x);
-    if (cuda::detail::canUse32BitIndexMath(result) && cuda::detail::canUse32BitIndexMath(self)) {
-      auto result_info = cuda::detail::getTensorInfo<scalar_t, int32_t>(result);
-      auto self_info = cuda::detail::getTensorInfo<const scalar_t, int32_t>(self);
-      BOOL_SWITCH(self.is_same(result), inplace, [&] {
-        triu_tril_kernel<scalar_t, int32_t, upper, elements_per_thread, inplace>
-          <<<dim_grid, dim_block, 0, at::cuda::getCurrentCUDAStream()>>>(
-            result_info, self_info, k, N_padded, last_dim_padded);
-      });
-      C10_CUDA_KERNEL_LAUNCH_CHECK();
-    } else {
-      auto result_info = cuda::detail::getTensorInfo<scalar_t, int64_t>(result);
-      auto self_info = cuda::detail::getTensorInfo<const scalar_t, int64_t>(self);
-      BOOL_SWITCH(self.is_same(result), inplace, [&] {
-        triu_tril_kernel<scalar_t, int64_t, upper, elements_per_thread, inplace>
-          <<<dim_grid, dim_block, 0, at::cuda::getCurrentCUDAStream()>>>(
-            result_info, self_info, k, N_padded, last_dim_padded);
-      });
-      C10_CUDA_KERNEL_LAUNCH_CHECK();
-    }
+    launch_triu_tril_kernel<upper, scalar_t>(result, self, k);
   });
 }
 


### PR DESCRIPTION
This PR fixes triu/tril kernel on ROCm for 64-bit indexed large tensors

ROCm limits the total number of threads (grid_size*block_size) <= 2^32. And we have incorrect result or error if this limit is exceeded A strided loop with limited grid size is used on ROCm to stay within the limit

Fixes https://github.com/pytorch/pytorch/issues/165966

A benchmark was created to identify the optimal grid size and elements-per-thread configuration for maximum performance across all dtypes on MI300X. The shapes were taken from the kernel optimization PR https://github.com/pytorch/pytorch/pull/115013

I ran the benchmark before and after my changes. The results are as follows:
- Fixed the triangular kernel on ROCm for 64-bit indexing large tensors
- Significant performance improvement in many shapes for 32- and 64-bit data types
- Minor performance regression for some shapes for 8- and 16-bit data types
- Significant performance degradation on very large shapes for 8- and 64-bit data types

Speedup results (k=0):
| mode |	shape |	float16 |	float32 |	float64 |	int8 | 
|--|--|--|--|--|--|
| in_place	| (1, 8192, 8192) | 121%	| 175%	| 277%	| 111% | 
| in_place	| (3072, 3072)	| 145%	| 212%	| 277%	| 107% | 
| in_place	| (1, 3072, 3072) | 144%	| 178%	| 272%	| 94% | 
| in_place	| (1, 1, 3072, 3072) | 134%	| 156%	| 262%	| 86% | 
| in_place	| (4, 1024, 1024)	| 116%	| 138%	| 193%	| 100% | 
| in_place	| (4, 1021, 1021)	| 102%	| 141%	| 219%	| 109% | 
| in_place	| (256, 128, 256)	| 124%	| 162%	| 296%	| 77% | 
| in_place	| (128, 257, 125)	| 105%	| 128%	| 168%	| 120% | 
| in_place	| (20480, 16, 16)	| 108%	| 135%	| 209%	| 102% | 
| in_place	| (40000, 40000)	| 179%	| 228%	| 305%	| 116% | 
| in_place	| (80000, 80000)	| 146%	| 166%	| 88%	| 89% | 
| out_of_place	| (1, 8192, 8192)	| 89%	| 114%	| 135%	| 89% | 
| out_of_place	| (3072, 3072)	| 96%	| 159%	| 169%	| 120% | 
| out_of_place	| (1, 3072, 3072)	| 96%	| 123%	| 175%	| 103% | 
| out_of_place	| (1, 1, 3072, 3072)	| 99%	| 103%	| 176%	| 91% | 
| out_of_place	| (4, 1024, 1024)	| 102%	| 114%	| 149%	| 105% | 
| out_of_place	| (4, 1021, 1021)	| 96%	| 114%	| 148%	| 114% | 
| out_of_place	| (256, 128, 256)	| 94%	| 123%	| 148%	| 103% | 
| out_of_place	| (128, 257, 125)	| 103%	| 114%	| 143%	| 118% | 
| out_of_place	| (20480, 16, 16)	| 99%	| 112%	| 126%	| 108% | 
| out_of_place	| (40000, 40000)	| 91%	| 111%	| 135%	| 80% | 
| out_of_place	| (80000, 80000)	| 84%	| 102%	| 46%	| 70% |

benchmark:
```python
iimport torch
import itertools
import pandas as pd

def in_place(t, k = 0):
        t.triu_(k)
        return t

def out_of_place(t, k = 0):
        return t.triu(k)

col_names = ["mode","shape", "k", "float16", "float32", "float64", "int8"]
dtype_list = [torch.float64, torch.float32, torch.float16, torch.int8]
shape_list = [
        (1, 8192, 8192),
        (3072, 3072),
        (1, 3072, 3072),
        (1, 1, 3072, 3072),
        (4, 1024, 1024),
        (4, 1021, 1021),
        (256, 128, 256),
        (128, 257, 125),
        (20480, 16, 16),
        (40000, 40000),
        # (80000, 80000),
        # (100000, 100000),
    ]
fn_list = [in_place, out_of_place]

rows = []

for fn, shape in itertools.product(fn_list, shape_list):
    for k in [0, shape[-1] // 2, -shape[-1] // 2]:
        row = {
            "mode": fn.__name__,
            "shape": str(shape),
            "k": "\t0" if k == 0 else "\t+1/2" if k > 0 else "\t-1/2",
            }
        for dtype in dtype_list:
            t = torch.empty(shape, device="cuda", dtype=dtype).fill_(-1)

            # validate
            t_h = t.cpu()
            out = fn(t, k)
            out_h = fn(t_h, k)
            torch.testing.assert_close(out, out_h, check_device=False)

            for _ in range(50): #warmup
                fn(t, k)

            torch.cuda.synchronize()
            prof = torch.profiler.profile()
            prof.start()

            for _ in range(100):
                fn(t, k)

            torch.cuda.synchronize()
            prof.stop()

            stats = prof.key_averages()
            # get the time of the triu_tril_kernel
            triu_time = round([s for s in stats if "triu_tril_kernel" in s.key][0].device_time, 4)
            row[str(dtype).replace("torch.", "")] = triu_time
        rows.append(row)

df = pd.DataFrame(rows, columns=col_names)
# df.to_csv("stats_triu.csv", index=False)
print(df.to_csv(index=False, sep=";"))
```

Pull Request resolved: https://github.com/pytorch/pytorch/pull/179717
Approved by: https://github.com/jerrymannil, https://github.com/jeffdaily


(cherry picked from commit 4ee86118ba3f6ed561e4c17c915ed61b6607cdf3)