### PR TITLE
[CI] Surface upstream pytorch CI job link in parity summary

### DIFF
--- a/.automation_scripts/pytorch-unit-test-scripts/detect_log_failures.py
+++ b/.automation_scripts/pytorch-unit-test-scripts/detect_log_failures.py
@@ -292,7 +292,10 @@ def scan_logs(logs_dir):
         job_total = shard_totals.get((platform, test_config), 0)
         job_shard_str = f"{shard_num}/{job_total}" if job_total else str(shard_num)
 
-        # Written by download_testlogs next to each log file.
+        # If download_testlogs left a "<log>.job_url" file next to this log,
+        # it contains the URL of the upstream pytorch CI job that produced
+        # the log. We surface it in the LOG-BASED FAILURES table as a link
+        # to that job's page. Empty for older runs that predate this.
         job_url_file = os.path.join(logs_dir, fname + ".job_url")
         job_url = ""
         if os.path.isfile(job_url_file):

--- a/.automation_scripts/pytorch-unit-test-scripts/detect_log_failures.py
+++ b/.automation_scripts/pytorch-unit-test-scripts/detect_log_failures.py
@@ -292,6 +292,18 @@ def scan_logs(logs_dir):
         job_total = shard_totals.get((platform, test_config), 0)
         job_shard_str = f"{shard_num}/{job_total}" if job_total else str(shard_num)
 
+        # Companion .job_url file written by download_testlogs.write_test_log_to_file.
+        # Absent for log archives produced before that change landed; in that
+        # case job_url stays empty and the column renders as a blank cell.
+        job_url_file = os.path.join(logs_dir, fname + ".job_url")
+        job_url = ""
+        if os.path.isfile(job_url_file):
+            try:
+                with open(job_url_file) as jf:
+                    job_url = jf.read().strip()
+            except OSError:
+                pass
+
         filepath = os.path.join(logs_dir, fname)
         results, consistent_failures, flaky_tests = parse_log_file(filepath)
 
@@ -306,6 +318,7 @@ def scan_logs(logs_dir):
                 "test_name": ft["method"],
                 "job_shard": job_shard_str,
                 "test_shard": ft["test_shard"],
+                "job_url": job_url,
             })
 
         # Record every (test_file, test_shard) observed in this log file,
@@ -365,6 +378,7 @@ def scan_logs(logs_dir):
                 "category": "+".join(categories),
                 "reason": reason,
                 "exit_codes": ",".join(str(c) for c in info["exit_codes"]),
+                "job_url": job_url,
             })
 
         for test_path, shard_str in consistent_failures:
@@ -384,6 +398,7 @@ def scan_logs(logs_dir):
                 "category": "CONSISTENT_FAILURE",
                 "reason": f"{test_class}::{test_name}" if test_class else "",
                 "exit_codes": "",
+                "job_url": job_url,
             })
 
     def _sort_shards(vals):
@@ -420,6 +435,7 @@ def write_csv_report(failures, output_path):
         "log_file", "platform", "test_config", "test_file",
         "job_shard", "test_shard",
         "status", "category", "reason", "exit_codes",
+        "job_url",
     ]
     with open(output_path, "w", newline="") as f:
         writer = csv.DictWriter(f, fieldnames=fieldnames)
@@ -441,6 +457,7 @@ def write_flaky_report(flaky, output_path):
     fieldnames = [
         "log_file", "platform", "test_config", "test_file",
         "test_class", "test_name", "job_shard", "test_shard",
+        "job_url",
     ]
     with open(output_path, "w", newline="") as f:
         writer = csv.DictWriter(f, fieldnames=fieldnames)

--- a/.automation_scripts/pytorch-unit-test-scripts/detect_log_failures.py
+++ b/.automation_scripts/pytorch-unit-test-scripts/detect_log_failures.py
@@ -292,17 +292,12 @@ def scan_logs(logs_dir):
         job_total = shard_totals.get((platform, test_config), 0)
         job_shard_str = f"{shard_num}/{job_total}" if job_total else str(shard_num)
 
