### PR TITLE
[CI] Parity report: dedupe LOG-BASED FAILURES + fix empty Job ID links

### DIFF
--- a/.automation_scripts/pytorch-unit-test-scripts/download_testlogs
+++ b/.automation_scripts/pytorch-unit-test-scripts/download_testlogs
@@ -338,11 +338,12 @@ def _shorten_unzipped_dirs():
         m = re.search(r'test-(?:osdc-)?(default|distributed|inductor)-(\d+)-(\d+)', d.name)
         if m:
             short_name = f"test-{m.group(1)}-{m.group(2)}-{m.group(3)}"
-            # The original artifact name ends with "_<jobid>.zip" where
-            # <jobid> is the upstream pytorch CI job id (e.g.
-            # ..._68613413431.zip). Carry it onto short_name so
-            # summarize_xml_testreports.py can link to that job.
-            job_id_match = re.search(r'_(\d{6,})\.zip$', d.name)
+            # The artifact/dir name ends with "_<jobid>" (optionally ".zip")
+            # where <jobid> is the upstream pytorch CI job id (e.g.
+            # ..._68613413431 or ..._68613413431.zip). Carry it onto short_name
+            # so summarize_xml_testreports.py can link to that job. The unzipped
+            # directory has no .zip suffix, so it must be optional here.
+            job_id_match = re.search(r'_(\d{6,})(?:\.zip)?$', d.name)
             if job_id_match:
                 short_name += f"_{job_id_match.group(1)}"
             if not Path(short_name).exists():

--- a/.automation_scripts/pytorch-unit-test-scripts/generate_summary.py
+++ b/.automation_scripts/pytorch-unit-test-scripts/generate_summary.py
@@ -699,6 +699,42 @@ def _parse_log_failure_names(lf):
     return parts[0], parts[1]
 
 
+def _select_rocm_log_failures(log_failures, failed_tests, s1_name):
+    """ROCm log-detected failures not already in the XML FAILED TESTS table,
+    deduplicated to one row per test.
+
+    A single test can appear in log_failures more than once - e.g. a per-test
+    'FAILED' line and a 'FAILED CONSISTENTLY' line (category CONSISTENT_FAILURE)
+    describe the same test. Collapse those to a single row, preferring
+    CONSISTENT_FAILURE over a one-off FAILED so a test is never listed as both.
+    """
+    xml_failed_keys = {
+        (t['arch'], _norm_test_file(t['test_file']), t['test_class'], t['test_name'])
+        for t in (failed_tests or [])
+    }
+    best = {}
+    order = []
+    for lf in (log_failures or []):
+        if lf.get('platform', '') != s1_name:
+            continue
+        test_class, test_name = _parse_log_failure_names(lf)
+        key = (lf.get('arch', ''), _norm_test_file(lf.get('test_file', '')),
+               test_class, test_name)
+        # Skip entries already present in the XML-based FAILED TESTS table to
+        # avoid double-counting the same failure, except FLAKY entries which
+        # represent an independent signal (a rerun passed).
+        if key in xml_failed_keys and lf.get('category', '') != 'FLAKY':
+            continue
+        existing = best.get(key)
+        if existing is None:
+            best[key] = lf
+            order.append(key)
+        elif (lf.get('category') == 'CONSISTENT_FAILURE'
+              and existing.get('category') != 'CONSISTENT_FAILURE'):
+            best[key] = lf
+    return [best[k] for k in order]
+
+
 def write_csv(rows, archs, output_path, failed_tests=None, s1_name='set1', s2_name='set2', has_set2=True, log_failures=None, shard_lookup=None):
     csv_rows = []
     csv_rows.append([''] + list(archs))
