### PR TITLE
[release/2.12] Cleanup persistent cuBLASLt workspaces before test_mempool_ctx_multithread

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -6971,6 +6971,7 @@ class TestMemPool(TestCase):
 
     @serialTest()
     def test_mempool_ctx_multithread(self):
+        torch._C._cuda_clearCublasWorkspaces()
         torch.cuda.empty_cache()
         segments = torch.cuda.memory._snapshot()["segments"]
         self.assertEqual(len(segments), 0, "Expected empty pool in the beginning")


### PR DESCRIPTION
`test_cuda.py::TestMemPool::test_mempool_ctx_multithread` assumes the device allocator snapshot is empty after empty_cache(), but earlier tests in the same process can leave inactive segments behind.

Call `torch._C._cuda_clearCublasWorkspaces()` at the start of the test (before empty_cache()) so prior tests do not pollute the initial segment count. This matches the pattern already used in other tests

Reproducer (fails without the fix):
```bash
python test_cuda.py TestCuda.test_matmul_device_mismatch TestMemPool.test_mempool_ctx_multithread
```
test_matmul_device_mismatch leaves reserved segments. test_mempool_ctx_multithread then fails with `Expected 0 but got N` on the opening assertion. The test passes in isolation.

Fixes https://github.com/pytorch/pytorch/issues/153460 Pull Request resolved: https://github.com/pytorch/pytorch/pull/187991 Approved by: https://github.com/jeffdaily

(cherry picked from commit 77fa1dc19fd7c421bcdada25d1abcd7fc218680d)


Cherry-picked to release/2.11 branch via https://github.com/ROCm/pytorch/pull/3373

Cherry-picked to release/2.10 branch via https://github.com/ROCm/pytorch/pull/3374