-        # Companion .job_url file written by download_testlogs.write_test_log_to_file.
-        # Absent for log archives produced before that change landed; in that
-        # case job_url stays empty and the column renders as a blank cell.
+        # Written by download_testlogs next to each log file.
         job_url_file = os.path.join(logs_dir, fname + ".job_url")
         job_url = ""
         if os.path.isfile(job_url_file):
-            try:
-                with open(job_url_file) as jf:
-                    job_url = jf.read().strip()
-            except OSError:
-                pass
+            with open(job_url_file) as f:
+                job_url = f.read().strip()
 
         filepath = os.path.join(logs_dir, fname)
         results, consistent_failures, flaky_tests = parse_log_file(filepath)

--- a/.automation_scripts/pytorch-unit-test-scripts/download_testlogs
+++ b/.automation_scripts/pytorch-unit-test-scripts/download_testlogs
@@ -90,6 +90,18 @@ def write_test_log_to_file(filename, test_key, jobs, sha):
     with open(filename, "w", encoding="utf-8") as f:
         f.write(response.text)
 
+    # Write the pytorch/pytorch CI job URL to a companion .job_url file next
+    # to this log so detect_log_failures.py can surface it in the LOG-BASED
+    # FAILURES table of the parity summary, giving reviewers a click-through
+    # to the failing job's logs for the stacktrace.
+    job_url = js[0].get('html_url') or ''
+    if job_url:
+        try:
+            with open(filename + ".job_url", "w", encoding="utf-8") as f:
+                f.write(job_url)
+        except OSError as e:
+            print(f"  WARNING: failed to write {filename}.job_url: {e}")
+
 def get_workflow_jobs(wf):
     """Get all jobs for a workflow run."""
     if wf is None:
@@ -239,24 +251,32 @@ def _shorten_unzipped_dirs():
       unzipped-test-reports-runattempt1-test-default-1-6-linux.rocm.gpu.gfx942.1_68613413431.zip
       unzipped-test-reports-runattempt1-test-osdc-default-1-5-mt-l-x86aavx2-29-113-l4_73385044118.zip
     to:
-      test-default-1-6
-      test-default-1-5
+      test-default-1-6_68613413431
+      test-default-1-5_73385044118
 