@@ -755,23 +791,7 @@ def write_csv(rows, archs, output_path, failed_tests=None, s1_name='set1', s2_na
         csv_rows.append([])
 
     if log_failures:
-        xml_failed_keys = {
-            (t['arch'], _norm_test_file(t['test_file']), t['test_class'], t['test_name'])
-            for t in (failed_tests or [])
-        }
-        rocm_log_failures = []
-        for lf in log_failures:
-            if lf.get('platform', '') != s1_name:
-                continue
-            test_class, test_name = _parse_log_failure_names(lf)
-            key = (lf.get('arch', ''), _norm_test_file(lf.get('test_file', '')),
-                   test_class, test_name)
-            # Skip entries already present in the XML-based FAILED TESTS table
-            # to avoid double-counting the same failure, except for FLAKY
-            # entries which represent an independent signal (a rerun passed).
-            if key in xml_failed_keys and lf.get('category', '') != 'FLAKY':
-                continue
-            rocm_log_failures.append(lf)
+        rocm_log_failures = _select_rocm_log_failures(log_failures, failed_tests, s1_name)
         if rocm_log_failures:
             csv_rows.append(['LOG-BASED FAILURES (not in XML)'])
             csv_rows.append(['Arch', 'Platform', 'Test Config', 'Test File', 'Test Class',
@@ -897,20 +917,7 @@ def write_markdown(rows, archs, output_path, failed_tests=None, s1_name='set1', 
         lines.append('')
 
     if log_failures:
-        xml_failed_keys = {
-            (t['arch'], _norm_test_file(t['test_file']), t['test_class'], t['test_name'])
-            for t in (failed_tests or [])
-        }
-        rocm_log_failures = []
-        for lf in log_failures:
-            if lf.get('platform', '') != s1_name:
-                continue
-            test_class, test_name = _parse_log_failure_names(lf)
-            key = (lf.get('arch', ''), _norm_test_file(lf.get('test_file', '')),
-                   test_class, test_name)
-            if key in xml_failed_keys and lf.get('category', '') != 'FLAKY':
-                continue
-            rocm_log_failures.append(lf)
+        rocm_log_failures = _select_rocm_log_failures(log_failures, failed_tests, s1_name)
         if rocm_log_failures:
             lines.append(f'### LOG-BASED FAILURES (not in XML) ({len(rocm_log_failures)})')
             lines.append('')


### PR DESCRIPTION
Two user-reported bugs in the parity report.

## 1. LOG-BASED FAILURES duplication
A test could be listed **twice** in the LOG-BASED FAILURES table — once as `FAILED` and once as `CONSISTENT_FAILURE` — because `detect_log_failures.py` emits both a per-test `FAILED` record and a `FAILED CONSISTENTLY` record for the same test, and `generate_summary.py` never deduped within `log_failures` (it only filtered against the XML FAILED TESTS table).

**Fix:** add a shared `_select_rocm_log_failures()` helper (used by both the CSV and markdown renderers) that filters out XML-failed tests and **dedupes per test, preferring `CONSISTENT_FAILURE`** — so a test is never shown as both.

Example that regressed: `mi350 · default · test_sparse · TestSparseMaskedReductionsCUDA · test_future_empty_dim_masked_prod_cuda_complex128` showed as both; it now shows only `CONSISTENT_FAILURE`.

## 2. Empty Job ID columns in FAILED TESTS
`download_testlogs._shorten_unzipped_dirs` extracted the upstream CI job id with `re.search(r'_(\d{6,})\.zip$', ...)`, but the **unzipped** shard dirs end in `_<jobid>` with no `.zip` (e.g. `unzipped-...gfx950.2_83371682957`). So the `_<jobid>` suffix was dropped, dirs became `test-default-1-8`, and `summarize_xml`'s `parse_xml_reports_as_dict` (`_(\d+)$`) couldn't recover the id -> `job_url` was empty for every row -> the FAILED TESTS "Job ID" columns were always blank.

**Fix:** make `.zip` optional: `r'_(\d{6,})(?:\.zip)?$'` (still matches the older `.zip` form).

## Validation
- Both files `py_compile` / parse clean.
- Dedup: ran `_select_rocm_log_failures` on a real `log_failures` CSV — the test that had both `FAILED` and `CONSISTENT_FAILURE` collapses to a single `CONSISTENT_FAILURE` row (0 keys left with multiple categories).
- Job id: the new regex extracts `83371682957` from the real `unzipped-...` dir name, and the resulting `test-distributed-1-3_83371682957` parses correctly, so `job_url` populates. End-to-end `Job ID` population will be confirmed by the next parity run after merge.

Independent of #3370 / #3371 (those touch a different section of `generate_summary.py`).

Made with [Cursor](https://cursor.com)

## Validation

Validated on a run of **this PR branch** (develop + both fixes) for the exact SHA that exhibited both bugs:

- `206283a284889f3a4f62510f8b5a8068d41121c4 · mi350`: https://github.com/ROCm/pytorch/actions/runs/28190615761
  - **Bug 1:** `test_sparse::TestSparseMaskedReductionsCUDA::test_future_empty_dim_masked_prod_cuda_complex128` is now listed **once** as `CONSISTENT_FAILURE` (was both FAILED + CONSISTENT_FAILURE); 0 keys with multiple categories across the LOG-BASED table.
  - **Bug 2:** FAILED TESTS table has **24 populated Job ID links**; in the status CSV `job_url_rocm` went 0 -> 308,793 and `job_url_cuda` 0 -> 354,344 non-empty.

Also applied to `ethanwee1/pytorch@main` (`fe21d4e`); the fork run (https://github.com/ethanwee1/pytorch/actions/runs/28189128743) confirms Bug 1. Note: the fork's `summarize_xml_testreports.py` predates develop's `_wf_run_id`->`job_url` feature, so Job IDs there populate once the fork syncs that from `develop` (Bug 2's fix is the `download_testlogs` regex, which is on the fork).
