### PR TITLE
[release/2.11] Fix flaky reentrant backward test by passing explicit grad for non-scalar output

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -12234,7 +12234,7 @@ class TestAutogradDeviceType(TestCase):
             @staticmethod
             def backward(ctx, grad):
                 # Reentrant backward in child will take much longer.
-                reentrant_root.backward()
+                reentrant_root.backward(grad)
                 return grad
 
         # Parent gpu graph.


### PR DESCRIPTION
Upstream PR: https://github.com/pytorch/pytorch/pull/179704, cherry pick to fix flaky UT `test_autograd.py::TestAutogradDeviceTypeCUDA::test_reentrant_parent_error_on_cpu_cuda`

Cherry-picked to release/2.12 branch via https://github.com/ROCm/pytorch/pull/3279

Cherry-picked to release/2.10 branch via https://github.com/ROCm/pytorch/pull/3280