### PR TITLE
[release/2.11] Fix graph capture error handling for ROCm 7.14+ (#187110)

### DIFF
--- a/c10/cuda/CUDAFunctions.h
+++ b/c10/cuda/CUDAFunctions.h
@@ -91,8 +91,9 @@ C10_CUDA_API void __inline__ memcpy_and_sync(
         c10::kCUDA, reinterpret_cast<uintptr_t>(stream));
   }
 #if defined(USE_ROCM) && USE_ROCM
-  // As of ROCm 6.4.1, HIP runtime does not raise an error during capture of
-  // hipMemcpyWithStream which is a synchronous call. Thus, we add a check
+#if ROCM_VERSION < 71400
+  // As of ROCm 6.4.1-7.13.x, HIP runtime does not raise an error during capture
+  // of hipMemcpyWithStream which is a synchronous call. Thus, we add a check
   // here explicitly.
   hipStreamCaptureStatus captureStatus;
   C10_CUDA_CHECK(hipStreamGetCaptureInfo(stream, &captureStatus, nullptr));
@@ -101,6 +102,11 @@ C10_CUDA_API void __inline__ memcpy_and_sync(
   } else {
     C10_CUDA_CHECK(hipErrorStreamCaptureUnsupported);
   }
+#else // ROCM_VERSION
+  // HIP reports the errors during graph capture in ROCm 7.14+
+  // no StreamCaptureStatus check required
+  C10_CUDA_CHECK(hipMemcpyWithStream(dst, src, nbytes, kind, stream));
+#endif // ROCM_VERSION
 #else
   C10_CUDA_CHECK(cudaMemcpyAsync(dst, src, nbytes, kind, stream));
   C10_CUDA_CHECK(cudaStreamSynchronize(stream));


### PR DESCRIPTION
This PR fixes only `c10/cuda/CUDAFunctions.h` file. Nothing to fix in release/2.11

Before ROCm 7.14, HIP does not report about errors during stream capture, need to use check hipStreamCaptureStatus to reject capture-unsafe work early.

From ROCm 7.14+, HIP reports capture error through, so that pre-check is unnecessary

Fixes https://github.com/pytorch/pytorch/issues/180232

Pull Request resolved: https://github.com/pytorch/pytorch/pull/187110
Approved by: https://github.com/jeffdaily, https://github.com/naromero77amd

(cherry picked from commit 1047ba51bc214fdbda297460ec835bad89f42a3c)