### PR TITLE
[CI] Parity: support sha=latest by resolving the latest green run on main

### DIFF
--- a/.automation_scripts/pytorch-unit-test-scripts/download_testlogs
+++ b/.automation_scripts/pytorch-unit-test-scripts/download_testlogs
@@ -654,17 +654,37 @@ def main():
     token = os.getenv('GITHUB_TOKEN', '...')
     global authentication_headers
     authentication_headers = {'Authorization': f'token {token}'}
-    if (args.pr_id and args.sha1) or (not args.pr_id and not args.sha1):
-        error_msg = "Error: Please provide either pr_id or sha!"
+    status = "success"
+    # An empty --sha1 (or the literal "latest") means "use the latest green
+    # run on main" rather than a specific commit. download_workflow_run()
+    # already resolves that when given no head_sha, so treat these as unset.
+    sha_is_latest = (not args.sha1) or (str(args.sha1).strip().lower() == "latest")
+    if args.pr_id and not sha_is_latest:
+        error_msg = "Error: Please provide either pr_id or sha (not both)!"
         print(error_msg)
         sys.exit(1)
     if args.pr_id:
         pr_id = args.pr_id
-        sha = get_latest_commit_sha(pr_id, token)        
-    else:
+        sha = get_latest_commit_sha(pr_id, token)
+    elif not sha_is_latest:
         sha = args.sha1
         pr_id = None
-    status = "success"
+    else:
+        # No pr_id and no explicit sha: resolve the latest green ROCm run on
+        # main and use its head commit as the target sha.
+        pr_id = None
+        print("No sha or pr_id given; resolving latest green ROCm run on main...")
+        latest_wf = download_workflow_run(
+            created=args.created,
+            max_pages=args.max_pages,
+            workflow=ROCmWorkflowNames["default"],
+            sha=None,
+            ignore_status=args.ignore_status,
+            status=status,
+            error_msg="Error: could not find a latest green ROCm run on main",
+        )
+        sha = latest_wf["head_sha"]
+        print(f"Resolved 'latest' to sha: {sha}")
     print(f"sha: {sha}")
 
     # When comparing two commits, prefix log filenames with short SHAs


### PR DESCRIPTION
## Summary

Dispatching a parity run with the `sha` input left empty / set to `latest` — the documented "latest green on main" option (e.g. the `baseline_sha` commit-vs-commit comparison in [this failing run](https://github.com/ROCm/pytorch/actions/runs/28552221495/job/84651949307#step:5:61)) — failed immediately with:

```
Running: python3 ./download_testlogs --arch mi200 ... --baseline_sha 4685e41c...
Error: Please provide either pr_id or sha!
```

`download_testlogs` required exactly one of `--pr_id` or `--sha1` and rejected the "neither" case, so `latest` was never actually supported despite the input hint saying "Leave empty for latest green on main."

## Fix

Treat an empty `--sha1` (or the literal string `latest`) as "resolve the latest green run on main":

- Look up the newest successful ROCm default-workflow run on `main` and use its head commit as the target `sha`. `download_workflow_run()` already does exactly this when called with no `head_sha`, so the change is small and self-contained.
- The `parity.yml` side already omits `--sha1` when the input is `latest`, so no workflow change is needed.
- Also clarifies the both-provided error message (`pr_id` and a real `sha`).

Kept entirely in `download_testlogs` so the script still works standalone (`./download_testlogs --arch mi300` now resolves latest instead of erroring).

## Validation (on fork)

- **Reproduces the reported scenario** (`baseline_sha` + empty sha, mi200): [run 28811245419](https://github.com/ethanwee1/pytorch/actions/runs/28811245419) — the guard no longer errors; the log now shows `No sha or pr_id given; resolving latest green ROCm run on main... Resolved 'latest' to sha: a09b29e7...`. (That run then stops later only because the arbitrary baseline commit's mi200 artifacts have expired — `HTTP 410 Gone` — which is unrelated to this change.)
- **Plain `latest` run** (no baseline, mi300): [run 28811384934](https://github.com/ethanwee1/pytorch/actions/runs/28811384934) — end-to-end latest-green resolution + parity.

## Test plan

- [x] `sha=latest` / empty no longer errors at the download step; resolves to a concrete head SHA.
- [x] `pr_id` path unchanged.
- [ ] Confirm plain-`latest` run produces a summary.

## Preview topology update

This branch is stacked on #3406 and now uses `preview` only, with the scheduled `rocm-preview` `mi350` prefix and 8/3/2 fallback matrix. Land #3406 first, then retarget this PR to `develop`.
