### PR TITLE
[ROCm][release/2.10] Skip profiler check for foreach tests on ROCm (ROCM-21749)

### DIFF
--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -81,7 +81,7 @@ class ForeachFuncWrapper:
 
         # Skip profiler check for CUDA 12.6, 12.8 as the upgrade makes profiler results flaky
         # https://github.com/pytorch/pytorch/issues/148681. TODO: ADD IT BACK!!!
-        skip_profiler_check = _get_torch_cuda_version() in [(12, 6), (12, 8)]
+        skip_profiler_check = _get_torch_cuda_version() in [(12, 6), (12, 8)] or TEST_WITH_ROCM
         if (
             is_cuda
             and not skip_profiler_check


### PR DESCRIPTION
## Summary

Fixes ROCM-21749: `test_big_num_tensors__foreach_norm` fails on all ROCm GPUs.

## Root Cause

`ForeachFuncWrapper.__call__` profiles a `_foreach_norm` call and checks for `multi_tensor_apply_kernel` in profiler output to verify the multi-tensor fast-path was taken. On CUDA, Kineto captures demangled kernel names like `multi_tensor_apply_kernel[...]`. On ROCm, ROCTracer/rocprofiler captures different symbols (`hipLaunchKernel`, `vectorized_elementwise_kernel`, etc.), so `mta_called` is always `False` and the assertion fails.

## Fix

Add `or TEST_WITH_ROCM` to `skip_profiler_check` so the profiler-based assertion is bypassed on ROCm, consistent with the existing skip for CUDA 12.6/12.8 flakiness.

## Test Plan

- `test_big_num_tensors__foreach_norm_*` should now pass on ROCm GPUs (MI210, MI300X, MI350X)
- No change in behavior on CUDA

Jira: https://amd-hub.atlassian.net/browse/ROCM-21749