### PR TITLE
Bump apex to ad1376f2 for release/2.12

### DIFF
--- a/related_commits
+++ b/related_commits
@@ -1,3 +1,3 @@
-ubuntu|pytorch|apex|release/1.12.0|7e4aca37812b99e9c3e302d7d1d2e37ad6377f8c|https://github.com/ROCm/apex
+ubuntu|pytorch|apex|release/1.12.0|ad1376f20dc0ac107040b6077c96aed52bd14298|https://github.com/ROCm/apex
 ubuntu|pytorch|torchvision|release/0.27|b3d5b111f54044b216013162706ca107aa7a4ec4|https://github.com/ROCm/vision
 ubuntu|pytorch|torchaudio|release/2.11|34c52a67e8941bbd8e6adaca0eb0b9eabec11d78|https://github.com/pytorch/audio


### PR DESCRIPTION
## Summary
Updates the apex pinned commit in `related_commits` for the ROCm apex `release/1.12.0` branch, from `7e4aca37812b99e9c3e302d7d1d2e37ad6377f8c` to `ad1376f20dc0ac107040b6077c96aed52bd14298`.

This bump brings in a cherry-pick of ROCm/apex PR #334 (https://github.com/ROCm/apex/pull/334), which fixes non-contiguous inputs in the fused RoPE aiter backend by enforcing last-dim contiguity at the apex/aiter boundary (fixing the "rope_2d_bwd_impl requires all stride_d to be 1" crash on transposed inputs and broadcast/expanded gradients). This is purely a dependency pin update to pull in the fix, not a PyTorch code change.

## Test plan
- [ ] Metadata-only change to the `related_commits` pin file; CI validates apex builds against the new pin.

Authored with the assistance of Claude (Anthropic AI assistant).