### PR TITLE
Add biweekly scheduled develop IFU workflow

### DIFF
--- a/.github/workflows/develop_ifu_schedule.yml
+++ b/.github/workflows/develop_ifu_schedule.yml
@@ -1,0 +1,43 @@
+name: Scheduled develop IFU
+run-name: "Scheduled develop IFU sync with pytorch/pytorch main"
+
+# Dispatches pytorch_ifu.yml on a ~biweekly cadence to merge upstream main into develop.
+
+on:
+  schedule:
+    # 1st and 15th of each month at 09:00 UTC (~every 2 weeks)
+    - cron: '0 9 1,15 * *'
+  pull_request:
+    paths:
+      - '.github/workflows/develop_ifu_schedule.yml'
+      - '.github/workflows/pytorch_ifu.yml'
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: develop-ifu-schedule
+  cancel-in-progress: false
+
+jobs:
+  trigger-ifu:
+    if: github.repository == 'ROCm/pytorch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger pytorch_ifu.yml
+        env:
+          GH_TOKEN: ${{ secrets.IFU_GITHUB_TOKEN }}
+        run: |
+          gh workflow run pytorch_ifu.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref develop \
+            -f ifu_target_repo=ROCm/pytorch \
+            -f ifu_target_branch=develop \
+            -f ifu_source_repo=pytorch/pytorch \
+            -f ifu_source_branch=main
+
+      - name: Summarize
+        run: |
+          echo "::notice title=Scheduled develop IFU::Dispatched pytorch_ifu.yml for develop <- pytorch/pytorch main"

--- a/.github/workflows/pytorch_develop_ifu_schedule.yml
+++ b/.github/workflows/pytorch_develop_ifu_schedule.yml
@@ -1,4 +1,4 @@
-name: Scheduled develop IFU
+name: PyTorch develop branch IFU
 run-name: "Scheduled develop IFU sync with pytorch/pytorch main"
 
 # Dispatches pytorch_ifu.yml on a ~biweekly cadence to merge upstream main into develop.

--- a/.github/workflows/pytorch_develop_ifu_schedule.yml
+++ b/.github/workflows/pytorch_develop_ifu_schedule.yml
@@ -9,7 +9,7 @@ on:
     - cron: '0 9 1,15 * *'
   pull_request:
     paths:
-      - '.github/workflows/develop_ifu_schedule.yml'
+      - '.github/workflows/pytorch_develop_ifu_schedule.yml'
       - '.github/workflows/pytorch_ifu.yml'
   workflow_dispatch:
 

--- a/.github/workflows/pytorch_ifu.yml
+++ b/.github/workflows/pytorch_ifu.yml
@@ -11,7 +11,7 @@ on:
       ifu_target_branch:
         description: "Target branch for IFU"
         required: true
-        default: "rocm7.1_internal_testing"
+        default: "develop"
         type: string
       ifu_source_repo:
         description: "Source repo for IFU"


### PR DESCRIPTION
## Summary

Adds `develop_ifu_schedule.yml`, which runs on the 1st and 15th of each month (~every 2 weeks) and dispatches `pytorch_ifu.yml` to sync `develop` with `pytorch/pytorch` `main`.

Also updates `pytorch_ifu.yml` default target branch from `rocm7.1_internal_testing` to `develop`.

## Test plan

- [ ] Review workflow YAML
- [ ] After merge, manually dispatch `develop_ifu_schedule.yml` via workflow_dispatch to verify it triggers `pytorch_ifu.yml` with the expected inputs

Authored with assistance from Cursor

Made with [Cursor](https://cursor.com)