### PR TITLE
[CI] Parity: add regex-filtered HUD link to the summary

### DIFF
--- a/.automation_scripts/pytorch-unit-test-scripts/generate_summary.py
+++ b/.automation_scripts/pytorch-unit-test-scripts/generate_summary.py
@@ -639,6 +639,18 @@ def build_rows(args, archs, arch_data):
 
     if args.sha:
         out.append(('__header__', f'Commit SHA: {args.sha}'))
+        # Link straight to the upstream HUD page filtered (regex) to the trunk
+        # CUDA / inductor / rocm test jobs this report is built from, so a
+        # reviewer can jump from the summary to the matching CI jobs. Parens and
+        # pipes are percent-encoded to keep the markdown link valid.
+        hud_url = (
+            f'https://hud.pytorch.org/hud/pytorch/pytorch/{args.sha}/1'
+            '?per_page=50'
+            '&name_filter=%28trunk.*cuda%7Cinductor%7Crocm%29.*test.*'
+            '%28default%7Cdistributed%7Cinductor%29%2C'
+            '&useRegexFilter=true'
+        )
+        out.append(('__header__', f'HUD: [parity jobs for this commit]({hud_url})'))
     if args.pr_id:
         out.append(('__header__', f'PR ID: {args.pr_id}'))
 


### PR DESCRIPTION
## Summary
Re-adds a clickable **HUD** link to the parity report summary, pointing at the upstream HUD page for the report's resolved commit, **regex-filtered** to the trunk CUDA / inductor / rocm test jobs the report is built from:

`https://hud.pytorch.org/hud/pytorch/pytorch/<sha>/1?per_page=50&name_filter=(trunk.*cuda|inductor|rocm).*test.*(default|distributed|inductor),&useRegexFilter=true`

## Why
The HUD link originally added in #3258 was **dropped when `parity.yml` was rewritten** (during the #3278/#3231 work). This re-adds it in `generate_summary.py` (next to the `Commit SHA` header) instead of the workflow, so it lives in the report itself — visible in both the GitHub Actions step summary and the CSV artifact's `_summary.md` — and survives future workflow rewrites.

## Notes
- Parens (`%28`/`%29`) and pipes (`%7C`) are percent-encoded so the markdown link stays valid; the URL decodes to exactly `(trunk.*cuda|inductor|rocm).*test.*(default|distributed|inductor),`.
- Only emitted when a SHA is resolved.

## Test plan
- [x] `py_compile` clean.
- [x] End-to-end: ran `generate_summary.py` on a real mi350 status CSV → summary renders `**HUD: [parity jobs for this commit](…)**`; decoded `name_filter` matches the intended regex, `useRegexFilter=true`, `per_page=50`.

Made with [Cursor](https://cursor.com)

---

## Rebased onto current develop + validated

This PR was rebased onto current `develop` (it was previously opened against an old lineage and showed unrelated files). Validation parity run on the clean SHA `ba9910c6` (mi300): https://github.com/ethanwee1/pytorch/actions/runs/28884934635
