### PR TITLE
[release/2.11][ROCm] Remove test_upsamplingNearest2d_launch_rocm test as ROCm reduces max grid size

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -32,7 +32,7 @@ from torch.nn import Buffer, Parameter
 from torch.nn.parallel._functions import Broadcast
 from torch.testing._internal.common_dtype import integral_types, get_all_math_dtypes, floating_types
 from torch.testing._internal.common_utils import dtype_name, freeze_rng_state, run_tests, TestCase, \
-    skipIfNoLapack, skipIfRocm, MI300_ARCH, skipIfRocmArch, \
+    skipIfNoLapack, skipIfRocmVersionLessThan, MI300_ARCH, skipIfRocmArch, \
     TEST_NUMPY, TEST_SCIPY, TEST_WITH_CROSSREF, TEST_WITH_ROCM, \
     download_file, get_function_arglist, load_tests, skipIfMPS, \
     IS_PPC, \
@@ -11647,19 +11647,11 @@ class TestNNDeviceType(NNTestCase):
         self.assertEqual(out_ref, out)
 
     @unittest.expectedFailure
-    @skipIfRocm
+    @skipIfRocmVersionLessThan((7, 14))
     @onlyCUDA
     def test_upsamplingNearest2d_launch_fail(self, device):
         m = nn.Upsample(scale_factor=2)
         # launch grid_y == 2**16 (larger than maximum y-dimension limit 65535)
-        inp = torch.rand(1, 1, 2**15, 2**8, device=device)
-        out = m(inp)
-
-    @onlyCUDA
-    @skipCUDAIfNotRocm
-    def test_upsamplingNearest2d_launch_rocm(self, device):
-        # test_upsamplingNearest2d_launch_fail should run OK on ROCm
-        m = nn.Upsample(scale_factor=2)
         inp = torch.rand(1, 1, 2**15, 2**8, device=device)
         out = m(inp)
 


### PR DESCRIPTION
Cherry picking upstream PR https://github.com/pytorch/pytorch/pull/186257

Cherry-picked to release/2.12 branch via https://github.com/ROCm/pytorch/pull/3285

Cherry-picked to release/2.10 branch via https://github.com/ROCm/pytorch/pull/3286

Cherry-picked to release/2.9 branch via https://github.com/ROCm/pytorch/pull/3288