### PR TITLE
[CI] Parity: include PR head SHA in run name for PR-triggered runs

### DIFF
--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -104,6 +104,9 @@ on:
 jobs:
   setup-matrix:
     runs-on: ubuntu-latest
+    # actions:write lets the step below rename this run via the REST API.
+    permissions:
+      actions: write
     outputs:
       arch-matrix: ${{ steps.parse.outputs.matrix }}
       prefix: ${{ steps.parse.outputs.prefix }}
@@ -132,6 +135,30 @@ jobs:
           PREFIX=$(echo "$PREFIX" | xargs)
           echo "prefix=$PREFIX" >> "$GITHUB_OUTPUT"
           echo "Artifact prefix: $PREFIX"
+
+      - name: Add commit SHA to run name (PR runs)
+        # run-name is evaluated once when the run starts, so it can't include the
+        # commit SHA that download_testlogs resolves later from the PR id. For
+        # PR-triggered runs we resolve the PR head SHA here and PATCH the run
+        # name so it reads "PR <id> · <sha> · <archs>". The PR->SHA lookup is
+        # intentionally duplicated (download_testlogs keeps its own copy so it
+        # can still be run standalone with just --pr_id).
+        if: ${{ inputs.pr_id && !inputs.baseline_sha && !inputs.csv_name }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_ID: ${{ inputs.pr_id }}
+          AUTOPARITY: ${{ inputs.auto_triggered && 'autoparity-' || '' }}
+          ARCH: ${{ inputs.arch }}
+        run: |
+          set -euo pipefail
+          SHA=$(gh api "repos/pytorch/pytorch/pulls/${PR_ID}" --jq '.head.sha' 2>/dev/null || true)
+          if [ -z "$SHA" ] || [ "$SHA" = "null" ]; then
+            echo "Could not resolve head SHA for PR ${PR_ID}; leaving run name unchanged."
+            exit 0
+          fi
+          NAME="${AUTOPARITY}PR ${PR_ID} · ${SHA} · ${ARCH}"
+          echo "Renaming run to: ${NAME}"
+          gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" -X PATCH -f name="${NAME}"
 
   generate-parity:
     needs: setup-matrix


### PR DESCRIPTION
## Summary

PR-triggered parity runs currently show only `PR <id> · <archs>` in the Actions run list (e.g. [this run](https://github.com/ROCm/pytorch/actions/runs/28547837578) reads `PR 187011 · mi200`), which makes it hard to tell which upstream commit was actually tested. This adds the resolved PR head SHA so the run name reads:

```
PR 187011 · 99cb7e843ec2c2afd680b3804dbf7d9c4498e4f5 · mi200
```

## How

`run-name` is evaluated once when the run starts and can only read the `inputs`/`github` contexts, so it cannot include the SHA that `download_testlogs` resolves later from `--pr_id`. Instead, `setup-matrix` now resolves the PR head SHA (`repos/pytorch/pytorch/pulls/<id>`) and PATCHes the run name via the REST API (`PATCH /repos/{owner}/{repo}/actions/runs/{run_id}`).

- Only applies to PR-triggered runs (`inputs.pr_id` set, no `baseline_sha`/`csv_name`); other run names are unchanged.
- The `pr_id → sha` lookup is **intentionally duplicated** here — `download_testlogs` keeps its own `get_latest_commit_sha` so it can still be run standalone with just `--pr_id`.
- Adds `actions: write` to the `setup-matrix` job (required for the run-name PATCH).
- No-ops gracefully (leaves the run name unchanged) if the SHA can't be resolved.

## Test plan

- [ ] Dispatch a PR-triggered parity run and confirm the run name updates to `PR <id> · <sha> · <archs>` shortly after start.
- [ ] Dispatch a SHA-triggered / autoparity run and confirm its run name is unchanged.
- Validation run: _to be linked_