-    Preserves the 'test-<config>' prefix so that summarize_xml_testreports.py
-    can still detect workflow type via substring matching.
+    Preserves the 'test-<config>' prefix so summarize_xml_testreports.py can
+    still detect workflow type via substring matching. The trailing
+    '_<jobid>' encodes the upstream pytorch/pytorch CI job id, which
+    summarize_xml_testreports.py combines with the workflow run id to build
+    a direct link to the failing job. Existing consumers tolerate the
+    suffix: `re.match(r'test-\\w+-(\\d+)-(\\d+)', dirname)` is unanchored at
+    the end, and `"test-default" in dirname` is a substring check.
     """
     from pathlib import Path
     for d in sorted(Path(".").glob("unzipped-*")):
         if not d.is_dir():
             continue
         m = re.search(r'test-(?:osdc-)?(default|distributed|inductor)-(\d+)-(\d+)', d.name)
-        if m:
-            short_name = f"test-{m.group(1)}-{m.group(2)}-{m.group(3)}"
-            if not Path(short_name).exists():
-                d.rename(short_name)
-                print(f"  Renamed {d.name} -> {short_name}")
-            else:
-                print(f"  WARNING: {short_name} already exists, keeping {d.name}")
+        if not m:
+            continue
+        job_id_match = re.search(r'_(\d{6,})\.zip$', d.name)
+        job_id_suffix = f"_{job_id_match.group(1)}" if job_id_match else ""
+        short_name = f"test-{m.group(1)}-{m.group(2)}-{m.group(3)}{job_id_suffix}"
+        if not Path(short_name).exists():
+            d.rename(short_name)
+            print(f"  Renamed {d.name} -> {short_name}")
+        else:
+            print(f"  WARNING: {short_name} already exists, keeping {d.name}")
 
 def download_xml_files(workflow_run_id, workflow_run_attempts, prefixes=[], allowed_substrings=None):
     # Get from S3 artifacts
@@ -296,6 +316,14 @@ def download_xml_files(workflow_run_id, workflow_run_attempts, prefixes=[], allo
             unzip(path)
 
     _shorten_unzipped_dirs()
+
+    # Workflow run id used by summarize_xml_testreports.py to build per-job
+    # URLs (combined with the '_<jobid>' suffix on each test-<cfg>-N-N dir).
+    try:
+        with open("_wf_run_id", "w") as f:
+            f.write(str(workflow_run_id))
+    except OSError as e:
+        print(f"  WARNING: failed to write _wf_run_id: {e}")
 
     # Delete raw zip files now that contents are extracted
     for path in artifact_paths:

--- a/.automation_scripts/pytorch-unit-test-scripts/download_testlogs
+++ b/.automation_scripts/pytorch-unit-test-scripts/download_testlogs
@@ -90,6 +90,9 @@ def write_test_log_to_file(filename, test_key, jobs, sha):
     with open(filename, "w", encoding="utf-8") as f:
         f.write(response.text)
 
+    # Save the upstream pytorch CI job's page URL next to the log so
+    # detect_log_failures.py can later surface it as a link in the
+    # LOG-BASED FAILURES table of the parity summary.
     job_url = js[0].get('html_url', '')
     if job_url:
         with open(filename + ".job_url", "w", encoding="utf-8") as f:
@@ -259,9 +262,13 @@ def _shorten_unzipped_dirs():
         m = re.search(r'test-(?:osdc-)?(default|distributed|inductor)-(\d+)-(\d+)', d.name)
         if m:
             short_name = f"test-{m.group(1)}-{m.group(2)}-{m.group(3)}"
-            jid = re.search(r'_(\d{6,})\.zip$', d.name)
-            if jid:
-                short_name += f"_{jid.group(1)}"
+            # The original artifact name ends with "_<jobid>.zip" where
+            # <jobid> is the upstream pytorch CI job id (e.g.
+            # ..._68613413431.zip). Carry it onto short_name so
+            # summarize_xml_testreports.py can link to that job.
+            job_id_match = re.search(r'_(\d{6,})\.zip$', d.name)
+            if job_id_match:
+                short_name += f"_{job_id_match.group(1)}"
             if not Path(short_name).exists():
                 d.rename(short_name)
                 print(f"  Renamed {d.name} -> {short_name}")

--- a/.automation_scripts/pytorch-unit-test-scripts/download_testlogs
+++ b/.automation_scripts/pytorch-unit-test-scripts/download_testlogs
@@ -90,17 +90,10 @@ def write_test_log_to_file(filename, test_key, jobs, sha):
     with open(filename, "w", encoding="utf-8") as f:
         f.write(response.text)
 
-    # Write the pytorch/pytorch CI job URL to a companion .job_url file next
-    # to this log so detect_log_failures.py can surface it in the LOG-BASED
-    # FAILURES table of the parity summary, giving reviewers a click-through
-    # to the failing job's logs for the stacktrace.
-    job_url = js[0].get('html_url') or ''
+    job_url = js[0].get('html_url', '')
     if job_url:
-        try:
-            with open(filename + ".job_url", "w", encoding="utf-8") as f:
-                f.write(job_url)
-        except OSError as e:
-            print(f"  WARNING: failed to write {filename}.job_url: {e}")
+        with open(filename + ".job_url", "w", encoding="utf-8") as f:
+            f.write(job_url)
 
 def get_workflow_jobs(wf):
     """Get all jobs for a workflow run."""
@@ -254,29 +247,26 @@ def _shorten_unzipped_dirs():
       test-default-1-6_68613413431
       test-default-1-5_73385044118
 
-    Preserves the 'test-<config>' prefix so summarize_xml_testreports.py can
-    still detect workflow type via substring matching. The trailing
-    '_<jobid>' encodes the upstream pytorch/pytorch CI job id, which
-    summarize_xml_testreports.py combines with the workflow run id to build
-    a direct link to the failing job. Existing consumers tolerate the
-    suffix: `re.match(r'test-\\w+-(\\d+)-(\\d+)', dirname)` is unanchored at
-    the end, and `"test-default" in dirname` is a substring check.
+    Preserves the 'test-<config>' prefix so that summarize_xml_testreports.py
+    can still detect workflow type via substring matching. The trailing
+    '_<jobid>' is the upstream pytorch CI job id, used to link to the
+    failing job from the parity summary.
     """
     from pathlib import Path
     for d in sorted(Path(".").glob("unzipped-*")):
         if not d.is_dir():
             continue
         m = re.search(r'test-(?:osdc-)?(default|distributed|inductor)-(\d+)-(\d+)', d.name)
