### PR TITLE
[release/2.11][ROCm] Skip linalg UT's when MAGMA is not available with ROCM (#178229)

### DIFF
--- a/test/inductor/test_compile_subprocess.py
+++ b/test/inductor/test_compile_subprocess.py
@@ -76,6 +76,11 @@ test_failures = {
     "test_weight_norm_conv2d": TestFailure(("cpu", "cuda"), is_skip=True),
 }
 
+if TEST_WITH_ROCM and not torch.cuda.has_magma:
+    test_failures["test_linalg_eig_stride_consistency"] = TestFailure(
+        ("cuda",), is_skip=True
+    )
+
 
 class TestSubprocess(TestCase):
     def setUp(self):

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -6222,6 +6222,10 @@ class CommonTemplate:
             reference_in_float=False,
         )
 
+    @unittest.skipIf(
+        TEST_WITH_ROCM and not torch.cuda.has_magma,
+        "ROCm hipsolver backend does not currently support eig",
+    )
     @skipIfMPS
     def test_linalg_eig_stride_consistency(self):
         def fn(x):


### PR DESCRIPTION
Skipping MAGMA related UT's failing in https://github.com/pytorch/pytorch/pull/176306. These tests should be skipped when ROCm is available but MAGMA is not. tested in https://github.com/pytorch/pytorch/pull/176306

Snippet here from XMLs
```
<testcase classname="GPUTests" name="test_linalg_eig_stride_consistency_cuda" time="0.000" file="inductor/test_torchinductor.py">
  <skipped type="pytest.skip" message="ROCm hipsolver backend does not currently support eig">
    /var/lib/jenkins/pytorch/test/inductor/test_torchinductor.py:6421: ROCm hipsolver backend does not currently support eig
  </skipped>
</testcase>
<testcase classname="GPUTests" name="test_linalg_eig_stride_consistency_cuda" time="0.000" file="inductor/test_compile_subprocess.py">
  <skipped type="pytest.skip" message="Skipped!">
    /var/lib/jenkins/pytorch/test/inductor/test_torchinductor.py:6421: Skipped!
  </skipped>
</testcase>
<testcase classname="DynamicShapesGPUTests" name="test_linalg_eig_stride_consistency_dynamic_shapes_cuda" time="0.000" file="inductor/test_torchinductor_dynamic_shapes.py">
  <skipped type="pytest.skip" message="ROCm hipsolver backend does not currently support eig">
    /var/lib/jenkins/pytorch/test/inductor/test_torchinductor.py:6421: ROCm hipsolver backend does not currently support eig
  </skipped>
</testcase>

```

Pull Request resolved: https://github.com/pytorch/pytorch/pull/178229
Approved by: https://github.com/jeffdaily

(cherry picked from commit 1c55be6f67c65baf42b76b502a519c335327972d)

Cherry-picked to release/2.12 branch via https://github.com/ROCm/pytorch/pull/3340

Cherry-picked to release/2.10 branch via https://github.com/ROCm/pytorch/pull/3341

Cherry-picked to release/2.9 branch via https://github.com/ROCm/pytorch/pull/3342