### PR TITLE
[CI] Parity: add rocm-preview arch

### DIFF
--- a/.automation_scripts/pytorch-unit-test-scripts/download_testlogs
+++ b/.automation_scripts/pytorch-unit-test-scripts/download_testlogs
@@ -526,7 +526,7 @@ def parse_args():
     parser.add_argument('--no_rocm', action='store_true')
     parser.add_argument('--no_cuda', action='store_true')
     parser.add_argument('--pr_id', type=int, help='The pull request ID')
-    parser.add_argument('--arch', type=str, choices=['mi200', 'mi300', 'mi350', 'navi31', 'nightly'], default='mi350', help='ROCm GPU architecture (mi200, mi300, mi350, navi31, or nightly, default: mi350)')
+    parser.add_argument('--arch', type=str, choices=['mi200', 'mi300', 'mi350', 'navi31', 'nightly', 'preview'], default='mi350', help='ROCm GPU architecture (mi200, mi300, mi350, navi31, nightly, or preview, default: mi350)')
     parser.add_argument('--include_inductor_periodic', action='store_true', help='Also download inductor-periodic benchmark artifacts (into a separate directory, not included in parity CSV)')
     parser.add_argument('--baseline_sha', type=str, help='Baseline commit SHA to compare against. Downloads the same ROCm workflows for this commit into baseline_xml/.')
     return parser.parse_args()

--- a/.automation_scripts/pytorch-unit-test-scripts/parity_job_config.json
+++ b/.automation_scripts/pytorch-unit-test-scripts/parity_job_config.json
@@ -70,6 +70,13 @@
       "inductor": [{ "workflow": "rocm-nightly", "job_prefix": "linux-noble-rocm-nightly-py3.12-gfx942" }],
       "shard_counts": { "default": 6, "distributed": 3, "inductor": 2 },
       "checkrun_regex": "rocm-nightly.*/ test [(](default|distributed|inductor),"
+    },
+    "preview": {
+      "default": [{ "workflow": "rocm-preview", "job_prefix": "linux-noble-rocm-preview-py3.12-gfx942" }],
+      "distributed": [{ "workflow": "rocm-preview", "job_prefix": "linux-noble-rocm-preview-py3.12-gfx942" }],
+      "inductor": [{ "workflow": "rocm-preview", "job_prefix": "linux-noble-rocm-preview-py3.12-gfx942" }],
+      "shard_counts": { "default": 6, "distributed": 3, "inductor": 2 },
+      "checkrun_regex": "linux-noble-rocm-preview-py3.12-gfx942 / test [(](default|distributed|inductor),"
     }
   }
 }

--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -31,7 +31,7 @@ on:
         required: false
         type: string
       arch:
-        description: 'ROCm architectures, comma or space separated. Options: mi350, mi300, mi200, nightly, navi31. Example: "nightly, mi350" or "mi300"'
+        description: 'ROCm architectures, comma or space separated. Options: mi350, mi300, mi200, nightly, navi31, preview. Example: "nightly, mi350" or "preview"'
         required: false
         default: 'mi350, mi300, mi200'
         type: string


### PR DESCRIPTION
## Summary

Adds a **`preview`** ROCm arch to the parity tooling so we can run parity against the upstream **`rocm-preview`** lane — `linux-noble-rocm-preview-py3.12-gfx942` (gfx942), which runs the TheRock preview wheel (e.g. ROCm 7.14, cf. pytorch/pytorch#188593) via the `ciflow/rocm-preview` label.

## Changes

- `parity_job_config.json`: new `rocm.preview` entry. `default`/`distributed`/`inductor` all come from the single `rocm-preview` workflow (6/3/2 shards); `checkrun_regex` matches `linux-noble-rocm-preview-py3.12-gfx942 / test (...)`.
- `download_testlogs`: allow `--arch preview`.
- `parity.yml`: list `preview` as an arch option.

## Notes

`rocm-preview` is **ciflow-triggered** (runs when a PR carries the `ciflow/rocm-preview` label), not scheduled on `main`. So this arch is for **manual/on-demand** parity runs against a specific `rocm-preview` commit; it is intentionally **not** added to the auto-trigger scope. Run it as e.g. `arch = preview`, `sha = <a ciflow/rocm-preview commit>`.

## Test plan

- [ ] Manual parity run with `arch=preview` against a `rocm-preview` commit — validation run linked below.

## Validation

ROCm-only preview parity run (arch=preview, skip_cuda) on rocm-preview commit `51d3aca0`: https://github.com/ethanwee1/pytorch/actions/runs/28885011289 — resolves all rocm-preview default/distributed/inductor data. Note: a full preview-vs-CUDA report needs a preview SHA that also has a CUDA `trunk` run; ciflow-only preview commits lack it (a same-SHA run failed with "No trunk workflow run found for CUDA tests").