-        if not m:
-            continue
-        job_id_match = re.search(r'_(\d{6,})\.zip$', d.name)
-        job_id_suffix = f"_{job_id_match.group(1)}" if job_id_match else ""
-        short_name = f"test-{m.group(1)}-{m.group(2)}-{m.group(3)}{job_id_suffix}"
-        if not Path(short_name).exists():
-            d.rename(short_name)
-            print(f"  Renamed {d.name} -> {short_name}")
-        else:
-            print(f"  WARNING: {short_name} already exists, keeping {d.name}")
+        if m:
+            short_name = f"test-{m.group(1)}-{m.group(2)}-{m.group(3)}"
+            jid = re.search(r'_(\d{6,})\.zip$', d.name)
+            if jid:
+                short_name += f"_{jid.group(1)}"
+            if not Path(short_name).exists():
+                d.rename(short_name)
+                print(f"  Renamed {d.name} -> {short_name}")
+            else:
+                print(f"  WARNING: {short_name} already exists, keeping {d.name}")
 
 def download_xml_files(workflow_run_id, workflow_run_attempts, prefixes=[], allowed_substrings=None):
     # Get from S3 artifacts
@@ -317,13 +307,8 @@ def download_xml_files(workflow_run_id, workflow_run_attempts, prefixes=[], allo
 
     _shorten_unzipped_dirs()
 
-    # Workflow run id used by summarize_xml_testreports.py to build per-job
-    # URLs (combined with the '_<jobid>' suffix on each test-<cfg>-N-N dir).
-    try:
-        with open("_wf_run_id", "w") as f:
-            f.write(str(workflow_run_id))
-    except OSError as e:
-        print(f"  WARNING: failed to write _wf_run_id: {e}")
+    with open("_wf_run_id", "w") as f:
+        f.write(str(workflow_run_id))
 
     # Delete raw zip files now that contents are extracted
     for path in artifact_paths:

--- a/.automation_scripts/pytorch-unit-test-scripts/generate_summary.py
+++ b/.automation_scripts/pytorch-unit-test-scripts/generate_summary.py
@@ -3,6 +3,7 @@
 import argparse
 import csv
 import os
+import re
 import sys
 
 
@@ -289,10 +290,12 @@ def collect_failed_tests(arch_data, archs, s1_name, s2_name):
                     'test_name': r.get('test_name', ''),
                     'test_config': r.get('test_config', ''),
                     f'shard_{s1_name}': r.get(f'shard_{s1_name}', ''),
+                    f'job_url_{s1_name}': r.get(f'job_url_{s1_name}', ''),
                     f'status_{s1_name}': s1,
                 }
                 if has_set2:
                     entry[f'shard_{s2_name}'] = r.get(f'shard_{s2_name}', '')
+                    entry[f'job_url_{s2_name}'] = r.get(f'job_url_{s2_name}', '')
                     entry[f'status_{s2_name}'] = s2
                 failed.append(entry)
 
@@ -418,6 +421,7 @@ def load_flaky_tests_as_log_failures(filepaths):
                     'category': 'FLAKY',
                     'reason': f'{test_class}::{test_name}' if test_class else test_name,
                     'exit_codes': '',
+                    'job_url': row.get('job_url', ''),
                 })
     return entries
 
@@ -691,6 +695,18 @@ def write_markdown(rows, archs, output_path, failed_tests=None, s1_name='set1', 
                _norm_test_file(t.get('test_file', '')))
         return _format_test_shards(shard_lookup.get(key, ''))
 
