### PR TITLE
parity: tidy comments and config docs

### DIFF
--- a/.automation_scripts/pytorch-unit-test-scripts/parity_job_config.json
+++ b/.automation_scripts/pytorch-unit-test-scripts/parity_job_config.json
@@ -1,5 +1,15 @@
 {
-  "_comment": "Single source of truth for pytorch/pytorch job-name matching used by the parity tooling. Consumed by parity-auto.yml (bash/jq, upstream check-run gating) and, as of #3278, by download_testlogs (Python, S3 artifact + log matching). Per ROCm arch: 'workflows' (upstream workflow file each test type lives in), 'job_prefixes' (check-run/job name prefix per test type), 'shard_counts' (per test type), 'artifact_substrings' (filter passed to the artifact downloader, null = no filter), 'fallbacks' (per test type: workflow + job_prefix to try when the primary workflow run is missing), 'checkrun_regex' (PCRE matching this arch's ROCm test check-run names for parity-auto gating), 'workflow_regex' (PCRE matching upstream workflow file paths that mean this arch ran). CUDA mirrors the same idea for the trunk CUDA test jobs.",
+  "_comment": "Job-name matching for the parity tooling, consumed by parity-auto.yml (bash/jq) to gate on upstream check-runs before dispatching parity.yml. See _fields for the per-arch schema.",
+  "_fields": {
+    "workflows": "Upstream workflow file each test type lives in.",
+    "job_prefixes": "Check-run/job name prefix per test type.",
+    "shard_counts": "Number of shards per test type.",
+    "artifact_substrings": "Filter for the artifact downloader (null = no filter).",
+    "fallbacks": "Per test type: workflow + job_prefix to try when the primary workflow run is missing.",
+    "checkrun_regex": "PCRE matching this arch's ROCm test check-run names (parity-auto gating).",
+    "workflow_regex": "PCRE matching upstream workflow file paths that mean this arch ran.",
+    "cuda": "Same idea as a ROCm arch, for the trunk CUDA test jobs."
+  },
   "cuda": {
     "workflows": { "default": "trunk", "inductor": "inductor" },
     "job_prefix": "linux-jammy-cuda13.0-py3.10-gcc11",

--- a/.github/workflows/parity-auto.yml
+++ b/.github/workflows/parity-auto.yml
@@ -89,20 +89,20 @@ jobs:
           TARGET_REF_IN: ${{ inputs.target_ref || '' }}
           DRY_RUN: ${{ github.event_name == 'pull_request' && 'true' || inputs.dry_run || 'false' }}
         run: |
-          # Actions runs this as `bash -e {0}`, but -e is too aggressive for the
-          # grep -q / date / paginated-API pipelines here (it silently aborted
-          # the scan loop). Turn -e off; keep -u + pipefail to still catch bugs.
+          # GitHub runs this step as `bash -e`, which exits on the first non-zero
+          # status. Our grep -q / date / paginated-API calls return non-zero in
+          # normal cases and were silently killing the scan loop, so disable -e.
+          # Keep -u (catch unset vars) and pipefail (catch errors mid-pipe).
           set +e
           set -uo pipefail
 
           # Check-runs from rerun/flaky tooling are not parity test shards.
           NON_TEST_CHECKRUNS='mem_leak_check|rerun_disabled_tests'
 
-          # Read parity_job_config.json over the API at GITHUB_SHA (this job
-          # never checks out the fork; download_testlogs consumes the same file
-          # as of #3278) and populate the regex maps used for matching. Override
-          # inputs win when set. Sets ARCH_JOBNAME_REGEX_MAP / ARCH_WORKFLOW_REGEX_MAP
-          # / CUDA_JOBNAME_REGEX.
+          # Read parity_job_config.json over the API at GITHUB_SHA (this job never
+          # checks out the fork) and build the regex maps used for matching.
+          # Manual override inputs win when set. Sets ARCH_JOBNAME_REGEX_MAP,
+          # ARCH_WORKFLOW_REGEX_MAP, and CUDA_JOBNAME_REGEX.
           load_matching_config() {
             local config_json
             config_json=$(gh api "repos/$GITHUB_REPOSITORY/contents/$CONFIG_PATH?ref=$GITHUB_SHA" --jq '.content' | base64 -d)

--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -158,14 +158,11 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
-          # Translate the workflow inputs into download_testlogs CLI flags. Job
-          # names, shard counts and workflow matching live in
-          # parity_job_config.json (download_testlogs consumes it as of #3278);
-          # this step only forwards the per-run options.
+          # Forward run options to download_testlogs; job/shard/workflow matching
+          # lives in parity_job_config.json (used by parity-auto.yml gating).
           #
-          # pipefail so a download_testlogs failure fails this step instead of
-          # being hidden by tee's 0 exit code (which would publish a partial,
-          # half-empty report as a green run).
+          # pipefail: without it, tee's 0 exit code hides a download_testlogs
+          # failure and we'd publish a partial report as a green run.
           set -o pipefail
           ARGS="--arch ${{ matrix.arch }}"
 


### PR DESCRIPTION
## Summary
- Trim verbose/narrating comments in parity.yml and parity-auto.yml, keeping only the non-obvious `why` (pipefail/tee gotcha, `set +e` rationale, check-run gating).
- Drop the misleading cross-PR `#3278` references: in this branch `download_testlogs` does not consume `parity_job_config.json`, so the `as of #3278` notes described a future/parallel state.
- Replace the single-line `_comment` blob in `parity_job_config.json` with a scannable `_fields` map (one short line per field).

## Notes
- No behavior change. Consumers (`parity-auto.yml` jq) only read `.rocm`/`.cuda`; the new `_fields` key is ignored.
- Targets `ethanwee/parity-auto-every-commit` so the cleanups fold into #3231.