### PR TITLE
[release/2.12] reuse one stream for warmup and captures in make_graphed_callables

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -3640,7 +3640,6 @@ exit(2)
             model_graphed({"x": real_inputs[0]}), model_control({"x": real_inputs[0]})
         )
 
-    @skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/179961")
     @unittest.skipIf(
         not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
     )

--- a/torch/cuda/graphs.py
+++ b/torch/cuda/graphs.py
@@ -449,7 +449,10 @@ def make_graphed_callables(
     # Hopefully prevents cudnn benchmarking and other lazy-initialization cuda work
     # from ending up in any captures.
     torch.cuda.synchronize()
-    with torch.cuda.stream(torch.cuda.Stream()):
+    # hipBLASLt handles are per-(device, stream) on ROCm and lazily created.
+    # Need to use the same stream for warmup and capture to avoid capture errors.
+    stream = torch.cuda.Stream()
+    with torch.cuda.stream(stream):
         for func, args, static_input_surface in zip(
             callables, _sample_args, per_callable_static_input_surfaces
         ):
@@ -482,7 +485,7 @@ def make_graphed_callables(
     per_callable_static_outputs = []
     per_callable_output_unflatten_spec = []
     for func, args, fwd_graph in zip(callables, _sample_args, fwd_graphs):
-        with torch.cuda.graph(fwd_graph, pool=mempool):
+        with torch.cuda.graph(fwd_graph, stream=stream, pool=mempool):
             func_outputs = func(*args)
 
         flatten_outputs, spec = torch.utils._pytree.tree_flatten(func_outputs)
@@ -506,7 +509,7 @@ def make_graphed_callables(
         outputs_grad = tuple(o for o in static_outputs if o.requires_grad)
         grad_inputs = None
         if len(outputs_grad) > 0:
-            with torch.cuda.graph(bwd_graph, pool=mempool):
+            with torch.cuda.graph(bwd_graph, stream=stream, pool=mempool):
                 grad_inputs = torch.autograd.grad(
                     outputs=outputs_grad,
                     inputs=tuple(i for i in static_input_surface if i.requires_grad),


### PR DESCRIPTION
### Summary

This PR updates `torch.cuda.make_graphed_callables` so warmup and graph capture use the same stream, avoiding ROCm graph capture failures tied to hipBLASLt.

### Why

On ROCm, hipBLASLt handle caching is per (device, stream). If `stream=` is omitted, `torch.cuda.graph` uses its own default capture stream, which is not the stream used for warmup. The first real use on that capture stream will trigger a lazy hipblasLtCreate there. Handle creation runs capture‑unsafe internal allocation/setup, which fail with stream-capture errors (and sometimes hang) during capture.

Running warmup on the same stream passed into `torch.cuda.graph(..., stream=...)` creates and caches the hipBLASLt handle before capture, so hipblasLtCreate (and its associated allocations) are not hit mid‑capture.

Fixes https://github.com/pytorch/pytorch/issues/179961

Pull Request resolved: https://github.com/pytorch/pytorch/pull/187745
Approved by: https://github.com/jeffdaily

(cherry picked from commit d9d756c9889206622e7880da70a459cac7b09a2e)