### PR TITLE
[release/2.12] Fix TestCuda: test_host_memory_stats

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -254,12 +254,21 @@ class TestCuda(TestCase):
                 "active_requests.peak": 0,
             }
 
+        # Deltas from baseline captured after cleanup (not absolute totals), so
+        # ordering against other tests cannot leave host stats in a broken state.
+        baseline = {}
+
         def check_stats(expected):
             stats = torch.cuda.host_memory_stats()
             for k, v in expected.items():
-                if v != stats[k]:
-                    print(f"key: {k}, expected: {v}, stats: {stats[k]}")
-                self.assertEqual(v, stats[k])
+                want = baseline[k] + v
+                actual = stats[k]
+                if actual != want:
+                    print(
+                        f"key: {k}, baseline: {baseline[k]}, delta: {v}, "
+                        f"want: {want}, got: {actual}"
+                    )
+                self.assertEqual(actual, want)
 
         # Setup the test cleanly
         alloc1 = 10
@@ -268,11 +277,12 @@ class TestCuda(TestCase):
         alloc2_aligned = 32
         expected = empty_stats()
 
-        # Reset any lingering state
         gc.collect()
         torch._C._host_emptyCache()
+        torch.cuda.reset_peak_host_memory_stats()
+        torch.cuda.reset_accumulated_host_memory_stats()
+        baseline.update(torch.cuda.host_memory_stats())
 
-        # Check that stats are empty
         check_stats(expected)
 
         # Make first allocation and check stats


### PR DESCRIPTION
For `TestCuda::test_host_memory_stats::test_host_memory_stats`: use pinned-host stats as deltas from a post-cleanup baseline (after gc, _host_emptyCache(), and reset peak/accumulated) instead of requiring absolute zeros, so test order and leftover allocations do not flake the empty-state check while the test still validates its own traffic.

Example of such negative impact is that can't be fixed via reseting of host memory stats: `PYTORCH_TEST_WITH_ROCM=1 python test/test_cuda.py TestCuda.test_cuda_kernel_loop_overflow TestCuda.test_host_memory_stats` 

Pull Request resolved: https://github.com/pytorch/pytorch/pull/179070 
Approved by: https://github.com/jeffdaily

(cherry picked from commit 3037af3e5ccfaf60937f0b6f2ad3a3c2cee503a5)
