### PR TITLE
[ROCm] Fix duplicate hipMemMap call in map_block() causing SIGSEGV

### DIFF
--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryUtils.cpp
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryUtils.cpp
@@ -72,7 +72,7 @@ IpcChannel::~IpcChannel() {
 }
 
 void IpcChannel::send_fd(int dst_pid, int fd) {
-  // Because file descriptors are process-local kernel objects, and we can’t
+  // Because file descriptors are process-local kernel objects, and we can't
   // pass them via normal socket payloads (like write() or send()).  Unix domain
   // sockets provide a mechanism to pass actual FDs via sendmsg()/recvmsg().
   // Define destination socket address
@@ -245,12 +245,6 @@ void map_block(
   C10_CUDA_DRIVER_CHECK(driver_api->cuMemSetAccess_(*dev_ptr, size, &desc, 1));
 #elif defined(USE_ROCM)
   C10_CUDA_CHECK(hipMemAddressReserve(ptr, size, 0ULL, 0, 0ULL));
-  C10_CUDA_CHECK(hipMemMap(
-      *ptr,
-      size,
-      0,
-      reinterpret_cast<hipMemGenericAllocationHandle_t>(handle),
-      0ULL));
   C10_CUDA_CHECK(hipMemMap(
       *ptr,
       size,


### PR DESCRIPTION
## Summary

Fixes SIGSEGV (exit -11) in `IntraNodeComm::rendezvous()` during `test_intra_node_comm_all_reduce_custom_group_name_{True,False}` on MI300X/MI308X gfx942 (ROCM-25272).

## Root Cause

The ROCm code path in `map_block()` (`CUDASymmetricMemoryUtils.cpp`) calls `hipMemMap()` **twice** with identical arguments — a copy-paste bug. The CUDA path correctly calls `cuMemMap_()` only once.

**Before (buggy):**
```cpp
#elif defined(USE_ROCM)
  C10_CUDA_CHECK(hipMemAddressReserve(ptr, size, 0ULL, 0, 0ULL));
  C10_CUDA_CHECK(hipMemMap(*ptr, size, 0, ...handle..., 0ULL));
  C10_CUDA_CHECK(hipMemMap(*ptr, size, 0, ...handle..., 0ULL));  // DUPLICATE
```

**After (fixed):**
```cpp
#elif defined(USE_ROCM)
  C10_CUDA_CHECK(hipMemAddressReserve(ptr, size, 0ULL, 0, 0ULL));
  C10_CUDA_CHECK(hipMemMap(*ptr, size, 0, ...handle..., 0ULL));
```

Mapping over an already-mapped VA range causes undefined behavior in the HIP VMM driver, leading to SIGSEGV when `IntraNodeComm::rendezvous()` is called during the first `allreduce`.

## Why This Bug Was Not Caught Earlier

- **Upstream pytorch/pytorch** (`main` and `release/2.12`): `test_intra_node_comm_all_reduce` has `@skipIfRocm` — test never runs on ROCm, bug is dormant.
- **ROCm/pytorch `release/2.12`**: `@skipIfRocm` was replaced with `@runOnRocmArch(MI300_ARCH)` to enable IntraNodeComm on MI300X, exposing this crash.
- Same bug exists on upstream `main` but no impact since test is skipped.

## Crash Stack (from logs)

```
#0  <unknown> + 0x38535e5 in libtorch_hip.so
#1  c10d::intra_node_comm::IntraNodeComm::rendezvous() + 0x18aa
#2  c10d::ProcessGroupNCCL::initIntraNodeComm() + 0x196
#3  c10d::ProcessGroupNCCL::allreduce() + 0x8a9
```

Both ranks crash at the exact same instruction within ~2 seconds of `init_process_group` completing. Hard SIGSEGV, not a hang.

## Test Plan

- [ ] Run `test_intra_node_comm_all_reduce_custom_group_name_True` on MI300X with `ENABLE_INTRA_NODE_COMM=1`
- [ ] Run `test_intra_node_comm_all_reduce_custom_group_name_False` on MI300X with `ENABLE_INTRA_NODE_COMM=1`
- [ ] Verify no regression in `distributed.test_c10d_nccl` suite

## References

- Jira: [ROCM-25272](https://amd-hub.atlassian.net/browse/ROCM-25272)
- Upstream issue (test disabled on ROCm since Dec 2023): [pytorch/pytorch#115859](https://github.com/pytorch/pytorch/issues/115859)
- groupName fix (already on release/2.12): [pytorch/pytorch#180809](https://github.com/pytorch/pytorch/pull/180809)
- Test parametrization (already on release/2.12): [pytorch/pytorch#181331](https://github.com/pytorch/pytorch/pull/181331)

[ROCM-25272]: https://amd-hub.atlassian.net/browse/ROCM-25272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