### PR TITLE
Upload parity summary markdown as a separate artifact

### DIFF
--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -376,6 +376,14 @@ jobs:
 
           cat "${OUTPUT}.md" >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Upload parity summary markdown
+        uses: actions/upload-artifact@v4
+        with:
+          name: parity-summary-md
+          path: .automation_scripts/pytorch-unit-test-scripts/*_summary.md
+          if-no-files-found: ignore
+          retention-days: 120
+
       - name: Add artifact links to summary
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary

Adds a single step to the `summarize` job in `parity.yml` that uploads
the generated `*_summary.md` (the same content already appended to
`$GITHUB_STEP_SUMMARY`) as a standalone artifact named
`parity-summary-md`, with N-day retention.

The existing per-arch result artifacts have a 1-day retention, which
makes it impossible to recover the summary content (e.g. `### FAILED
TESTS`, `### LOG-BASED FAILURES`) after that window. This change lets
external tooling — for example the in-progress upstream CI failure
tracking — fetch the exact UI summary via `gh run download` long after
the CSVs are gone, with only a standard PAT.

No behavior change for any existing job. `if-no-files-found: ignore`
keeps the step a no-op on early-exit runs (no CSVs produced).

## Test plan

- [ ] Re-run `parity.yml` (or an autoparity manual dispatch) and verify
      the `parity-summary-md` artifact appears alongside the per-arch
      results artifacts.
- [ ] `gh run download <run_id> -R ROCm/pytorch -n parity-summary-md`
      returns the expected `*_summary.md`.
- [ ] On a run with no CSVs (forced early exit), confirm the workflow
      still succeeds and no artifact is uploaded.
