### PR TITLE
[CI] Add HUD link to parity summary

### DIFF
--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -143,8 +143,7 @@ jobs:
 
           if [ -n "${{ inputs.sha }}" ]; then
             ARGS="$ARGS --sha1 ${{ inputs.sha }}"
-          fi
-          if [ -n "${{ inputs.pr_id }}" ]; then
+          elif [ -n "${{ inputs.pr_id }}" ]; then
             ARGS="$ARGS --pr_id ${{ inputs.pr_id }}"
           fi
           if [ "${{ inputs.exclude_distributed }}" = "true" ]; then

--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -332,6 +332,29 @@ jobs:
             ARCH_ARGS+=("$ARCH")
           done
 
+          HUD_SHA="$SHA"
+          if [ -z "$HUD_SHA" ]; then
+            HUD_SHA=$(basename "$(find ../../artifacts/ -name '*.csv' | head -1)" | grep -oP '[0-9a-f]{40}' || true)
+          fi
+          HUD_URL=""
+          if [ -n "$PR_ID" ]; then
+            if [ -n "$HUD_SHA" ]; then
+              HUD_URL="https://hud.pytorch.org/pytorch/pytorch/pull/${PR_ID}?sha=${HUD_SHA}"
+            else
+              HUD_URL="https://hud.pytorch.org/pytorch/pytorch/pull/${PR_ID}"
+            fi
+          elif [ -n "$HUD_SHA" ]; then
+            HUD_URL="https://hud.pytorch.org/pytorch/pytorch/commit/${HUD_SHA}"
+          fi
+          if [ -n "$HUD_URL" ]; then
+            {
+              echo "### HUD"
+              echo ""
+              echo "[Open this run in HUD]($HUD_URL)"
+              echo ""
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
           if [ ${#CSV_ARGS[@]} -eq 0 ]; then
             echo "::warning::No CSVs found for any architecture — some or all generate-parity jobs may have failed"
             echo "## ⚠ No CSVs produced" >> "$GITHUB_STEP_SUMMARY"
@@ -345,9 +368,8 @@ jobs:
           if [ -n "$SHA" ]; then
             ARGS+=(--sha "$SHA")
           else
-            DETECTED_SHA=$(basename "$(find ../../artifacts/ -name '*.csv' | head -1)" | grep -oP '[0-9a-f]{40}' || true)
-            if [ -n "$DETECTED_SHA" ]; then
-              ARGS+=(--sha "$DETECTED_SHA")
+            if [ -n "$HUD_SHA" ]; then
+              ARGS+=(--sha "$HUD_SHA")
             fi
           fi
           if [ -n "$PR_ID" ]; then

--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -187,6 +187,7 @@ jobs:
           echo "folder=$FOLDER" >> "$GITHUB_OUTPUT"
           SHA=$(echo "$FOLDER" | grep -oP '[0-9a-f]{40}')
           echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          printf '%s\n' "$SHA" > "$FOLDER/hud_sha.txt"
           DATE=$(TZ='America/Los_Angeles' date '+%Y%m%d')
           echo "date=$DATE" >> "$GITHUB_OUTPUT"
           mv download_${{ matrix.arch }}.log "$FOLDER/" 2>/dev/null || true
@@ -260,6 +261,7 @@ jobs:
         run: |
           FOLDER=".automation_scripts/pytorch-unit-test-scripts/${{ steps.folder.outputs.folder }}"
           PATHS="${FOLDER}/*.csv
+          ${FOLDER}/hud_sha.txt
           ${FOLDER}/*.log
           ${FOLDER}/*.txt
           ${FOLDER}/inductor_periodic_rocm_dir/
@@ -332,6 +334,12 @@ jobs:
           done
 
           HUD_SHA="$SHA"
+          if [ -z "$HUD_SHA" ]; then
+            HUD_SHA_FILE=$(find ../../artifacts/ -name hud_sha.txt -print -quit)
+            if [ -n "$HUD_SHA_FILE" ]; then
+              HUD_SHA=$(cat "$HUD_SHA_FILE" | head -1)
+            fi
+          fi
           if [ -z "$HUD_SHA" ]; then
             HUD_SHA=$(find ../../artifacts/ -name '*.csv' | grep -oE '[0-9a-f]{40}' | head -1 || true)
           fi

--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -349,7 +349,7 @@ jobs:
             {
               echo "### HUD"
               echo ""
-              echo "[Open this run in HUD]($HUD_URL)"
+              echo "[HUD LINK]($HUD_URL)"
               echo ""
             } >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -333,14 +333,14 @@ jobs:
 
           HUD_SHA="$SHA"
           if [ -z "$HUD_SHA" ]; then
-            HUD_SHA=$(basename "$(find ../../artifacts/ -name '*.csv' | head -1)" | grep -oP '[0-9a-f]{40}' || true)
+            HUD_SHA=$(find ../../artifacts/ -name '*.csv' | grep -oE '[0-9a-f]{40}' | head -1 || true)
           fi
           HUD_URL=""
           if [ -n "$PR_ID" ]; then
             if [ -n "$HUD_SHA" ]; then
               HUD_URL="https://hud.pytorch.org/pytorch/pytorch/pull/${PR_ID}?sha=${HUD_SHA}"
             else
-              HUD_URL="https://hud.pytorch.org/pytorch/pytorch/pull/${PR_ID}"
+              echo "::warning::Unable to determine exact SHA for PR HUD link"
             fi
           elif [ -n "$HUD_SHA" ]; then
             HUD_URL="https://hud.pytorch.org/pytorch/pytorch/commit/${HUD_SHA}"


### PR DESCRIPTION
## Summary

Add a clickable `HUD LINK` to the parity report summary so users can jump from the GitHub Actions run to the matching PyTorch HUD page.

For PR runs, the link points to the PR HUD page with the exact SHA used for the report, e.g. `https://hud.pytorch.org/pytorch/pytorch/pull/<pr_id>?sha=<sha>`. For SHA-only runs, the link points to the commit HUD page.

## Validation

- PR-only example: triggered `parity.yml` with `pr_id=184377`, `arch=mi355`, and no SHA. The report resolved SHA `291ff45ffe10a301a88d1a83e98b9ba9987dbbfa`, so the HUD link is `https://hud.pytorch.org/pytorch/pytorch/pull/184377?sha=291ff45ffe10a301a88d1a83e98b9ba9987dbbfa`. Run passed: https://github.com/ROCm/pytorch/actions/runs/26476256833
- SHA-only example: triggered `parity.yml` with `sha=fe1b0a2ae93e0efcfa0defeee2ed879cf68eaac6`, `arch=mi355`, and no PR ID. Run passed: https://github.com/ROCm/pytorch/actions/runs/26475135922
