### PR TITLE
[ROCm] Use portable compiler names in cpp_extension compatibility tests (#188580)

### DIFF
--- a/test/cpp_extensions/libtorch_agn_2_10_extension/test_version_compatibility.py
+++ b/test/cpp_extensions/libtorch_agn_2_10_extension/test_version_compatibility.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from torch.testing._internal.common_utils import IS_WINDOWS, run_tests, TestCase
 from torch.utils.cpp_extension import (
     CUDA_HOME,
+    get_cxx_compiler,
     include_paths as torch_include_paths,
     ROCM_HOME,
 )
@@ -83,7 +84,7 @@ if not IS_WINDOWS:
             torch_version_2_9 = "0x0209000000000000"
 
             cmd = [
-                "g++",
+                get_cxx_compiler(),
                 "-c",
                 "-std=c++17",
                 f"-DTORCH_TARGET_VERSION={torch_version_2_9}",


### PR DESCRIPTION
Use util function to get compiler executable names instead of hardcoded `g++`

Pull Request resolved: https://github.com/pytorch/pytorch/pull/188580
Approved by: https://github.com/jeffdaily

(cherry picked from commit e6e48bfc0c3247f8ed5ee85d921150da0289de36)


Cherry-picked to release/2.9 branch via https://github.com/ROCm/pytorch/pull/3385

Cherry-picked to release/2.10 branch via https://github.com/ROCm/pytorch/pull/3386

Cherry-picked to release/2.12 branch via https://github.com/ROCm/pytorch/pull/3387