### PR TITLE
[release/2.10] Add conv3d backward tolerance overrides for CUDA (cherry-pick from #173188)

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -15669,6 +15669,18 @@ op_db: list[OpInfo] = [
                    toleranceOverride({torch.float16: tol(atol=5e-3, rtol=1e-3)}),
                    'TestInductorOpInfo', 'test_comprehensive',
                ),
+               DecorateInfo(
+                   toleranceOverride({torch.float32: tol(atol=5e-5, rtol=5e-6)}),
+                   'TestOperators', 'test_jvpvjp', device_type="cuda",
+               ),
+               DecorateInfo(
+                   toleranceOverride({torch.float32: tol(atol=5e-5, rtol=5e-6)}),
+                   'TestOperators', 'test_vjp', device_type="cuda",
+               ),
+               DecorateInfo(
+                   toleranceOverride({torch.float32: tol(atol=5e-5, rtol=5e-6)}),
+                   'TestCompositeCompliance', 'test_backward', device_type="cuda",
+               ),
            ),
            skips=(
                # RuntimeError: !lhs.isAliasOf(rhs) INTERNAL ASSERT FAILED at


### PR DESCRIPTION
## Summary

Cherry-pick three `DecorateInfo` tolerance overrides from upstream pytorch/pytorch PR [#173188](https://github.com/pytorch/pytorch/pull/173188) (`[ROCm][CI] Upgrade ROCm CI to 7.2 - 4/N`, commit `8301e14b7003`, merged 2026-02-22 by @jithunnair-amd).

These overrides relax float32 tolerance for `nn.functional.conv3d` backward on CUDA (`atol=5e-5`, `rtol=5e-6`) for:
- `TestOperators.test_jvpvjp`
- `TestOperators.test_vjp`
- `TestCompositeCompliance.test_backward`

## Root Cause

`TestCompositeComplianceCUDA.test_backward_nn_functional_conv3d_cuda_float32` flakily fails on ROCm (ROCM-25028) because:

1. **MIOpen dilation workspace bug**: A legacy guard in `GetWorkSpaceSizeGEMM` returns workspace=0 for `dilation > 1`, blocking preferred GEMM solvers (`GemmBwdRest`/`GemmWrwUniversal`) and forcing fallback to a less-accurate solver. Fix [rocm-libraries#6507](https://github.com/ROCm/rocm-libraries/pull/6507) was merged but [reverted](https://github.com/ROCm/rocm-libraries/pull/6974) due to OOM on large diffusion workloads.

2. **Missing tolerance override**: The fallback solver produces gradient error of ~2.5e-5 — within the `atol=5e-5` override on release/2.12 but exceeding the default `atol=1e-5` on release/2.10.

The upstream tolerance override was added **after** the release/2.10 branch point (~Oct 2025) and is already present on release/2.11 and release/2.12. Intel XPU documented the identical pattern (pytorch/pytorch PRs #177069, #177848).

## Test plan

- [ ] Verify `PYTORCH_OPINFO_SAMPLE_INPUT_INDEX=10 PYTORCH_TEST_WITH_ROCM=1 python test/test_ops.py TestCompositeComplianceCUDA.test_backward_nn_functional_conv3d_cuda_float32` passes consistently on MI308/gfx94X
- [ ] Verify no regressions in `test_ops.py -k TestCompositeComplianceCUDA` test suite

Fixes: [ROCM-25028](https://amd-hub.atlassian.net/browse/ROCM-25028)

[ROCM-25028]: https://amd-hub.atlassian.net/browse/ROCM-25028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