### PR TITLE
[release/2.11_gfx1250] [ROCm] Fix multi-arch AOT Inductor compilation with newer Triton LLVM…

### DIFF
--- a/torch/_inductor/rocm_multiarch_utils.py
+++ b/torch/_inductor/rocm_multiarch_utils.py
@@ -3,12 +3,17 @@ ROCm Multi-Architecture Support Utilities
 Compile LLVM IR to multi-arch bundles that HIP can load automatically.
 """
 
+import logging
 import os
+import re
 import subprocess
 from typing import Optional
 
 import torch
 from torch.utils.cpp_extension import _join_rocm_home, ROCM_HOME
+
+
+log = logging.getLogger(__name__)
 
 
 def get_rocm_compiler() -> str:
@@ -69,19 +74,21 @@ def get_rocm_bundler() -> str:
 
 
 def get_rocm_target_archs() -> list[str]:
-    """
-    Get target architectures from environment or config.
-    Returns: List of architecture strings (e.g., ['gfx90a', 'gfx942'])
-    """
-    # Check PYTORCH_ROCM_ARCH environment variable
     env_archs = os.environ.get("PYTORCH_ROCM_ARCH", "").strip()
     if env_archs:
         archs = [arch.strip() for arch in env_archs.replace(";", ",").split(",")]
         archs = [arch for arch in archs if arch]
         if archs:
+            # Ensure current device arch is included
+            if torch.cuda.is_available():
+                for dev_idx in range(torch.cuda.device_count()):
+                    current_arch = torch.cuda.get_device_properties(
+                        dev_idx
+                    ).gcnArchName.split(":")[0]
+                    if current_arch not in archs:
+                        archs.append(current_arch)
             return archs
 
-    # Try to get from inductor config
     try:
         from torch._inductor import config
 
@@ -94,6 +101,43 @@ def get_rocm_target_archs() -> list[str]:
         pass
 
     return torch.cuda.get_arch_list()
+
+
+def _sanitize_llvm_ir_for_rocm(llvm_ir_path: str) -> str:
+    """
+    Sanitize LLVM IR to be compatible with ROCm's clang.
+
+    Triton's LLVM (upstream) may emit attributes and metadata that ROCm's
+    older clang does not yet support. Only strips attributes confirmed to
+    cause parse errors — preserves all others to maintain correct codegen.
+
+    Currently strips:
+        - nocreateundeforpoison: function attribute (upstream LLVM, not in ROCm)
+        - dwarfAddressSpace: debug metadata field (upstream LLVM, not in ROCm)
+
+    Returns:
+        Path to sanitized .ll file, or original path if no changes needed.
+    """
+    with open(llvm_ir_path) as f:
+        content = f.read()
+
+    sanitized = content
+    sanitized = re.sub(r"\bnocreateundeforpoison\b\s*", "", sanitized)
+    sanitized = re.sub(r",\s*dwarfAddressSpace:\s*\d+", "", sanitized)
+
+    if sanitized == content:
+        return llvm_ir_path
+
+    sanitized_path = llvm_ir_path + ".sanitized.ll"
+    with open(sanitized_path, "w") as f:
+        f.write(sanitized)
+
+    log.debug(
+        "Sanitized LLVM IR for ROCm clang compatibility: %s -> %s",
+        llvm_ir_path,
+        sanitized_path,
+    )
+    return sanitized_path
 
 
 def compile_llvm_ir_to_code_object(
@@ -119,6 +163,9 @@ def compile_llvm_ir_to_code_object(
         clang = get_rocm_compiler()
     except RuntimeError:
         return False
+
+    # Sanitize LLVM IR to remove attributes unsupported by ROCm's clang
+    llvm_ir_path = _sanitize_llvm_ir_for_rocm(llvm_ir_path)
 
     # Using clang and not hipcc since we are not compiling source code
     # Instead we use the LLVM IR (.ll) provided by triton


### PR DESCRIPTION
… (#175021)

test/inductor/test_aot_inductor.py::AOTInductorTestABICompatibleGpu::test_simple_multi_arch_embed_kernel_binary_False_cuda now PASSES (verified on gfx942, single GPU).
test/inductor/test_aot_inductor_package.py::TestAOTInductorPackageCpp_cuda::test_compile_after_package_multi_arch now PASSES (verified on gfx942; the package build additionally needs PYTORCH_ROCM_ARCH=gfx942 and PKG_CONFIG_PATH to include …/rocm_sysdeps/lib/pkgconfig for the libdrm lookup — both pre-existing env requirements, unrelated to this fix).

Triton's LLVM bump (76e2689) emits IR attributes (`nocreateundeforpoison`,`dwarfAddressSpace`) that ROCm's clang doesn't recognize, breaking multi-arch compilation. This sanitizes those two attributes from the IR before passing to clang. Other newer attributes (`memory()`, `captures()`, `range()`) are kept as ROCm 7.0 accepts them and stripping them breaks kernel ABI.

Also ensures the current device arch is always included in the multi-arch target list when `PYTORCH_ROCM_ARCH` doesn't list it.

Pull Request resolved: https://github.com/pytorch/pytorch/pull/175021
Approved by: https://github.com/jeffdaily

(cherry picked from commit 717898d443a57e3c3927fe307d4299f595fc88af)