### PR TITLE
[release/2.11] Skip test_is_pinned_no_context on python 3.14 and above due to known behavior change

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -4147,6 +4147,7 @@ print(f"{{r1}}, {{r2}}")
     @unittest.skipIf(
         IS_WINDOWS, "test relies on fork; Windows multiprocessing uses spawn"
     )
+    @unittest.skipIf(sys.version_info >= (3, 14), "test fails on Python 3.14+")
     def test_is_pinned_no_context(self):
         test_script = """\
 import torch


### PR DESCRIPTION
Fix one of the failing test in ticket ROCM-27477
The test is already skipped in the rock, manually adding it here to ensure coverage outside of the rock. Will cherry pick to other release branches after merge.

Cherry-picked to release/2.10 branch via https://github.com/ROCm/pytorch/pull/3395

Cherry-picked to release/2.12 branch via https://github.com/ROCm/pytorch/pull/3396