### PR TITLE
[release/2.11] Turn off shape padding for opinfo tests (#178802)

### DIFF
--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -1176,6 +1176,7 @@ class TestInductorOpInfo(TestCase):
     )
     @torch._inductor.config.patch("test_configs.runtime_triton_dtype_assert", True)
     @torch._inductor.config.patch("test_configs.static_cpp_dtype_assert", True)
+    @torch._inductor.config.patch("shape_padding", False)
     @collection_decorator
     def test_comprehensive(self, device, dtype, op):
         device_type = torch.device(device).type


### PR DESCRIPTION
I have this pr https://github.com/pytorch/pytorch/pull/177546 that should fix this issue more generically. in the meantime, turn off shape padding because it was flakily causing stride issues.

Pull Request resolved: https://github.com/pytorch/pytorch/pull/178802
Approved by: https://github.com/karthickai

(cherry picked from commit 38a058ae6314250477ebd4d17ab96fa8c3e9e286)
