### PR TITLE
[release/2.11] Skip test_reentrant_parent_error_on_cpu_cuda on ROCm

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -76,6 +76,7 @@ from torch.testing._internal.common_utils import (
     skipCUDANonDefaultStreamIf,
     skipIfMPS,
     skipIfNoLapack,
+    skipIfRocm,
     skipIfSlowGradcheckEnv,
     skipIfTorchDynamo,
     skipIfWindows,
@@ -12252,6 +12253,7 @@ class TestAutogradDeviceType(TestCase):
         self.assertIsNone(t3.grad)
 
     @onlyCUDA
+    @skipIfRocm
     def test_reentrant_parent_error_on_cpu(self, device):
         def _get_cuda_memory_usage():
             # we don't need CUDA synchronize because the statistics are not tracked at


### PR DESCRIPTION
The test is flaky by nature and the rock CI doesn't rerun tests makes this even worse. Per discussion, we are skipping it here.