### PR TITLE
[release/2.10] Fix test_opaque_obj leaking opaque type registration across tests

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -48,6 +48,7 @@ from torch._higher_order_ops.hints_wrap import hints_wrapper
 from torch._higher_order_ops.scan import scan
 from torch._higher_order_ops.while_loop import while_loop
 from torch._inductor.compile_fx import split_const_gm
+from torch._library.opaque_object import _OPAQUE_TYPES_BY_NAME
 from torch._subclasses import FakeTensorMode
 from torch.export import default_decompositions, Dim, export, unflatten
 from torch.export._trace import (
@@ -13392,6 +13393,12 @@ graph():
                 return x + f.int_1 + f.int_2
 
         torch._library.opaque_object.register_opaque_type(MyInput, typ="value")
+        self.addCleanup(
+            lambda name=torch._library.opaque_object.get_opaque_type_name(MyInput): (
+                torch._C._unregister_opaque_type(name),
+                _OPAQUE_TYPES_BY_NAME.pop(name, None),
+            )
+        )
         ep = export(Foo(), (torch.randn(2, 2), MyInput(4, 4)), strict=False)
 
         inp = torch.ones(2, 2)


### PR DESCRIPTION
Opaque types live in a global registry for the whole process. The registered name is the class's fully qualified name: `name = f"{cls.__module__}.{cls.__qualname__}"`

`test_opaque_obj` defines a nested `MyInput`, so every invocation registers the same name as `test_export.TestExport.test_opaque_obj.<locals>.MyInput`.

Test generators reuse that body under different method names. The second run fails with: `Type '...MyInput' is already registered as an opaque type`

Unregister the opaque type using `self.addCleanup` lambda so each test run cleans up the registries before the next variant runs. Cleanup restores _OPAQUE_TYPES_BY_NAME, not _OPAQUE_TYPES same as test_opaque_obj_v2

Fixed tests:
- export/test_export_training_ir_to_run_decomp.py::TrainingIRToRunDecompExportNonStrictTestExport::test_opaque_obj_training_ir_to_decomp_nonstrict
- export/test_retraceability.py::RetraceExportNonStrictTestExport::test_opaque_obj_retraceability_nonstrict

Fixes https://github.com/pytorch/pytorch/issues/170302 
Fixes https://github.com/pytorch/pytorch/issues/170449 
Pull Request resolved: https://github.com/pytorch/pytorch/pull/186005 Approved by: https://github.com/jeffdaily

(cherry picked from commit d96583df9faa8cb2e0aa285a2479ab76547dc030)