### PR TITLE
[release/2.11] Fix UnaryUfuncInfo ref lambda syntax

### DIFF
--- a/torch/testing/_internal/opinfo/definitions/special.py
+++ b/torch/testing/_internal/opinfo/definitions/special.py
@@ -381,7 +381,7 @@ op_db: list[OpInfo] = [
         ),
         dtypes=all_types_and(torch.bool, *_unsigned_int_types),
         dtypesIfMPS=all_types_and(torch.bool),
-        ref=lambda x: scipy.special.airy(x)[0] if TEST_SCIPY else None,
+        ref=(lambda x: scipy.special.airy(x)[0]) if TEST_SCIPY else None,
         skips=(
             DecorateInfo(
                 unittest.skip("Skipped!"),
@@ -862,7 +862,7 @@ op_db: list[OpInfo] = [
         ),
         dtypes=all_types_and(torch.bool, *_unsigned_int_types),
         dtypesIfMPS=all_types_and(torch.bool, torch.float16, torch.bfloat16),
-        ref=lambda x: scipy.special.spherical_jn(0, x) if TEST_SCIPY else None,
+        ref=(lambda x: scipy.special.spherical_jn(0, x)) if TEST_SCIPY else None,
         supports_autograd=False,
         skips=(
             DecorateInfo(


### PR DESCRIPTION
Cherry pick from 139fc0e00f658ac42f2173420f4e0b430977ace5
Fixes UnaryUfuncInfo tests when scipy is not installed