### PR TITLE
[release/2.12] skip test_graph_make_graphed_callables_same_pool on rocm

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -3638,6 +3638,7 @@ exit(2)
             model_graphed({"x": real_inputs[0]}), model_control({"x": real_inputs[0]})
         )
 
+    @skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/179961")
     @unittest.skipIf(
         not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
     )


### PR DESCRIPTION
The test is hanging
- test_cuda.py::TestCuda::test_graph_make_graphed_callables_same_pool

Skip it for ROCm like on the upstream https://github.com/pytorch/pytorch/blob/aba031700129c79591605a81ae79f74ed358aa16/test/test_cuda.py#L4084

