### PR TITLE
[release/2.11][ROCm] Bump conv3d test_grad tolerance for MIOpen Wrw atomic flake (#…

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -16221,6 +16221,18 @@ op_db: list[OpInfo] = [
                    toleranceOverride({torch.float32: tol(atol=5e-5, rtol=5e-6)}),
                    'TestCompositeCompliance', 'test_backward', device_type="cuda"
                ),
+               # Flake source: MIOpen ConvHipImplicitGemm3DGroupWrwXdlops accumulates
+               # dW via atomic_add across KBatch=128 split-K blocks (CK
+               # device_grouped_conv_bwd_weight_xdl_cshuffle.hpp:382). Atomic order is
+               # nondeterministic so two invocations disagree at fp32 round-off.
+               # Higham's bound on a random-order sum of 128 partial sums (sigma_op~5,
+               # K=1320) gives sigma_pair ~5e-5 between invocations; atol=2e-4 ~= 4
+               # sigma; rtol=2e-5 covers small-|dW|.
+               DecorateInfo(
+                   toleranceOverride({torch.float32: tol(atol=2e-4, rtol=2e-5)}),
+                   'TestOperators', 'test_grad', device_type="cuda",
+                   active_if=TEST_WITH_ROCM,
+               ),
                DecorateInfo(
                    toleranceOverride({torch.float16: tol(atol=5e-3, rtol=1e-3)}),
                    'TestInductorOpInfo', 'test_comprehensive',


### PR DESCRIPTION
…182908)

The MIOpen ConvHipImplicitGemm3DGroupWrwXdlops solver accumulates dW across KBatch=128 split-K blocks via atomic_add (CK device_grouped_conv_bwd_weight_xdl_cshuffle.hpp:382). The atomic-add ordering is hardware-nondeterministic, so two invocations of the same kernel disagree at fp32 round-off. functorch test_grad's `result = grad(...)` vs `expected = _autograd_grad(wrapped_fn(...))` triggers two such invocations and compares them, which trips the default fp32 tolerance (atol=1e-5, rtol=1.3e-6) intermittently on sample 12 (input (1,1,10,11,12), weight (1,1,4,4,4), padding='same', dilation=3 - GEMM K=1320).

Higham's probabilistic bound on a random-order sum of n=128 partial sums with sigma_op~5 gives pairwise stdev ~5e-5 between invocations, matching empirical p99 (200-run, 1000-pair sweep). atol=2e-4 = ~4*sigma_pair; rtol=2e-5 covers the regime where the failing-element |dW| is small.

Authored with assistance from Claude.

Pull Request resolved: https://github.com/pytorch/pytorch/pull/182908
Approved by: https://github.com/jeffdaily
