### PR TITLE
[release/2.11] Clean up gfx1250 specific code

### DIFF
--- a/.ci/docker/build.sh
+++ b/.ci/docker/build.sh
@@ -188,7 +188,7 @@ case "$tag" in
     NINJA_VERSION=1.9.0
     TRITON=yes
     KATEX=yes
-    PYTORCH_ROCM_ARCH="gfx90a;gfx942;gfx950;gfx1100;gfx1250"
+    PYTORCH_ROCM_ARCH="gfx90a;gfx942;gfx950;gfx1100"
     if [[ $tag =~ "benchmarks" ]]; then
       INDUCTOR_BENCHMARKS=yes
     fi

--- a/.ci/pytorch/build.sh
+++ b/.ci/pytorch/build.sh
@@ -150,7 +150,6 @@ if [[ "$BUILD_ENVIRONMENT" == *vulkan* ]]; then
   source /var/lib/jenkins/vulkansdk/setup-env.sh
 fi
 
-# Example BUILD_ENVIRONMENT: linux-noble-rocm-py3.12-gfx1250
 if [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
   # hcc used to run out of memory, silently exiting without stopping
   # the build process, leaving undefined symbols in the shared lib,
@@ -160,23 +159,10 @@ if [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
     export MAX_JOBS=$(($(nproc) - 1))
   fi
 
-  # Logic for multiple architectures based on the discriminator BUILD_ENVIRONMENT
-  # that is set by the workflow YAML and follows a consistent naming pattern.
   if [[ -n "$CI" && -z "$PYTORCH_ROCM_ARCH" ]]; then
-      if [[ "$BUILD_ENVIRONMENT" == *gfx1250* ]]; then
-          echo "Setting PYTORCH_ROCM_ARCH to gfx1250 for CI builds"
-          export PYTORCH_ROCM_ARCH="gfx1250"
-      elif [[ "$BUILD_ENVIRONMENT" == *mi355* ]] || [[ "$BUILD_ENVIRONMENT" == *gfx950* ]]; then
-          echo "Setting PYTORCH_ROCM_ARCH to gfx950 for CI builds"
-          export PYTORCH_ROCM_ARCH="gfx950"
-      elif [[ "$BUILD_ENVIRONMENT" == *mi300* ]] || [[ "$BUILD_ENVIRONMENT" == *gfx942* ]]; then
-          echo "Setting PYTORCH_ROCM_ARCH to gfx942 for CI builds"
-          export PYTORCH_ROCM_ARCH="gfx942"
-      else
-          # Set ROCM_ARCH to gfx906 for CI builds, if user doesn't override.
-          echo "Limiting PYTORCH_ROCM_ARCH to gfx906 for CI builds"
-          export PYTORCH_ROCM_ARCH="gfx906"
-      fi
+      # Set ROCM_ARCH to gfx906 for CI builds, if user doesn't override.
+      echo "Limiting PYTORCH_ROCM_ARCH to gfx906 for CI builds"
+      export PYTORCH_ROCM_ARCH="gfx906"
   fi
 
   # hipify sources

--- a/aten/src/ATen/native/cuda/KernelUtils.cuh
+++ b/aten/src/ATen/native/cuda/KernelUtils.cuh
@@ -13,8 +13,7 @@
 
 #if ROCM_VERSION < 60400
 __device__ inline __hip_bfloat162 preview_unsafeAtomicAdd(__hip_bfloat162* address, __hip_bfloat162 value) {
-// `__gfx1250__`-specific `s_wait_loadcnt(0)` path for committed store already there
-#if (defined(__gfx942__) || defined(__gfx1250__)) && \
+#if (defined(__gfx942__)) && \
   __has_builtin(__builtin_amdgcn_flat_atomic_fadd_v2bf16)
   typedef unsigned short __attribute__((ext_vector_type(2))) vec_short2;
   static_assert(sizeof(vec_short2) == sizeof(__hip_bfloat162_raw));

--- a/aten/src/ATen/native/cuda/ScaledBlas.cpp
+++ b/aten/src/ATen/native/cuda/ScaledBlas.cpp
@@ -625,9 +625,14 @@ _scaled_mm_out_cuda(const Tensor& mat1, const Tensor& mat2,
   }
   else if (scaling_choice_a == ScalingType::BlockWise1x32 && scaling_choice_b == ScalingType::BlockWise1x32) {
 #ifdef USE_ROCM
-    #if ROCM_VERSION >= 70000
+#if ROCM_VERSION >= 70000
+#if ROCM_VERSION >= 70200
     TORCH_CHECK_NOT_IMPLEMENTED(at::detail::getCUDAHooks().isGPUArch({"gfx950", "gfx1250"}),
                 "Block-wise scaling for Float8_e8m0fnu is only supported on gfx950/gfx1250");
+#else
+    TORCH_CHECK_NOT_IMPLEMENTED(at::detail::getCUDAHooks().isGPUArch({"gfx950"}),
+                "Block-wise scaling for Float8_e8m0fnu is only supported on gfx950");
+#endif
 
     int packed_factor = 1;
     if (mat1.scalar_type() == ScalarType::Float4_e2m1fn_x2) {
@@ -1070,8 +1075,13 @@ _scaled_mxfp8_mxfp8(
 
 #ifdef USE_ROCM
 #if ROCM_VERSION >= 70000
+#if ROCM_VERSION >= 70200
   TORCH_CHECK_NOT_IMPLEMENTED(at::detail::getCUDAHooks().isGPUArch({"gfx950", "gfx1250"}),
               "Block-wise scaling for Float8_e8m0fnu is only supported on gfx950/gfx1250");
+#else
+  TORCH_CHECK_NOT_IMPLEMENTED(at::detail::getCUDAHooks().isGPUArch({"gfx950"}),
+              "Block-wise scaling for Float8_e8m0fnu is only supported on gfx950");
+#endif
 
   TORCH_CHECK_VALUE(mat_a.size(0) % 32 == 0 && mat_a.size(1) % 32 == 0 &&
               mat_b.size(0) % 32 == 0 && mat_b.size(1) % 32 == 0,
@@ -1156,8 +1166,13 @@ _scaled_mxfp4_mxfp4(
   auto scaling_choice_b = ScalingType::BlockWise1x32;
 
 #if ROCM_VERSION >= 70000
+#if ROCM_VERSION >= 70200
   TORCH_CHECK_NOT_IMPLEMENTED(at::detail::getCUDAHooks().isGPUArch({"gfx950", "gfx1250"}),
               "Block-wise scaling for Float8_e8m0fnu is only supported on gfx950/gfx1250");
+#else
+  TORCH_CHECK_NOT_IMPLEMENTED(at::detail::getCUDAHooks().isGPUArch({"gfx950"}),
+              "Block-wise scaling for Float8_e8m0fnu is only supported on gfx950");
+#endif
 
   TORCH_CHECK_VALUE(mat_a.size(0) % 32 == 0 && mat_a.size(1) % 32 == 0 &&
               mat_b.size(0) % 32 == 0 && mat_b.size(1) % 32 == 0,

--- a/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
+++ b/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
@@ -30,7 +30,16 @@ static void initHipSparseLtSupport() {
     // Check only the first available device
     try {
         if (at::cuda::device_count() > 0) {
-            g_hipSparseLtSupported = at::detail::getCUDAHooks().isGPUArch({"gfx950", "gfx942", "gfx1250"}, 0);
+            // hipSparseLt gfx1250 support requires ROCm 7.2+. Older ROCm builds
+            // should not treat gfx1250 as supported here to avoid failing deeper
+            // in hipSparseLt after we pass this gate.
+#if ROCM_VERSION >= 70200
+            g_hipSparseLtSupported = at::detail::getCUDAHooks().isGPUArch(
+                {"gfx950", "gfx942", "gfx1250"}, 0);
+#else
+            g_hipSparseLtSupported = at::detail::getCUDAHooks().isGPUArch(
+                {"gfx950", "gfx942"}, 0);
+#endif
         }
     } catch (const std::exception&) {
         // If an exception occurs during device property check, we assume hipSparseLt is not supported
@@ -48,9 +57,13 @@ static bool isHipSparseLtSupported() {
     if (!g_hipSparseLtSupported) {
         TORCH_CHECK(
             false,
-            "hipSparseLt not supported on this device, supported architectures: "
+            "hipSparseLt not supported on this device. Supported architectures: "
+#if ROCM_VERSION >= 70200
             "gfx1250, gfx950, gfx942. "
-            "required ROCM version: 6.4.0 or later.");
+#else
+            "gfx950, gfx942 (gfx1250 requires a PyTorch build against ROCm 7.2 or newer). "
+#endif
+            "hipSparseLt on ROCm requires ROCm 7.12 or newer.");
     }
     return g_hipSparseLtSupported;
 }

--- a/aten/src/ATen/native/transformers/hip/flash_attn/ck/CMakeLists.txt
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/ck/CMakeLists.txt
@@ -1,6 +1,6 @@
 # generate a list of kernels, but not actually emit files at config stage
 execute_process(
-  COMMAND python3 ${CMAKE_SOURCE_DIR}/third_party/composable_kernel/example/ck_tile/01_fmha/generate.py --targets gfx1250
+  COMMAND python3 ${CMAKE_SOURCE_DIR}/third_party/composable_kernel/example/ck_tile/01_fmha/generate.py
   --api fwd --receipt 4 --list_blobs ${CMAKE_CURRENT_LIST_DIR}/fwd_blob_list.txt
   RESULT_VARIABLE ret
 )
@@ -10,7 +10,7 @@ if(ret AND NOT ret EQUAL 0)
 endif()
 
 execute_process(
-  COMMAND python3 ${CMAKE_SOURCE_DIR}/third_party/composable_kernel/example/ck_tile/01_fmha/generate.py --targets gfx1250
+  COMMAND python3 ${CMAKE_SOURCE_DIR}/third_party/composable_kernel/example/ck_tile/01_fmha/generate.py
   --api fwd_splitkv --receipt 4 --list_blobs ${CMAKE_CURRENT_LIST_DIR}/fwd_splitkv_blob_list.txt
   RESULT_VARIABLE ret
 )
@@ -20,7 +20,7 @@ if(ret AND NOT ret EQUAL 0)
 endif()
 
 execute_process(
-  COMMAND python3 ${CMAKE_SOURCE_DIR}/third_party/composable_kernel/example/ck_tile/01_fmha/generate.py --targets gfx1250
+  COMMAND python3 ${CMAKE_SOURCE_DIR}/third_party/composable_kernel/example/ck_tile/01_fmha/generate.py
   --api fwd_appendkv --receipt 4 --list_blobs ${CMAKE_CURRENT_LIST_DIR}/fwd_appendkv_blob_list.txt
   RESULT_VARIABLE ret
 )
@@ -30,7 +30,7 @@ if(ret AND NOT ret EQUAL 0)
 endif()
 
 execute_process(
-  COMMAND python3 ${CMAKE_SOURCE_DIR}/third_party/composable_kernel/example/ck_tile/01_fmha/generate.py --targets gfx1250
+  COMMAND python3 ${CMAKE_SOURCE_DIR}/third_party/composable_kernel/example/ck_tile/01_fmha/generate.py
   --api bwd --receipt 4 --list_blobs ${CMAKE_CURRENT_LIST_DIR}/bwd_blob_list.txt
   RESULT_VARIABLE ret
 )
@@ -40,28 +40,28 @@ if(ret AND NOT ret EQUAL 0)
 endif()
 
 # Generate the files for both fwd, fwd_splitkv, fwd_appendkv, and bwd
-execute_process(COMMAND python3 ${CMAKE_SOURCE_DIR}/third_party/composable_kernel/example/ck_tile/01_fmha/generate.py --targets gfx1250 --api fwd --receipt 4 --output_dir ${CMAKE_CURRENT_LIST_DIR}
+execute_process(COMMAND python3 ${CMAKE_SOURCE_DIR}/third_party/composable_kernel/example/ck_tile/01_fmha/generate.py --api fwd --receipt 4 --output_dir ${CMAKE_CURRENT_LIST_DIR}
 )
 
 if(ret AND NOT ret EQUAL 0)
   message( FATAL_ERROR "CK Tile FMHA FAILED to generate FWD kernels.")
 endif()
 
-execute_process(COMMAND python3 ${CMAKE_SOURCE_DIR}/third_party/composable_kernel/example/ck_tile/01_fmha/generate.py --targets gfx1250 --api fwd_splitkv --receipt 4 --output_dir ${CMAKE_CURRENT_LIST_DIR}
+execute_process(COMMAND python3 ${CMAKE_SOURCE_DIR}/third_party/composable_kernel/example/ck_tile/01_fmha/generate.py --api fwd_splitkv --receipt 4 --output_dir ${CMAKE_CURRENT_LIST_DIR}
 )
 
 if(ret AND NOT ret EQUAL 0)
     message( FATAL_ERROR "CK Tile FMHA FAILED to generate FWD_SPLITKV kernels.")
 endif()
 
-execute_process(COMMAND python3 ${CMAKE_SOURCE_DIR}/third_party/composable_kernel/example/ck_tile/01_fmha/generate.py --targets gfx1250 --api fwd_appendkv --receipt 4 --output_dir ${CMAKE_CURRENT_LIST_DIR}
+execute_process(COMMAND python3 ${CMAKE_SOURCE_DIR}/third_party/composable_kernel/example/ck_tile/01_fmha/generate.py --api fwd_appendkv --receipt 4 --output_dir ${CMAKE_CURRENT_LIST_DIR}
 )
 
 if(ret AND NOT ret EQUAL 0)
     message( FATAL_ERROR "CK Tile FMHA FAILED to generate FWD_APPENDKV kernels.")
 endif()
 
-execute_process(COMMAND python3 ${CMAKE_SOURCE_DIR}/third_party/composable_kernel/example/ck_tile/01_fmha/generate.py --targets gfx1250 --api bwd --receipt 4 --output_dir ${CMAKE_CURRENT_LIST_DIR}
+execute_process(COMMAND python3 ${CMAKE_SOURCE_DIR}/third_party/composable_kernel/example/ck_tile/01_fmha/generate.py --api bwd --receipt 4 --output_dir ${CMAKE_CURRENT_LIST_DIR}
   RESULT_VARIABLE ret
 )
 

--- a/c10/core/AllocatorConfig.h
+++ b/c10/core/AllocatorConfig.h
@@ -19,13 +19,7 @@ constexpr size_t kMinBlockSize = 512;
 // largest "small" allocation is 1 MiB
 constexpr size_t kSmallSize = 1048576;
 // allocations between 1 and 10 MiB may use kLargeBuffer
-#if defined(USE_ROCM) && defined(__gfx1250__)
-// Increase the buffer threshold for gfx1250
-// to avoid fragmentation on 432GB devices.
-constexpr size_t kMinLargeAlloc = 20 * 1024 * 1024;  // 20 MiB
-#else
-constexpr size_t kMinLargeAlloc = 10485760;  // 10 MiB
-#endif
+constexpr size_t kMinLargeAlloc = 10485760;
 // round up large allocations to 2 MiB
 constexpr size_t kRoundLarge = 2097152;
 


### PR DESCRIPTION
This change backs out gfx1250 specific additions that were unnecessary, incorrect, or harmful for non–gfx1250 builds.

- **CI**: Drop `gfx1250` from the default multi-arch list in `.ci/docker/build.sh` and `.ci/pytorch/build.sh` .
- **CK FMHA codegen**: Remove unconditional `--targets gfx1250` from `generate.py` invocations for non–gfx1250 builds.
- **Allocator**: Remove the `__gfx1250__` branch in `c10/core/AllocatorConfig.h` and keep the original code.
- **Kernels**: Drop gfx1250 from in `KernelUtils.cuh`  as we have `#if ROCM_VERSION < 60400` condition in place.
- **Scaled BLAS / hipSparseLt**: Only treat **gfx1250** as supported where it matches the rest of the stack—**ROCm ≥ 7.2** .