### PR TITLE
[ROCm] Allow external CUDA events on ROCm 7.0+

### DIFF
--- a/c10/cuda/CUDAEvent.h
+++ b/c10/cuda/CUDAEvent.h
@@ -141,9 +141,9 @@ struct CUDAEvent {
         ".");
     CUDAGuard guard(device_index_);
 
-#ifndef USE_ROCM
+#if !defined(USE_ROCM) || ROCM_VERSION >= 70000
     // it is an error to use cudaEventRecordExternal when not doing stream
-    // capture
+    // capture (same applies to hipEventRecordExternal on ROCm 7.0+)
     unsigned int flags = (c10::cuda::currentStreamCaptureStatusMayInitCtx() !=
                               c10::cuda::CaptureStatus::None &&
                           external_)
@@ -168,9 +168,9 @@ struct CUDAEvent {
   void block(const CUDAStream& stream) {
     if (is_created_) {
       CUDAGuard guard(stream.device_index());
-#ifndef USE_ROCM
+#if !defined(USE_ROCM) || ROCM_VERSION >= 70000
       // it is an error to use cudaEventWaitExternal when not doing stream
-      // capture
+      // capture (same applies to hipEventWaitExternal on ROCm 7.0+)
       unsigned int flags = (c10::cuda::currentStreamCaptureStatusMayInitCtx() !=
                                 c10::cuda::CaptureStatus::None &&
                             external_)
@@ -252,8 +252,9 @@ struct CUDAEvent {
 
   void createEvent(DeviceIndex device_index) {
     external_ = (flags_ & cudaEventExternal) != 0;
-#ifdef USE_ROCM
-    TORCH_CHECK(!external_, "External events are disallowed in rocm");
+#if defined(USE_ROCM) && ROCM_VERSION < 70000
+    TORCH_CHECK(
+        !external_, "External CUDA-graph events on ROCm require ROCm 7.0+");
 #endif
     flags_ &= ~cudaEventExternal;
     device_index_ = device_index;

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -85,6 +85,7 @@ from torch.testing._internal.common_utils import (
     skipCUDANonDefaultStreamIf,
     skipIfRocm,
     skipIfRocmArch,
+    skipIfRocmVersionLessThan,
     slowTest,
     subtest,
     TemporaryFileName,
@@ -148,8 +149,10 @@ def skip_background_threads_on_windows(f):
 
 
 def get_wait_for_cpu_kernel():
-    """Returns a compiled CUDA spin-wait kernel that blocks the GPU stream until
-    the host sets a pinned int32 flag to non-zero. Requires SM70+.
+    """Returns a compiled CUDA/HIP spin-wait kernel that blocks the GPU stream
+    until the host sets a pinned int32 flag to non-zero. On NVIDIA, requires
+    SM70+ for the relaxed-system-scope PTX load. On AMD, uses
+    __hip_atomic_load with __HIP_MEMORY_SCOPE_SYSTEM (the AMDGCN equivalent).
 
     Usage::
 
@@ -169,7 +172,11 @@ def get_wait_for_cpu_kernel():
             __global__ void wait_for_cpu(int *pinned_cpu_flag) {
                 int flag = 0;
                 do {
+            #ifdef __HIP_PLATFORM_AMD__
+                    flag = __hip_atomic_load(pinned_cpu_flag, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
+            #else
                     asm volatile("ld.relaxed.sys.global.s32 %0, [%1];" : "=r"(flag) : "l"(pinned_cpu_flag) : "memory");
+            #endif
                 } while (flag == 0);
             }
             """,
@@ -2550,9 +2557,10 @@ torch.cuda.synchronize()
             g.debug_dump(os.path.join(tempdir, "out_multi_stream.dot"))
 
     @unittest.skipIf(
-        not TEST_CUDA_GRAPH or TEST_WITH_ROCM,
-        "CUDA >= 11.0 required for external events in cuda graphs. rocm does not support external events",
+        not TEST_CUDA_GRAPH,
+        "CUDA >= 11.0 / ROCm >= 7.0 required for external events in cuda graphs",
     )
+    @skipIfRocmVersionLessThan((7, 0))
     def test_graph_timing(self):
         torch.cuda.empty_cache()
         x = torch.randn(10240000, device="cuda")
@@ -8786,9 +8794,7 @@ class TestCompileKernel(TestCase):
 
 @unittest.skipIf(not TEST_CUDA, "CUDA not available, skipping tests")
 class TestCudaDeviceParametrized(TestCase):
-    @unittest.skipIf(
-        TEST_WITH_ROCM, "ROCM does not support nvrtc or external cuda graph events"
-    )
+    @skipIfRocmVersionLessThan((7, 0))
     @skipCUDAIf(
         not SM70OrLater, "Compute capability >= SM70 required for relaxed ptx flag"
     )
@@ -8868,6 +8874,13 @@ class TestCudaDeviceParametrized(TestCase):
             torch.all(x_cpu == 1.0),
             "Copy should be done once end_event is synchronized",
         )
+        # On HIP graphs, the event-record node can become visible to
+        # event.synchronize() a few microseconds before the host-side
+        # stream state is updated; poll briefly so we exercise the
+        # invariant ("after sync the stream is drained") without flaking.
+        deadline = time.monotonic() + 0.1
+        while not work_stream.query() and time.monotonic() < deadline:
+            pass
         self.assertTrue(
             work_stream.query(),
             "end_event.synchronize() completing should imply that work_stream is done",

--- a/torch/utils/hipify/cuda_to_hip_mappings.py
+++ b/torch/utils/hipify/cuda_to_hip_mappings.py
@@ -1354,6 +1354,7 @@ CUDA_IDENTIFIER_MAP = collections.OrderedDict([
     ("cudaEventCreateWithFlags", "hipEventCreateWithFlags"),
     ("cudaEventDestroy", "hipEventDestroy"),
     ("cudaEventRecord", "hipEventRecord"),
+    ("cudaEventRecordWithFlags", "hipEventRecordWithFlags"),
     ("cudaEventElapsedTime", "hipEventElapsedTime"),
     ("cudaEventSynchronize", "hipEventSynchronize"),
     ("cudaEventQuery", "hipEventQuery"),


### PR DESCRIPTION
Backport upstream PR #178264 to branch [ROCm:release/2.12](https://github.com/ROCm/pytorch/tree/release/2.12) so torch.cuda.Event(external=True) works inside HIP graphs.

cc: @mgehre-amd 