### PR TITLE
[release/2.11] Guard ncclGetLsaMultimemDevicePointer behind device support

### DIFF
--- a/torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.cu
@@ -141,7 +141,8 @@ class NCCLPeerAllocInfo : public c10::intrusive_ptr_target {
       cudaMemcpyDeviceToHost));
 #endif
 
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 29, 0)
+#if defined(NCCL_HAS_SYMMEM_DEVICE_SUPPORT) && \
+    NCCL_VERSION_CODE >= NCCL_VERSION(2, 29, 0)
   // Starting from NCCL 2.29, we can use `ncclGetLsaMultimemDevicePointer`
   void* mc_addr = nullptr;
   if (ncclGetLsaMultimemDevicePointer(buffer_win_, 0, &mc_addr) == ncclSuccess) {


### PR DESCRIPTION
## Summary

Guard the `ncclGetLsaMultimemDevicePointer` path in `NCCLSymmetricMemory.cu` behind `NCCL_HAS_SYMMEM_DEVICE_SUPPORT`.

This is a follow-up to https://github.com/ROCm/pytorch/pull/3293, which guarded `NCCL_HAS_ONE_SIDED_API` in `nccl_dev_cap.hpp`. That fixed one ROCm build failure, but TheRock `release/2.11` wheel builds were still failing with:

```text
NCCLSymmetricMemory.cu:148:7: error: use of undeclared identifier 'ncclGetLsaMultimemDevicePointer'