### PR TITLE
[release/2.10] Import skipIfRocm in test_nn.py

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -32,7 +32,7 @@ from torch.nn import Buffer, Parameter
 from torch.nn.parallel._functions import Broadcast
 from torch.testing._internal.common_dtype import integral_types, get_all_math_dtypes, floating_types
 from torch.testing._internal.common_utils import dtype_name, freeze_rng_state, run_tests, TestCase, \
-    skipIfNoLapack, skipIfRocmVersionLessThan, MI300_ARCH, skipIfRocmArch, \
+    skipIfNoLapack, skipIfRocm, skipIfRocmVersionLessThan, MI300_ARCH, skipIfRocmArch, \
     TEST_NUMPY, TEST_SCIPY, TEST_WITH_CROSSREF, TEST_WITH_ROCM, \
     download_file, get_function_arglist, load_tests, skipIfMPS, \
     IS_PPC, \


### PR DESCRIPTION
In a previous automated cherry pick (https://github.com/ROCm/pytorch/pull/3286), `skipIfRocm` import is changed to `skipIfRocmVersionLessThan`, which is okay on some release branches but some other still use that decorator.