### PR TITLE
[release/2.10] bump torchvision commit to skip gaussian blur tests on gfx90a

### DIFF
--- a/related_commits
+++ b/related_commits
@@ -1,7 +1,7 @@
 ubuntu|pytorch|apex|release/1.10.0|751f5dd5ae26adedfd8bd0f39c3aa46a8fdcb4d8|https://github.com/ROCm/apex
 centos|pytorch|apex|release/1.10.0|751f5dd5ae26adedfd8bd0f39c3aa46a8fdcb4d8|https://github.com/ROCm/apex
-ubuntu|pytorch|torchvision|release/0.25|82df5f599578b383987510836bb05ea97dcc9669|https://github.com/pytorch/vision
-centos|pytorch|torchvision|release/0.25|82df5f599578b383987510836bb05ea97dcc9669|https://github.com/pytorch/vision
+ubuntu|pytorch|torchvision|release/0.25|8967bfbe3affba47ad52016f631b4309bc23ac0c|https://github.com/ROCm/vision
+centos|pytorch|torchvision|release/0.25|8967bfbe3affba47ad52016f631b4309bc23ac0c|https://github.com/ROCm/vision
 ubuntu|pytorch|torchdata|release/0.11|377e64c1be69a9be6649d14c9e3664070323e464|https://github.com/pytorch/data
 centos|pytorch|torchdata|release/0.11|377e64c1be69a9be6649d14c9e3664070323e464|https://github.com/pytorch/data
 ubuntu|pytorch|torchaudio|release/2.10|5047768f2447d963dffc250b64a5d6c01afc84fa|https://github.com/pytorch/audio


### PR DESCRIPTION
Bump torchvision commit in relatest_commits to https://github.com/ROCm/vision/commit/8967bfbe3affba47ad52016f631b4309bc23ac0c 
Two torchvision gaussian blur tests are skipped on gfx90a (ROCM-19786)