### PR TITLE
[release/2.11] Guard NCCL one-sided API behind device support

### DIFF
--- a/torch/csrc/distributed/c10d/symm_mem/nccl_dev_cap.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/nccl_dev_cap.hpp
@@ -16,7 +16,9 @@
 #endif
 #endif
 
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 29, 0)
+#if defined(NCCL_HAS_SYMMEM_DEVICE_SUPPORT) && \
+    NCCL_VERSION_CODE >= NCCL_VERSION(2, 29, 0)
 #define NCCL_HAS_ONE_SIDED_API
 #endif
+
 #endif // USE_NCCL


### PR DESCRIPTION
## Summary

Guard `NCCL_HAS_ONE_SIDED_API` behind `NCCL_HAS_SYMMEM_DEVICE_SUPPORT`.

ROCm builds do not enable NCCL symmetric-memory device support because `nccl_device.h` is excluded under `USE_ROCM`. Without this guard, release branches can compile one-sided signal paths that reference device-support-only code such as `NCCLDevCommManager`.

This mirrors the intent of the related device-support guard from https://github.com/pytorch/pytorch/pull/186794, but applies it to the one-sided API macro as well.

## Testing

- Verified the build passes on the `release/2.11` ROCm branch with `NCCL_HAS_ONE_SIDED_API` guarded.