+    def _job_url_cell(url):
+        """Render the job-url column as a markdown link labeled with the job_id.
+
+        Empty when no URL is present, so the column gracefully degrades for
+        rows produced before the upstream pipeline starts emitting job_url.
+        """
+        if not url:
+            return ''
+        m = re.search(r'/job/(\d+)', url)
+        label = m.group(1) if m else 'job'
+        return f'[{label}]({url})'
+
     cols = ['Arch', 'Test Config', 'Test File', 'Test Class', 'Test Name',
             f'Job-Level Shard ({s1_name})',
             f'Test-Level Shard ({s1_name})']
@@ -701,6 +717,9 @@ def write_markdown(rows, archs, output_path, failed_tests=None, s1_name='set1', 
     if has_set2:
         cols.append(f'Status ({s2_name})')
     cols.append('Also Failing In')
+    cols.append(f'Job ID ({s1_name})')
+    if has_set2:
+        cols.append(f'Job ID ({s2_name})')
 
     if s1_failed:
         lines.append(f'### FAILED TESTS ({len(s1_failed)})')
@@ -718,7 +737,11 @@ def write_markdown(rows, archs, output_path, failed_tests=None, s1_name='set1', 
             line += f" | {t[f'status_{s1_name}']}"
             if has_set2:
                 line += f" | {t.get(f'status_{s2_name}', '')}"
-            line += f" | {t.get('also_failing_in', '')} |"
+            line += f" | {t.get('also_failing_in', '')}"
+            line += f" | {_job_url_cell(t.get(f'job_url_{s1_name}', ''))}"
+            if has_set2:
+                line += f" | {_job_url_cell(t.get(f'job_url_{s2_name}', ''))}"
+            line += ' |'
             lines.append(line)
         lines.append('')
     else:
@@ -748,8 +771,8 @@ def write_markdown(rows, archs, output_path, failed_tests=None, s1_name='set1', 
             lines.append('These test failures were detected from CI log files but have no XML report')
             lines.append('(typically due to timeouts, crashes, or process kills).')
             lines.append('')
-            lines.append('| Arch | Platform | Test Config | Test File | Test Class | Test Name | Job-Level Shard | Test-Level Shard | Category | Also Failing In |')
-            lines.append('| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |')
+            lines.append('| Arch | Platform | Test Config | Test File | Test Class | Test Name | Job-Level Shard | Test-Level Shard | Category | Also Failing In | Job ID |')
+            lines.append('| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |')
             for lf in rocm_log_failures:
                 test_class, test_name = _parse_log_failure_names(lf)
                 lines.append(
@@ -759,7 +782,8 @@ def write_markdown(rows, archs, output_path, failed_tests=None, s1_name='set1', 
                     f"| {lf.get('job_shard', '')} "
                     f"| {lf.get('test_shard', lf.get('shard', ''))} "
                     f"| {lf.get('category', '')} "
-                    f"| {lf.get('also_failing_in', '')} |"
+                    f"| {lf.get('also_failing_in', '')} "
+                    f"| {_job_url_cell(lf.get('job_url', ''))} |"
                 )
             lines.append('')
 

--- a/.automation_scripts/pytorch-unit-test-scripts/generate_summary.py
+++ b/.automation_scripts/pytorch-unit-test-scripts/generate_summary.py
@@ -698,8 +698,12 @@ def write_markdown(rows, archs, output_path, failed_tests=None, s1_name='set1', 
     def _job_id_link(url):
         if not url:
             return ''
+        # Use the job id (digits after "/job/" in the URL) as the visible
+        # link label so the cell reads e.g. [76905282313](...).
         m = re.search(r'/job/(\d+)', url)
-        return f'[{m.group(1)}]({url})' if m else f'[job]({url})'
+        if not m:
+            return ''
+        return f'[{m.group(1)}]({url})'
 
     cols = ['Arch', 'Test Config', 'Test File', 'Test Class', 'Test Name',
             f'Job-Level Shard ({s1_name})',

--- a/.automation_scripts/pytorch-unit-test-scripts/generate_summary.py
+++ b/.automation_scripts/pytorch-unit-test-scripts/generate_summary.py
@@ -695,17 +695,11 @@ def write_markdown(rows, archs, output_path, failed_tests=None, s1_name='set1', 
                _norm_test_file(t.get('test_file', '')))
         return _format_test_shards(shard_lookup.get(key, ''))
 
-    def _job_url_cell(url):
-        """Render the job-url column as a markdown link labeled with the job_id.
-
-        Empty when no URL is present, so the column gracefully degrades for
-        rows produced before the upstream pipeline starts emitting job_url.
-        """
+    def _job_id_link(url):
         if not url:
             return ''
         m = re.search(r'/job/(\d+)', url)
-        label = m.group(1) if m else 'job'
-        return f'[{label}]({url})'
+        return f'[{m.group(1)}]({url})' if m else f'[job]({url})'
 
     cols = ['Arch', 'Test Config', 'Test File', 'Test Class', 'Test Name',
             f'Job-Level Shard ({s1_name})',
@@ -738,9 +732,9 @@ def write_markdown(rows, archs, output_path, failed_tests=None, s1_name='set1', 
             if has_set2:
                 line += f" | {t.get(f'status_{s2_name}', '')}"
             line += f" | {t.get('also_failing_in', '')}"
-            line += f" | {_job_url_cell(t.get(f'job_url_{s1_name}', ''))}"
+            line += f" | {_job_id_link(t.get(f'job_url_{s1_name}', ''))}"
             if has_set2:
-                line += f" | {_job_url_cell(t.get(f'job_url_{s2_name}', ''))}"
+                line += f" | {_job_id_link(t.get(f'job_url_{s2_name}', ''))}"
             line += ' |'
             lines.append(line)
         lines.append('')
@@ -783,7 +777,7 @@ def write_markdown(rows, archs, output_path, failed_tests=None, s1_name='set1', 
                     f"| {lf.get('test_shard', lf.get('shard', ''))} "
                     f"| {lf.get('category', '')} "
                     f"| {lf.get('also_failing_in', '')} "
-                    f"| {_job_url_cell(lf.get('job_url', ''))} |"
+                    f"| {_job_id_link(lf.get('job_url', ''))} |"
                 )
             lines.append('')
 

--- a/.automation_scripts/pytorch-unit-test-scripts/summarize_xml_testreports.py
+++ b/.automation_scripts/pytorch-unit-test-scripts/summarize_xml_testreports.py
@@ -69,6 +69,21 @@ def _extract_shard(dirname):
 def parse_xml_reports_as_dict(workflow_run_id, workflow_run_attempt, tag, path="."):
     test_config = ""
     test_cases = {}
+
+    # The '_wf_run_id' file is written by download_testlogs.download_xml_files
+    # and identifies the upstream pytorch/pytorch CI workflow run these XML
+    # reports came from. Combined with the '_<jobid>' suffix on each
+    # test-<cfg>-N-N directory, it lets us build a direct link to the
+    # failing job page so reviewers can jump straight to the stacktrace.
+    wf_run_id = ""
+    wf_id_file = os.path.join(path, "_wf_run_id")
+    if os.path.isfile(wf_id_file):
+        try:
+            with open(wf_id_file) as f:
+                wf_run_id = f.read().strip()
+        except OSError:
+            pass
+
     items_list = os.listdir(path)
     for dir in items_list:
         new_dir = path + '/' + dir + '/'
@@ -80,6 +95,11 @@ def parse_xml_reports_as_dict(workflow_run_id, workflow_run_attempt, tag, path="
             elif "test-inductor" in new_dir:
                 test_config = TestConfigName.inductor.name
             shard = _extract_shard(dir)
+            m_jid = re.search(r'_(\d{6,})$', dir)
+            job_id = m_jid.group(1) if m_jid else ""
+            job_url = ""
+            if wf_run_id and job_id:
+                job_url = f"https://github.com/pytorch/pytorch/actions/runs/{wf_run_id}/job/{job_id}"
             for xml_report in Path(new_dir).glob("**/*.xml"):
                 try:
                     new_cases = parse_xml_report(
@@ -94,6 +114,8 @@ def parse_xml_reports_as_dict(workflow_run_id, workflow_run_attempt, tag, path="
                     continue
                 for key, case in new_cases.items():
                     case["shard"] = shard
+                    if job_url:
+                        case["job_url"] = job_url
                     existing = test_cases.get(key)
                     if existing is None or _status_priority(case) > _status_priority(existing):
                         test_cases[key] = case
@@ -472,6 +494,8 @@ def summarize_xml_files(args):
         item_values["test_config"] = config_name
         item_values[f"shard_{set1_name}"] = v_values.get('shard', '') if v_values else ''
         item_values[f"shard_{set2_name}"] = v1_values.get('shard', '') if v1_values else ''
+        item_values[f"job_url_{set1_name}"] = v_values.get('job_url', '') if v_values else ''
+        item_values[f"job_url_{set2_name}"] = v1_values.get('job_url', '') if v1_values else ''
         # get test related info
         item_values[f"message_{set1_name}"] = get_test_message(v[0])
         item_values[f"message_{set2_name}"] = get_test_message(v[1]) if set2_path else ""
@@ -564,6 +588,10 @@ def summarize_xml_files(args):
           return 21
         elif e == f"shard_{set2_name}":
           return 22
+        elif e == f"job_url_{set1_name}":
+          return 23
+        elif e == f"job_url_{set2_name}":
+          return 24
         elif e == "workflow_run_attempt" or e == "job_id":
           return 1000
         else:

--- a/.automation_scripts/pytorch-unit-test-scripts/summarize_xml_testreports.py
+++ b/.automation_scripts/pytorch-unit-test-scripts/summarize_xml_testreports.py
@@ -70,19 +70,12 @@ def parse_xml_reports_as_dict(workflow_run_id, workflow_run_attempt, tag, path="
     test_config = ""
     test_cases = {}
 
-    # The '_wf_run_id' file is written by download_testlogs.download_xml_files
-    # and identifies the upstream pytorch/pytorch CI workflow run these XML
-    # reports came from. Combined with the '_<jobid>' suffix on each
-    # test-<cfg>-N-N directory, it lets us build a direct link to the
-    # failing job page so reviewers can jump straight to the stacktrace.
+    # Written by download_testlogs alongside the test-<cfg>-N-N dirs.
     wf_run_id = ""
     wf_id_file = os.path.join(path, "_wf_run_id")
     if os.path.isfile(wf_id_file):
-        try:
-            with open(wf_id_file) as f:
-                wf_run_id = f.read().strip()
-        except OSError:
-            pass
+        with open(wf_id_file) as f:
+            wf_run_id = f.read().strip()
 
     items_list = os.listdir(path)
     for dir in items_list:
@@ -95,11 +88,11 @@ def parse_xml_reports_as_dict(workflow_run_id, workflow_run_attempt, tag, path="
             elif "test-inductor" in new_dir:
                 test_config = TestConfigName.inductor.name
             shard = _extract_shard(dir)
-            m_jid = re.search(r'_(\d{6,})$', dir)
-            job_id = m_jid.group(1) if m_jid else ""
-            job_url = ""
-            if wf_run_id and job_id:
-                job_url = f"https://github.com/pytorch/pytorch/actions/runs/{wf_run_id}/job/{job_id}"
+            jid = re.search(r'_(\d+)$', dir)
+            job_url = (
+                f"https://github.com/pytorch/pytorch/actions/runs/{wf_run_id}/job/{jid.group(1)}"
+                if wf_run_id and jid else ""
+            )
             for xml_report in Path(new_dir).glob("**/*.xml"):
                 try:
                     new_cases = parse_xml_report(
@@ -114,8 +107,7 @@ def parse_xml_reports_as_dict(workflow_run_id, workflow_run_attempt, tag, path="
                     continue
                 for key, case in new_cases.items():
                     case["shard"] = shard
-                    if job_url:
-                        case["job_url"] = job_url
+                    case["job_url"] = job_url
                     existing = test_cases.get(key)
                     if existing is None or _status_priority(case) > _status_priority(existing):
                         test_cases[key] = case

--- a/.automation_scripts/pytorch-unit-test-scripts/summarize_xml_testreports.py
+++ b/.automation_scripts/pytorch-unit-test-scripts/summarize_xml_testreports.py
@@ -70,7 +70,11 @@ def parse_xml_reports_as_dict(workflow_run_id, workflow_run_attempt, tag, path="
     test_config = ""
     test_cases = {}
 
-    # Written by download_testlogs alongside the test-<cfg>-N-N dirs.
+    # download_testlogs writes the upstream pytorch CI workflow run id
+    # into "_wf_run_id" alongside the shard dirs. We combine it with each
+    # shard dir's trailing "_<job_id>" to form the URL
+    # https://github.com/pytorch/pytorch/actions/runs/<wf>/job/<job_id>
+    # surfaced as the "Job ID" column in the FAILED TESTS table.
     wf_run_id = ""
     wf_id_file = os.path.join(path, "_wf_run_id")
     if os.path.isfile(wf_id_file):


### PR DESCRIPTION
## Summary

- Adds a clickable **Job ID** column at the end of both the `FAILED TESTS` and `LOG-BASED FAILURES (not in XML)` tables in the parity summary markdown. Each cell renders as `[<job_id>](https://github.com/pytorch/pytorch/actions/runs/<wf>/job/<job_id>)`, dropping the reviewer one click away from the stacktrace.
- Threads the upstream `pytorch/pytorch` CI job url through the existing pipeline — `download_testlogs` was already fetching that info, it just wasn't being preserved. No new API calls; no schema migrations; just persistence through `download_testlogs` → `summarize_xml_testreports.py` / `detect_log_failures.py` → `generate_summary.py`.
- Backwards-compatible: every consumer reads the new fields via `.get(..., '')` / `os.path.isfile`, so older artifacts and CSVs render the column as empty cells instead of breaking.

### Example resulting row (FAILED TESTS, set2-disabled case)

```
| Arch | Test Config | Test File | Test Class | Test Name | Job-Level Shard (rocm) | Test-Level Shard (rocm) | Status (rocm) | Also Failing In | Job ID (rocm) |
| mi300 | default | test_foo | TestBar | test_baz | 3/6 | 5/15 | FAILED | mi355 | [76905282313](https://github.com/pytorch/pytorch/actions/runs/26146653222/job/76905282313) |
```

### Data flow

- **FAILED TESTS** (XML-based): `_shorten_unzipped_dirs` keeps the trailing `_<jobid>` of the artifact name on each `test-<cfg>-N-N/` dir → `download_xml_files` writes one `_wf_run_id` file at the parent → `parse_xml_reports_as_dict` builds the url and stamps it on each test case → per-arch CSV carries `job_url_{set_name}` → `collect_failed_tests` propagates → markdown renders.
- **LOG-BASED FAILURES**: `write_test_log_to_file` writes a companion `<filename>.job_url` file (full url from the job's `html_url`) → `scan_logs` reads it and stamps `job_url` on every failure / flaky row → `log_failures_<arch>.csv` / `flaky_tests_<arch>.csv` carry it → `load_log_failures` / `load_flaky_tests_as_log_failures` propagate → markdown renders.

## Test plan

- Trigger a `parity.yml` run and confirm:
  - Per-arch test-report shard dirs are named `test-<cfg>-N-N_<jobid>` after `_shorten_unzipped_dirs`.
  - `_wf_run_id` file exists alongside the shard dirs in `rocm_xml/` and `cuda_xml/`.
  - `<filename>.job_url` companion files exist next to each `rocm*.txt` / `cuda*.txt` log file.
- Inspect the per-arch CSV emitted by `summarize_xml_testreports.py` and confirm `job_url_<set1_name>` / `job_url_<set2_name>` columns are populated for failing rows.
- Inspect `log_failures_<arch>.csv` / `flaky_tests_<arch>.csv` and confirm `job_url` column is populated.
- Inspect the parity summary markdown artifact and click a `Job ID` cell in both tables → lands on the failing pytorch/pytorch job page with the stacktrace.
- Re-run against a historical commit whose artifacts predate this change and confirm cells render as empty (no crash, no broken table).

