### PR TITLE
[release/2.10] [ROCm] Use rocm_sdk preloaded libraries for hiprtc and amdhip64

### DIFF
--- a/torch/cuda/_utils.py
+++ b/torch/cuda/_utils.py
@@ -9,10 +9,20 @@ from torch._utils import _get_device_index as _torch_get_device_index
 
 
 def _get_hip_runtime_library() -> ctypes.CDLL:
-    if sys.platform == "win32":
-        lib = ctypes.CDLL(f"amdhip64_{torch.version.hip[0]}.dll")
-    else:  # Unix-based systems
-        lib = ctypes.CDLL("libamdhip64.so")
+    # If ROCm python packages are available, query the OS-independent absolute
+    # path to the library provided by those packages, including any version suffix.
+    # See https://github.com/ROCm/TheRock/blob/main/docs/packaging/python_packaging.md#dynamic-library-resolution
+    try:
+        # pyrefly: ignore[import-error]
+        import rocm_sdk
+
+        lib = ctypes.CDLL(str(rocm_sdk.find_libraries("amdhip64")[0]))
+    except (ImportError, IndexError):
+        if sys.platform == "win32":
+            lib = ctypes.CDLL(f"amdhip64_{torch.version.hip[0]}.dll")
+        else:  # Unix-based systems
+            lib = ctypes.CDLL("libamdhip64.so")
+
     lib.cuGetErrorString = lib.hipGetErrorString  # type: ignore[attr-defined]
     lib.cuModuleLoadData = lib.hipModuleLoadData  # type: ignore[attr-defined]
     lib.cuModuleGetFunction = lib.hipModuleGetFunction  # type: ignore[attr-defined]
@@ -50,11 +60,19 @@ def _check_cuda(result: int) -> None:
 
 
 def _get_hiprtc_library() -> ctypes.CDLL:
-    if sys.platform == "win32":
-        version_str = "".join(["0", torch.version.hip[0], "0", torch.version.hip[2]])
-        lib = ctypes.CDLL(f"hiprtc{version_str}.dll")
-    else:
-        lib = ctypes.CDLL("libhiprtc.so")
+    try:
+        # pyrefly: ignore[import-error]
+        import rocm_sdk
+
+        lib = ctypes.CDLL(str(rocm_sdk.find_libraries("hiprtc")[0]))
+    except (ImportError, IndexError):
+        if sys.platform == "win32":
+            version_str = "".join(
+                ["0", torch.version.hip[0], "0", torch.version.hip[2]]
+            )
+            lib = ctypes.CDLL(f"hiprtc{version_str}.dll")
+        else:
+            lib = ctypes.CDLL("libhiprtc.so")
 
     # Provide aliases for HIP RTC functions to match NVRTC API
     lib.nvrtcGetErrorString = lib.hiprtcGetErrorString  # type: ignore[attr-defined]


### PR DESCRIPTION
## What

Backport of upstream [pytorch/pytorch#169855](https://github.com/pytorch/pytorch/pull/169855) to `release/2.10`. Single-file change to `torch/cuda/_utils.py` that makes `_get_hiprtc_library()` and `_get_hip_runtime_library()` resolve their libraries through `rocm_sdk.find_libraries(...)` first, falling back to the bare system soname only when the ROCm SDK is unavailable (non-TheRock installs).

## Why

TheRock-based ROCm wheels ship the runtime libraries (e.g. `libhiprtc.so.7`, `libamdhip64.so.7`) under the `_rocm_sdk_core` package, which is not on the default dynamic-linker search path, and they do not provide an unversioned `libhiprtc.so` symlink.

The current `release/2.10` code calls `ctypes.CDLL("libhiprtc.so")` directly, so on pip/TheRock ROCm installs it fails at runtime with:

```
OSError: libhiprtc.so: cannot open shared object file: No such file or directory
```

This surfaces in `test/test_cuda.py::TestCompileKernel` (e.g. `test_compile_kernel`), which calls `torch.cuda._compile_kernel`. Resolving via `rocm_sdk.find_libraries("hiprtc")` returns the absolute versioned path (`.../_rocm_sdk_core/lib/libhiprtc.so.7`) that is actually present in the wheel.

## Fix

Cherry-picked from `b4c8cee0db8f7528b68c08473e16193e79a22dfb` (original author: Luca Bruni <Luca.Bruni@amd.com>). The diff is identical to upstream (27 insertions, 9 deletions).

Fixes: ROCm/TheRock#2166 and ROCM-26014

## Test

```
PYTORCH_TEST_WITH_ROCM=1 python test/test_cuda.py TestCompileKernel.test_compile_kernel
```

## Validation

End-to-end validation is run through TheRock CI on gfx942 hardware. The wheel built from this branch is installed and `test/test_cuda.py` (including `TestCompileKernel::test_compile_kernel`) is executed via `external-builds/pytorch/run_pytorch_tests.py`.

- Build + chained "run pytorch tests" on gfx942 (py3.12): ROCm/TheRock#27847580695 — https://github.com/ROCm/TheRock/actions/runs/27847580695
- A supporting CI change ([ROCm/TheRock `ethanwee/test-pytorch-extra-index`](https://github.com/ROCm/TheRock/tree/ethanwee/test-pytorch-extra-index)) adds `--extra-index-url` to the wheel-test venv setup so the torch wheel (staging index) and its matching `rocm` SDK (release index) both resolve during the pre-promotion test.

Local sanity check on the installed wheel confirmed the dependency graph resolves and `_get_hiprtc_library()` returns the SDK's versioned `libhiprtc.so.7` via `rocm_sdk.find_libraries("hiprtc")`.
