### PR TITLE
[release/2.12] fix test_memory tests by extra gc.collect()

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -4662,6 +4662,9 @@ class TestCudaAllocator(TestCase):
             pass
         finally:
             torch.cuda.memory._record_memory_history(None)
+            # This test requires to run gc.collec() to fix other memory tests
+            torch.cuda.synchronize()
+            gc.collect()
 
     @unittest.skipIf(
         TEST_CUDAMALLOCASYNC, "setContextRecorder not supported by CUDAMallocAsync"


### PR DESCRIPTION
This PR fixes the tests, but not the root cause of the issue.
It seems like we're left with garbage in memory after the `test_cuda.py::TestCudaAllocator::test_memory_compile_regions`. The test uses a compiled model with _record_memory_history.
gc.collect() at the end of the test fixes several memory tests.

Modified test:
- test_cuda.py::TestCudaAllocator::test_memory_compile_regions

Fixed tests:
- test_cuda.py::TestCudaAllocator::test_memory_plots
- test_cuda.py::TestCudaAllocator::test_memory_plots_free_segment_stack
- test_cuda.py::TestCudaAllocator::test_memory_snapshot

Fixes https://github.com/pytorch/pytorch/issues/163202
Fixes https://github.com/pytorch/pytorch/issues/179744
Fixes https://github.com/pytorch/pytorch/issues/179798
Fixes https://github.com/pytorch/pytorch/issues/179745

Pull Request resolved: https://github.com/pytorch/pytorch/pull/186996
Approved by: https://github.com/jeffdaily

(cherry picked from commit 803e4aa41c053a30bc1236b2a859ec4ad7efe635)

Cherry-picked to release/2.11 branch via https://github.com/ROCm/pytorch/pull/3366