### PR TITLE
Bump apex to e97c6656 for release/2.10

### DIFF
--- a/related_commits
+++ b/related_commits
@@ -1,5 +1,5 @@
-ubuntu|pytorch|apex|release/1.10.0|57295015408696edf0d03ed09f6f17b42a0be2b6|https://github.com/ROCm/apex
-centos|pytorch|apex|release/1.10.0|57295015408696edf0d03ed09f6f17b42a0be2b6|https://github.com/ROCm/apex
+ubuntu|pytorch|apex|release/1.10.0|e97c6656fb57d03e5fa48ad417853aa497f123ce|https://github.com/ROCm/apex
+centos|pytorch|apex|release/1.10.0|e97c6656fb57d03e5fa48ad417853aa497f123ce|https://github.com/ROCm/apex
 ubuntu|pytorch|torchvision|release/0.25|8967bfbe3affba47ad52016f631b4309bc23ac0c|https://github.com/ROCm/vision
 centos|pytorch|torchvision|release/0.25|8967bfbe3affba47ad52016f631b4309bc23ac0c|https://github.com/ROCm/vision
 ubuntu|pytorch|torchdata|release/0.11|377e64c1be69a9be6649d14c9e3664070323e464|https://github.com/pytorch/data


### PR DESCRIPTION
## Summary
Updates the apex pinned commit in `related_commits` for the ROCm apex `release/1.10.0` branch, from `57295015408696edf0d03ed09f6f17b42a0be2b6` to `e97c6656fb57d03e5fa48ad417853aa497f123ce` (both ubuntu and centos lines).

This bump brings in a cherry-pick of ROCm/apex PR #334 (https://github.com/ROCm/apex/pull/334), which fixes non-contiguous inputs in the fused RoPE aiter backend by enforcing last-dim contiguity at the apex/aiter boundary (fixing the "rope_2d_bwd_impl requires all stride_d to be 1" crash on transposed inputs and broadcast/expanded gradients). This is purely a dependency pin update to pull in the fix, not a PyTorch code change.

## Test plan
- [ ] Metadata-only change to the `related_commits` pin file; CI validates apex builds against the new pin.

Authored with the assistance of Claude (Anthropic AI assistant).