### PR TITLE
[CI] Parity: exclude inductor.test_cpu_repro from comparison

### DIFF
--- a/.automation_scripts/pytorch-unit-test-scripts/summarize_xml_testreports.py
+++ b/.automation_scripts/pytorch-unit-test-scripts/summarize_xml_testreports.py
@@ -31,7 +31,10 @@ EXCLUDED_TEST_SUITES = [
     "_nvfuser.test_torchscript",
     "test_jit_cuda_fuser",
     "test_nvfuser_dynamo",
-    "test_nvfuser_frontend"
+    "test_nvfuser_frontend",
+    # Blocklisted on ROCm upstream, so it never runs there and would otherwise
+    # show up as falsely MISSED against the CUDA baseline.
+    "inductor.test_cpu_repro"
 ]
 
 

--- a/.automation_scripts/pytorch-unit-test-scripts/summarize_xml_testreports.py
+++ b/.automation_scripts/pytorch-unit-test-scripts/summarize_xml_testreports.py
@@ -29,11 +29,11 @@ EXCLUDED_TEST_SUITES = [
     "_nvfuser.test_dynamo",
     "_nvfuser.test_python_frontend",
     "_nvfuser.test_torchscript",
-    "test_jit_cuda_fuser",
     "test_nvfuser_dynamo",
     "test_nvfuser_frontend",
     # Blocklisted on ROCm upstream, so it never runs there and would otherwise
     # show up as falsely MISSED against the CUDA baseline.
+    "test_jit_cuda_fuser",
     "inductor.test_cpu_repro"
 ]
 


### PR DESCRIPTION
Split out of #3210 (2 of 3) for easier review.

`inductor.test_cpu_repro` is blocklisted on ROCm upstream, so it never runs there and would otherwise show up as falsely **MISSED** against the CUDA baseline (~791 phantom MISSED rows on a recent mi350 run). Add it to `EXCLUDED_TEST_SUITES` so it is dropped from the ROCm-vs-CUDA comparison.

Verified against a real mi350 run: removes all `inductor.test_cpu_repro` rows; MISSED gap drops ~1,294 -> ~503 and DEFAULT disagreement 3.03% -> 2.77% (SKIPPED unchanged).

Made with [Cursor](https://cursor.com)