### PR TITLE
[release/2.11][inductor][BE] Fix test_triton_kernel_clone_wekdeps test pollution (#…

### DIFF
--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -330,6 +330,8 @@ def forward(self, x_1, output_1):
         from torch._higher_order_ops.triton_kernel_wrap import kernel_side_table
         from torch._inductor.choices import InductorChoices
         from torch._inductor.compile_fx import compile_fx_inner
+        from torch._inductor.virtualized import V
+        from torch.fx.experimental.proxy_tensor import make_fx
 
         TENSOR_SIZE = 30_000_000
         BLOCK_SIZE = 1024
@@ -392,7 +394,7 @@ def forward(self, x_1, output_1):
 
         gm = make_fx(f, tracing_mode="fake")(t)
 
-        with inductor_config.patch({"inductor_choices_class": NoFusionChoices}):
+        with V.set_choices_handler(NoFusionChoices()):
             log_stream, ctx = logs_to_string("torch._inductor.codecache", "output_code")
             with ctx():
                 compiled_gm = compile_fx_inner(gm, [t])


### PR DESCRIPTION
…175342)

Summary: The test failed when running test_triton_kernels.py as a whole, but succeeded when running individually.

The test used inductor_config.patch({"inductor_choices_class": NoFusionChoices}) to disable scheduler fusion, but V.choices is lazily initialized and cached on thread-local storage. When running all tests in test_triton_kernels.py, a prior test triggers torch.compile first, the default InductorChoices gets cached, and the config patch has no effect since _choices_default() is never called again.

Fixed by using V.set_choices_handler(NoFusionChoices()) instead.

Pull Request resolved: https://github.com/pytorch/pytorch/pull/175342
Approved by: https://github.com/mlazos
ghstack dependencies: #175341

(cherry picked from commit 60dc00dcd74dd7e22533b81eeb0e6382fbf9dea2)
