### PR TITLE
[release/2.11][OSDC][4/n] Update pull test cases to support OSDC k8s migration (#17…

### DIFF
--- a/test/test_torch_config_hash_determinism.py
+++ b/test/test_torch_config_hash_determinism.py
@@ -19,6 +19,10 @@ HOSTNAME = socket.gethostname()
 
 
 class TestConfigModule(TestCase):
+    # Config keys that legitimately contain absolute paths, for example,
+    # /opt/clang-15/bin/clang
+    KNOWN_PATH_CONFIGS = {"cpp.cxx"}
+
     def check_deterministic(self, key: str, value: object):
         if isinstance(value, (int, float, bool)) or value is None:
             return
@@ -79,6 +83,8 @@ class TestConfigModule(TestCase):
         torch_config = inductor_config.save_config_portable()
 
         for key, value in torch_config.items():
+            if key in self.KNOWN_PATH_CONFIGS:
+                continue
             self.check_deterministic(key, value)
 
     def test_inductor_config_hash_portable_without_ignore(self):
@@ -93,6 +99,8 @@ class TestConfigModule(TestCase):
                     f"Detected path in config value '.*', key='{cutlass_dir_key}'",
                 ):
                     for key, value in changed_torch_config.items():
+                        if key in self.KNOWN_PATH_CONFIGS:
+                            continue
                         self.check_deterministic(key, value)
             finally:
                 inductor_config._cache_config_ignore_prefix.insert(idx, cutlass_dir_key)


### PR DESCRIPTION
…8741)

Fix the check in test/test_torch_config_hash_determinism.py that looks into the full path of clang which is now under the custom path `/opt/clang-15/bin/clang`


Pull Request resolved: https://github.com/pytorch/pytorch/pull/178741 Approved by: https://github.com/zhxchen17, https://github.com/malfet ghstack dependencies: #178739, #178740
(cherry picked from commit f6e6d4d7364ba4bf28cf2d12445e659f0f99eb4f)
