### PR TITLE
[release/2.12] Fix `test_throw_on_cudamalloc_oom` alllocation size

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -5045,12 +5045,16 @@ class TestCudaAllocator(TestCase):
             # preemptively rejected with OutOfMemoryError.
             # Both settings must go through _accelerator_setAllocatorSettings so
             # they are read from CUDAAllocatorConfig.
+            fraction = 0.005
             torch._C._accelerator_setAllocatorSettings(
-                "throw_on_cudamalloc_oom:True,per_process_memory_fraction:0.01"
+                f"throw_on_cudamalloc_oom:True,per_process_memory_fraction:{fraction}"
             )
 
+            total_mem = torch.cuda.get_device_properties(0).total_memory
+            # Allocate the allowed threshold + 1 MiB to guarantee rejection
+            alloc_bytes = int(total_mem * fraction) + 1024 * 1024
             with self.assertRaises(torch.cuda.OutOfMemoryError):
-                torch.empty(1024 * 1024 * 1024, dtype=torch.int8, device="cuda")
+                torch.empty(alloc_bytes, dtype=torch.int8, device="cuda")
 
             # Check that rejection counter was incremented
             stats = torch.cuda.memory_stats()


### PR DESCRIPTION
GPUs with more than 100 GiB of global memory exist
Fixed test:
- test_cuda.py::TestCudaAllocator::test_throw_on_cudamalloc_oom

Pull Request resolved: https://github.com/pytorch/pytorch/pull/180699
Approved by: https://github.com/nWEIdia, https://github.com/Skylion007, https://github.com/mlazos

(cherry picked from commit 81d5c3f0bf1102382db45d53a4f9784c9b7fd2aa)

