### PR TITLE
[CI] Parity: count a disagreement only when CUDA PASSED

### DIFF
--- a/.automation_scripts/pytorch-unit-test-scripts/generate_summary.py
+++ b/.automation_scripts/pytorch-unit-test-scripts/generate_summary.py
@@ -114,10 +114,10 @@ def test_config_stats_keys(s1_name, s2_name, has_set2=True):
             f'TOTAL {s1}',
         ]
     return [
-        f'SKIPPED (on {s1_name}, but not on {s2_name})',
+        f'SKIPPED (on {s1_name}, PASSED on {s2_name})',
         f'SKIPPED (on {s1_name})',
         f'SKIPPED (on {s2_name})',
-        f'MISSED (MISSED on {s1_name}, NOT SKIPPED on {s2_name})',
+        f'MISSED (on {s1_name}, PASSED on {s2_name})',
         f'{s1}ONLY (PASSED on {s1}, NOT PASSED on {s2})',
         s2,
         s1,
@@ -141,15 +141,18 @@ def compute_test_config_stats(rows, s1_col, s2_col, s1_name, s2_name, has_set2=T
         vals[keys[4]] = sum(1 for r in rows if r[s1_col].strip())
         return vals
 
+    # Count a ROCm SKIPPED/MISSED test as a disagreement only when CUDA actually
+    # PASSED it. This excludes parametrization variants CUDA never runs (CUDA
+    # MISSED) or also skips, which aren't real ROCm-vs-CUDA coverage gaps.
     s1_skip_not_s2 = sum(
         1 for r in rows
-        if r[s1_col] == 'SKIPPED' and r[s2_col] != 'SKIPPED'
+        if r[s1_col] == 'SKIPPED' and r[s2_col] == 'PASSED'
     )
     s1_skip = sum(1 for r in rows if r[s1_col] == 'SKIPPED')
     s2_skip = sum(1 for r in rows if r[s2_col] == 'SKIPPED')
     s1_miss_not_s2_skip = sum(
         1 for r in rows
-        if r[s1_col] == 'MISSED' and r[s2_col] != 'SKIPPED'
+        if r[s1_col] == 'MISSED' and r[s2_col] == 'PASSED'
     )
     only_s1 = sum(
         1 for r in rows
@@ -233,11 +236,11 @@ def compute_overall_stats(rows, s1_col, s2_col, s1_time_col, s2_time_col, s1_nam
         wf_rows = [r for r in rows if r['test_config'] == wf]
         s1_skip_not_s2 = sum(
             1 for r in wf_rows
-            if r[s1_col] == 'SKIPPED' and r[s2_col] != 'SKIPPED'
+            if r[s1_col] == 'SKIPPED' and r[s2_col] == 'PASSED'
         )
         s1_miss_not_s2_skip = sum(
             1 for r in wf_rows
-            if r[s1_col] == 'MISSED' and r[s2_col] != 'SKIPPED'
+            if r[s1_col] == 'MISSED' and r[s2_col] == 'PASSED'
         )
         total_disagree += s1_skip_not_s2 + s1_miss_not_s2_skip
         total_s2 += sum(1 for r in wf_rows if r[s2_col].strip() and r[s2_col].strip() != 'MISSED')


### PR DESCRIPTION
## Summary
Changes the parity DISAGREE/AGREE metric to count a ROCm `SKIPPED`/`MISSED` test as a disagreement **only when CUDA actually `PASSED`** it (`status_cuda == PASSED`), instead of "CUDA didn't SKIP it" (`!= SKIPPED`).

## Why
The old definition counted as disagreements the large set of **attention-backend parametrization variants** (e.g. `test_transformers` Flash/CK/CUTLASS cases) that **CUDA never even enumerates** (CUDA = `MISSED`). Those aren't real ROCm-vs-CUDA coverage gaps — they just inflated DISAGREE to ~3% (AGREE ~97%). Counting only "CUDA passed, ROCm didn't" reflects the **actionable** gap and matches the triage spreadsheet's adjusted definition.

## Effect (mi350, real data)
- Overall **AGREE% 97.3% → 99.07%**
- DEFAULT `SKIPPED+MISSED` 9,002 → **2,629**, DISAGREE 3.0% → **0.88%**
- The two line items are relabeled `SKIPPED (on rocm, PASSED on cuda)` / `MISSED (on rocm, PASSED on cuda)` for accuracy.

## Scope
`compute_test_config_stats` + `compute_overall_stats` in `generate_summary.py`. The dashboard's parity collector (`ROCm/AI-Frameworks-Dashboard#49`) is being updated with the same definition so the dashboard matches this report.

## Test plan
- [x] `py_compile` clean.
- [x] Ran against a real mi350 status CSV → Overall AGREE 99.07%, DEFAULT DISAGREE 0.88%.

Made with [Cursor](https://cursor.com)

---

## Rebased onto current develop + validated

This PR was rebased onto current `develop` (it was previously opened against an old lineage and showed unrelated files). Validation parity run on the clean SHA `ba9910c6` (mi300): https://github.com/ethanwee1/pytorch/actions/runs/28884929807
