### PR TITLE
parity tooling: add shared parity_job_config.json (single source of truth)

### DIFF
--- a/.automation_scripts/pytorch-unit-test-scripts/parity_job_config.json
+++ b/.automation_scripts/pytorch-unit-test-scripts/parity_job_config.json
@@ -1,0 +1,75 @@
+{
+  "_comment": "Single source of truth for pytorch/pytorch job-name matching used by the parity tooling. Consumed by download_testlogs (Python, S3 artifact + log matching) and parity-auto.yml (bash/jq, upstream check-run gating before dispatching parity.yml). See _fields for the per-arch schema.",
+  "_fields": {
+    "workflows": "Upstream workflow file each test type lives in.",
+    "job_prefixes": "Check-run/job name prefix per test type.",
+    "shard_counts": "Number of shards per test type.",
+    "artifact_substrings": "Filter for the artifact downloader (null = no filter).",
+    "fallbacks": "Per test type: workflow + job_prefix to try when the primary workflow run is missing.",
+    "checkrun_regex": "PCRE matching this arch's ROCm test check-run names (parity-auto gating).",
+    "workflow_regex": "PCRE matching upstream workflow file paths that mean this arch ran.",
+    "cuda": "Same idea as a ROCm arch, for the trunk CUDA test jobs."
+  },
+  "cuda": {
+    "workflows": { "default": "trunk", "inductor": "inductor" },
+    "job_prefix": "linux-jammy-cuda13.0-py3.10-gcc11",
+    "inductor_job_prefix": "unit-test / inductor-test",
+    "test_kinds": ["test-osdc", "test"],
+    "shard_counts": { "default": 5, "distributed": 3, "inductor": 2 },
+    "checkrun_regex": "(linux-jammy-cuda13[.]0-py3[.]10-gcc11 / (test-osdc|test) [(](default|distributed),|unit-test / inductor-test / (test-osdc|test) [(]inductor,)"
+  },
+  "rocm": {
+    "mi350": {
+      "workflows": { "default": "trunk", "distributed": "periodic-rocm-mi350", "inductor": "trunk" },
+      "job_prefixes": { "default": "linux-jammy-rocm-py3.10-mi350", "distributed": "linux-noble-rocm-py3.12-mi350", "inductor": "linux-jammy-rocm-py3.10-mi350" },
+      "shard_counts": { "default": 8, "distributed": 3, "inductor": 2 },
+      "artifact_substrings": ["rocm.gpu"],
+      "fallbacks": {
+        "default": { "workflow": "rocm-mi350", "job_prefix": "linux-noble-rocm-py3.12-mi350" },
+        "distributed": { "workflow": "trunk", "job_prefix": "linux-jammy-rocm-py3.10-mi350" }
+      },
+      "checkrun_regex": "rocm.*mi350.*/ test [(](default|distributed|inductor),",
+      "workflow_regex": "(^|/)(trunk|rocm-mi350|periodic-rocm-mi350|inductor-rocm-mi350)[.]yml$"
+    },
+    "mi300": {
+      "workflows": { "default": "rocm-mi300", "distributed": "periodic-rocm-mi300", "inductor": "inductor-rocm-mi300" },
+      "job_prefixes": { "default": "linux-noble-rocm-py3.12-mi300", "distributed": "linux-noble-rocm-py3.12-mi300", "inductor": "linux-noble-rocm-py3.12-mi300" },
+      "shard_counts": { "default": 6, "distributed": 3, "inductor": 2 },
+      "artifact_substrings": null,
+      "fallbacks": {},
+      "checkrun_regex": "rocm.*mi300.*/ test [(](default|distributed|inductor),",
+      "workflow_regex": "(^|/)(rocm-mi300|periodic-rocm-mi300|inductor-rocm-mi300)[.]yml$"
+    },
+    "mi200": {
+      "workflows": { "default": "rocm-mi200", "distributed": "periodic-rocm-mi200", "inductor": "inductor-rocm-mi200" },
+      "job_prefixes": { "default": "linux-jammy-rocm-py3.10-mi200", "distributed": "linux-jammy-rocm-py3.10-mi200", "inductor": "linux-jammy-rocm-py3.10-mi200" },
+      "shard_counts": { "default": 6, "distributed": 3, "inductor": 2 },
+      "artifact_substrings": null,
+      "fallbacks": {
+        "default": { "workflow": "trunk-rocm-sandbox", "job_prefix": "linux-jammy-rocm-py3.10" },
+        "distributed": { "workflow": "trunk-rocm-sandbox", "job_prefix": "linux-jammy-rocm-py3.10" },
+        "inductor": { "workflow": "trunk-rocm-sandbox", "job_prefix": "linux-jammy-rocm-py3.10" }
+      },
+      "checkrun_regex": "(rocm.*(mi200|mi210).*/ test [(](default|distributed|inductor),|linux-jammy-rocm-py3[.]10 / test [(](default|distributed|inductor),)",
+      "workflow_regex": "(^|/)(trunk-rocm-sandbox|rocm-mi200|periodic-rocm-mi200|inductor-rocm-mi200)[.]yml$"
+    },
+    "navi31": {
+      "workflows": { "default": "rocm-navi31", "distributed": "periodic-rocm-navi31", "inductor": "inductor-rocm-navi31" },
+      "job_prefixes": { "default": "linux-jammy-rocm-py3.10-navi31", "distributed": "linux-jammy-rocm-py3.10-navi31", "inductor": "linux-jammy-rocm-py3.10-navi31" },
+      "shard_counts": { "default": 2, "distributed": 3, "inductor": 2 },
+      "artifact_substrings": null,
+      "fallbacks": {},
+      "checkrun_regex": "rocm.*navi31.*/ test [(]default,",
+      "workflow_regex": "(^|/)(rocm-navi31|periodic-rocm-navi31|inductor-rocm-navi31)[.]yml$"
+    },
+    "nightly": {
+      "workflows": { "default": "rocm-nightly", "distributed": "rocm-nightly", "inductor": "rocm-nightly" },
+      "job_prefixes": { "default": "linux-noble-rocm-nightly-py3.12-gfx942", "distributed": "linux-noble-rocm-nightly-py3.12-gfx942", "inductor": "linux-noble-rocm-nightly-py3.12-gfx942" },
+      "shard_counts": { "default": 6, "distributed": 3, "inductor": 2 },
+      "artifact_substrings": ["rocm.gpu"],
+      "fallbacks": {},
+      "checkrun_regex": "rocm-nightly.*/ test [(](default|distributed|inductor),",
+      "workflow_regex": "(^|/)rocm-nightly[.]yml$"
+    }
+  }
+}

