### PR TITLE
[release/2.12] Fix graph capture error handling for ROCm 7.14+

### DIFF
--- a/aten/src/ATen/native/cuda/CUDAScalar.cu
+++ b/aten/src/ATen/native/cuda/CUDAScalar.cu
@@ -35,6 +35,7 @@ void _local_scalar_dense_cuda_impl(const Tensor& self, Scalar& r) {
       at::cuda::getCurrentDeviceProperties()->isLargeBar &&
       is_cuda_caching_allocator_tensor(self)) {
     cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+#if ROCM_VERSION < 71400
     hipStreamCaptureStatus captureStatus;
     C10_CUDA_CHECK(hipStreamGetCaptureInfo(stream, &captureStatus, nullptr));
     if (C10_LIKELY(captureStatus == hipStreamCaptureStatusNone)) {
@@ -43,6 +44,12 @@ void _local_scalar_dense_cuda_impl(const Tensor& self, Scalar& r) {
     } else {
       C10_CUDA_CHECK(hipErrorStreamCaptureUnsupported);
     }
+#else // ROCM_VERSION
+    // HIP reports the errors during graph capture in ROCm 7.14+
+    // no StreamCaptureStatus check required
+    at::cuda::stream_synchronize(stream);
+    r = Scalar(*self.template const_data_ptr<scalar_t>());
+#endif // ROCM_VERSION
     return;
   }
 #endif

--- a/c10/cuda/CUDAFunctions.h
+++ b/c10/cuda/CUDAFunctions.h
@@ -91,8 +91,9 @@ C10_CUDA_API void __inline__ memcpy_and_sync(
         c10::kCUDA, reinterpret_cast<uintptr_t>(stream));
   }
 #if defined(USE_ROCM) && USE_ROCM
-  // As of ROCm 6.4.1, HIP runtime does not raise an error during capture of
-  // hipMemcpyWithStream which is a synchronous call. Thus, we add a check
+#if ROCM_VERSION < 71400
+  // As of ROCm 6.4.1-7.13.x, HIP runtime does not raise an error during capture
+  // of hipMemcpyWithStream which is a synchronous call. Thus, we add a check
   // here explicitly.
   hipStreamCaptureStatus captureStatus;
   C10_CUDA_CHECK(hipStreamGetCaptureInfo(stream, &captureStatus, nullptr));
@@ -101,6 +102,11 @@ C10_CUDA_API void __inline__ memcpy_and_sync(
   } else {
     C10_CUDA_CHECK(hipErrorStreamCaptureUnsupported);
   }
+#else // ROCM_VERSION
+  // HIP reports the errors during graph capture in ROCm 7.14+
+  // no StreamCaptureStatus check required
+  C10_CUDA_CHECK(hipMemcpyWithStream(dst, src, nbytes, kind, stream));
+#endif // ROCM_VERSION
 #else
   C10_CUDA_CHECK(cudaMemcpyAsync(dst, src, nbytes, kind, stream));
   C10_CUDA_CHECK(cudaStreamSynchronize(stream));

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -85,6 +85,7 @@ from torch.testing._internal.common_utils import (
     skipCUDANonDefaultStreamIf,
     skipIfRocm,
     skipIfRocmArch,
+    skipIfRocmVersionLessThan,
     slowTest,
     subtest,
     TemporaryFileName,
@@ -2311,6 +2312,7 @@ torch.cuda.synchronize()
             # Compare the states generated outside and inside the graph
             self.assertEqual(random_values, graphed_random_values)
 
+    @skipIfRocmVersionLessThan((7, 14))
     @unittest.skipIf(
         not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
     )


### PR DESCRIPTION
Before ROCm 7.14, HIP does not report about errors during stream capture, need to use check hipStreamCaptureStatus to reject capture-unsafe work early.

From ROCm 7.14+, HIP reports capture error through, so that pre-check is unnecessary

Fixes https://github.com/pytorch/pytorch/issues/180232

Pull Request resolved: https://github.com/pytorch/pytorch/pull/187110
Approved by: https://github.com/jeffdaily, https://github.com/naromero77amd

(cherry picked from commit 1047ba51bc214fdbda297460ec835bad89f42a3c)
