### PR TITLE
[release/2.12] Pin torchaudio to release/2.11 (interim unblock)

### DIFF
--- a/related_commits
+++ b/related_commits
@@ -1,3 +1,3 @@
 ubuntu|pytorch|apex|release/1.12.0|7e4aca37812b99e9c3e302d7d1d2e37ad6377f8c|https://github.com/ROCm/apex
 ubuntu|pytorch|torchvision|release/0.27|b3d5b111f54044b216013162706ca107aa7a4ec4|https://github.com/ROCm/vision
-ubuntu|pytorch|torchaudio|main|c0cbdb95674556cdff7266f2d44bb855f634cfde|https://github.com/pytorch/audio
+ubuntu|pytorch|torchaudio|release/2.11|34c52a67e8941bbd8e6adaca0eb0b9eabec11d78|https://github.com/pytorch/audio


### PR DESCRIPTION
https://amd-hub.atlassian.net/browse/ROCM-24803?focusedCommentId=500051

Interim unblock: pins torchaudio to the stable release/2.11 (2.11.0), which already builds and publishes on Windows, replacing the floating pytorch/audio main (2.11.0a0) pin.

The torchaudio 2.11.0.1 ROCm GPU port is tracked separately in ROCm/pytorch#3382 and ROCm/audio#16.