--- a/.automation_scripts/pytorch-unit-test-scripts/parity_job_config.json
+++ b/.automation_scripts/pytorch-unit-test-scripts/parity_job_config.json
@@ -1,19 +1,17 @@
 {
-  "_comment": "Single source of truth for pytorch/pytorch job-name matching used by the parity tooling. Consumed by download_testlogs (Python, S3 artifact + log matching) and parity-auto.yml (bash/jq, upstream check-run gating before dispatching parity.yml). See _fields for the per-arch schema.",
-  "_fields": {
-    "workflows": "Upstream workflow file each test type lives in.",
-    "job_prefixes": "Check-run/job name prefix per test type.",
-    "shard_counts": "Number of shards per test type.",
-    "artifact_substrings": "Filter for the artifact downloader (null = no filter).",
-    "fallbacks": "Per test type: workflow + job_prefix to try when the primary workflow run is missing.",
+  "_comment": "Single source of truth for pytorch/pytorch job-name matching used by the parity tooling. Consumed by download_testlogs (Python, S3 artifact + log matching) and parity-auto.yml (bash/jq, upstream check-run gating before dispatching parity.yml). See _subfields for the per-arch schema.",
+  "_subfields": {
+    "workflows": "Upstream workflow file each test config lives in.",
+    "job_prefixes": "Check-run/job name prefix per test config.",
+    "shard_counts": "Number of shards per test config.",
+    "artifact_substrings": "S3 artifact-name substring filter (null = no filter). Set only when this arch's reports come from a workflow run that also carries other platforms' artifacts, so the downloader matches the ROCm-GPU runner tag (rocm.gpu) to avoid pulling foreign reports - e.g. mi350 (default/inductor ride in trunk.yml alongside CUDA) and nightly. mi300/mi200/navi31 read from their own dedicated rocm-* runs where every artifact already belongs to the arch, so no filter is needed.",
+    "fallbacks": "Per test config: workflow + job_prefix to try when the primary workflow run is missing.",
     "checkrun_regex": "PCRE matching this arch's ROCm test check-run names (parity-auto gating).",
-    "workflow_regex": "PCRE matching upstream workflow file paths that mean this arch ran.",
-    "cuda": "Same idea as a ROCm arch, for the trunk CUDA test jobs."
+    "workflow_regex": "PCRE matching upstream workflow file paths that mean this arch ran."
   },
   "cuda": {
-    "workflows": { "default": "trunk", "inductor": "inductor" },
-    "job_prefix": "linux-jammy-cuda13.0-py3.10-gcc11",
-    "inductor_job_prefix": "unit-test / inductor-test",
+    "workflows": { "default": "trunk", "distributed": "trunk", "inductor": "inductor" },
+    "job_prefixes": { "default": "linux-jammy-cuda13.0-py3.10-gcc11", "distributed": "linux-jammy-cuda13.0-py3.10-gcc11", "inductor": "unit-test / inductor-test" },
     "test_kinds": ["test-osdc", "test"],
     "shard_counts": { "default": 5, "distributed": 3, "inductor": 2 },
     "checkrun_regex": "(linux-jammy-cuda13[.]0-py3[.]10-gcc11 / (test-osdc|test) [(](default|distributed),|unit-test / inductor-test / (test-osdc|test) [(]inductor,)"


### PR DESCRIPTION
## What

Introduces `.automation_scripts/pytorch-unit-test-scripts/parity_job_config.json` — a single source of truth for `pytorch/pytorch` job-name matching used by the parity tooling.

Per-arch upstream workflow names, job-name prefixes, shard counts, artifact substrings, fallbacks (plus the CUDA equivalents and the check-run / workflow gating regexes) were previously duplicated:
- hardcoded as large dicts inside `download_testlogs`, and
- independently re-encoded as regexes inside `parity-auto.yml`.

This PR lands just the config file so the matching rules live in exactly one place.

## Why split this out

Per review feedback on #3278 (separate concerns, and this file also being introduced/changed in #3231), the shared config is pulled into its own foundational PR:

- **#3278** (download_testlogs re-run fixes) stacks on this and *consumes* the config for S3 artifact / log matching.
- **#3231** (parity auto-trigger) stacks on this and reads the check-run / workflow regexes for upstream gating.

Neither downstream PR carries its own copy of the file anymore — no more add/add duplication.

## Merge order

Land this first. #3278 and #3231 are rebased onto it and drop their copies of `parity_job_config.json`.

## Validation

This is a data-only file; it is exercised end-to-end by the downloader in #3278, which loads this exact config. A stacked #3278 parity run for `346976bc` (`mi350`) reads this file over the new path and produces a fully-populated report:

- https://github.com/ROCm/pytorch/actions/runs/27716114811 — passed

Made with [Cursor](https://cursor.com)

