### PR TITLE
[release/2.12][ROCm] - Prevent ck and mslk from building on unsupported HW (#183348)

### DIFF
--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -206,6 +206,32 @@ if(USE_FLASH_ATTENTION)
     message(STATUS "USE_CK_FLASH_ATTENTION is being deprecated. Please use USE_ROCM_CK_SDPA instead")
     caffe2_update_option(USE_ROCM_CK_SDPA ON)
   endif()
+  # Now building CK by default
+  if(USE_ROCM)
+    if(DEFINED ENV{USE_ROCM_CK_SDPA})
+        if(ENV{USE_ROCM_CK_SDPA} EQUAL 1)
+          caffe2_update_option(USE_ROCM_CK_SDPA ON)
+        endif()
+    else()
+      caffe2_update_option(USE_ROCM_CK_SDPA ON)
+    endif()
+    # CK SDPA only supports gfx942/gfx950. Auto-disable when none of those archs
+    # are in PYTORCH_ROCM_ARCH; otherwise the ck_sdpa target ends up with an
+    # empty HIP_ARCHITECTURES and CMake errors out.
+    if(USE_ROCM_CK_SDPA)
+      set(_have_ck_sdpa_arch FALSE)
+      foreach(ARCH gfx942 gfx950)
+        if("${ARCH}" IN_LIST PYTORCH_ROCM_ARCH)
+          set(_have_ck_sdpa_arch TRUE)
+          break()
+        endif()
+      endforeach()
+      if(NOT _have_ck_sdpa_arch)
+        message(STATUS "USE_ROCM_CK_SDPA disabled: PYTORCH_ROCM_ARCH (${PYTORCH_ROCM_ARCH}) has no MI3xx arch (gfx942/gfx950)")
+        caffe2_update_option(USE_ROCM_CK_SDPA OFF)
+      endif()
+    endif()
+  endif()
   if(USE_ROCM_CK_SDPA)
     if(DEFINED ENV{PYTORCH_ROCM_ARCH})
       list(LENGTH PYTORCH_ROCM_ARCH NUM_ARCHS)
@@ -407,6 +433,21 @@ IF(USE_MSLK)
     # Add MSLK include directories for gemm_torch.h
     list(APPEND ATen_CUDA_INCLUDE ${MSLK_INCLUDE})
   elseif(USE_ROCM)
+    # MSLK only supports gfx942/gfx950. Auto-disable when none of those archs
+    # are in PYTORCH_ROCM_ARCH; otherwise the mslk target ends up with an empty
+    # HIP_ARCHITECTURES and CMake errors out.
+    set(_mslk_hip_arches "")
+    foreach(ARCH gfx942 gfx950)
+      if(${ARCH} IN_LIST PYTORCH_ROCM_ARCH)
+        list(APPEND _mslk_hip_arches ${ARCH})
+      endif()
+    endforeach()
+  endif()
+  if(USE_MSLK AND USE_ROCM AND _mslk_hip_arches STREQUAL "")
+    message(STATUS "USE_MSLK disabled: PYTORCH_ROCM_ARCH (${PYTORCH_ROCM_ARCH}) has no MI3xx arch (gfx942/gfx950)")
+    caffe2_update_option(USE_MSLK OFF)
+  endif()
+  if(USE_MSLK AND USE_ROCM)
     # Path to vendored CK
     set(MSLK_CK_DIR "${MSLK_THIRD_PARTY}/composable_kernel")
     rocm_generate_ck_conf(
@@ -430,22 +471,11 @@ IF(USE_MSLK)
         list(PREPEND MSLK_EXTRA_HIPCC_FLAGS -mllvm -amdgpu-coerce-illegal-types=1)
       endif()
 
-    # Only compile for gfx942 and gfx950.
-    set(HIP_CLANG_FLAGS_ORIGINAL ${HIP_CLANG_FLAGS})
-    string(REGEX REPLACE "--offload-arch=[^ ]*" "" FILTERED_HIP_CLANG_FLAGS "${HIP_CLANG_FLAGS}")
-    foreach(ARCH gfx942 gfx950)
-      if(${ARCH} IN_LIST PYTORCH_ROCM_ARCH)
-        list(APPEND FILTERED_HIP_CLANG_FLAGS --offload-arch=${ARCH})
-      endif()
-    endforeach()
-    set(HIP_CLANG_FLAGS ${FILTERED_HIP_CLANG_FLAGS})
-
-    hip_add_library(
-      mslk STATIC
-      ${mslk_native_rocm_hip}
-      HIPCC_OPTIONS ${HIP_HCC_FLAGS} ${MSLK_EXTRA_HIPCC_FLAGS})
-    set(HIP_CLANG_FLAGS ${HIP_CLANG_FLAGS_ORIGINAL})
-    set_target_properties(mslk PROPERTIES POSITION_INDEPENDENT_CODE ON)
+    add_library(mslk STATIC ${mslk_native_rocm_hip})
+    set_target_properties(mslk PROPERTIES
+      POSITION_INDEPENDENT_CODE ON
+      HIP_ARCHITECTURES "${_mslk_hip_arches}")
+    target_compile_options(mslk PRIVATE $<$<COMPILE_LANGUAGE:HIP>:${MSLK_EXTRA_HIP_FLAGS}> ${HIP_CXX_FLAGS})
     target_compile_definitions(mslk PRIVATE MSLK_NO_EXTENDED_SHAPES)
 
     target_include_directories(mslk PRIVATE
@@ -462,7 +492,9 @@ IF(USE_MSLK)
   endif()
 
   # Ensure torch_cpu is built before mslk to avoid race conditions
-  add_dependencies(mslk torch_cpu)
+  if(TARGET mslk)
+    add_dependencies(mslk torch_cpu)
+  endif()
 endif()
 
 # XNNPACK

--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -202,9 +202,15 @@ file(GLOB native_flash_attn_api_cpp "native/transformers/cuda/flash_attn/flash_a
 file(GLOB flash_attention_hip_hip "native/transformers/hip/flash_attn/*.hip")
 # if USE_FLASH_ATTENTION is set, ensure CK instances get generated
 if(USE_FLASH_ATTENTION)
-  if("$ENV{USE_CK_FLASH_ATTENTION}" STREQUAL "1")
-    message(STATUS "USE_CK_FLASH_ATTENTION is being deprecated. Please use USE_ROCM_CK_SDPA instead")
-    caffe2_update_option(USE_ROCM_CK_SDPA ON)
+  # Now building CK by default
+  if(USE_ROCM)
+    if(DEFINED ENV{USE_ROCM_CK_SDPA})
+        if(ENV{USE_ROCM_CK_SDPA} EQUAL 1)
+          caffe2_update_option(USE_ROCM_CK_SDPA ON)
+        endif()
+    else()
+      caffe2_update_option(USE_ROCM_CK_SDPA ON)
+    endif()
   endif()
   # Now building CK by default
   if(USE_ROCM)

--- a/aten/src/ATen/native/transformers/hip/flash_attn/ck/CMakeLists.txt
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/ck/CMakeLists.txt
@@ -1,7 +1,7 @@
 # generate a list of kernels, but not actually emit files at config stage
 execute_process(
-  COMMAND python3 ${CMAKE_SOURCE_DIR}/third_party/composable_kernel/example/ck_tile/01_fmha/generate.py
-  --api fwd --receipt 4 --list_blobs ${CMAKE_CURRENT_LIST_DIR}/fwd_blob_list.txt
+  COMMAND python3 ${CMAKE_SOURCE_DIR}/third_party/composable_kernel/example/ck_tile/01_fmha/generate.py --optdim=32,64,128,256
+  --api fwd --receipt 4 --filter "*_lse*ntrload*nsink*" --list_blobs ${CMAKE_CURRENT_LIST_DIR}/fwd_blob_list.txt
   RESULT_VARIABLE ret
 )
 
@@ -10,8 +10,8 @@ if(ret AND NOT ret EQUAL 0)
 endif()
 
 execute_process(
-  COMMAND python3 ${CMAKE_SOURCE_DIR}/third_party/composable_kernel/example/ck_tile/01_fmha/generate.py
-  --api fwd_splitkv --receipt 4 --list_blobs ${CMAKE_CURRENT_LIST_DIR}/fwd_splitkv_blob_list.txt
+  COMMAND python3 ${CMAKE_SOURCE_DIR}/third_party/composable_kernel/example/ck_tile/01_fmha/generate.py --optdim=32,64,128,256
+  --api fwd_splitkv --receipt 4 --filter "*psdv*_lse*_nsquant*" --list_blobs ${CMAKE_CURRENT_LIST_DIR}/fwd_splitkv_blob_list.txt
   RESULT_VARIABLE ret
 )
 
@@ -20,8 +20,8 @@ if(ret AND NOT ret EQUAL 0)
 endif()
 
 execute_process(
-  COMMAND python3 ${CMAKE_SOURCE_DIR}/third_party/composable_kernel/example/ck_tile/01_fmha/generate.py
-  --api fwd_appendkv --receipt 4 --list_blobs ${CMAKE_CURRENT_LIST_DIR}/fwd_appendkv_blob_list.txt
+  COMMAND python3 ${CMAKE_SOURCE_DIR}/third_party/composable_kernel/example/ck_tile/01_fmha/generate.py --optdim=32,64,128,256
+  --api fwd_appendkv --receipt 4 --filter "*psskddv_*" --list_blobs ${CMAKE_CURRENT_LIST_DIR}/fwd_appendkv_blob_list.txt
   RESULT_VARIABLE ret
 )
 
@@ -31,7 +31,7 @@ endif()
 
 execute_process(
   COMMAND python3 ${CMAKE_SOURCE_DIR}/third_party/composable_kernel/example/ck_tile/01_fmha/generate.py
-  --api bwd --receipt 4 --list_blobs ${CMAKE_CURRENT_LIST_DIR}/bwd_blob_list.txt
+  --api bwd --optdim=32,64,128,256 --receipt 4 --filter "*psdv*@*psd*@*_pd1dv1*_ntrload*" --list_blobs ${CMAKE_CURRENT_LIST_DIR}/bwd_blob_list.txt
   RESULT_VARIABLE ret
 )
 
@@ -40,28 +40,28 @@ if(ret AND NOT ret EQUAL 0)
 endif()
 
 # Generate the files for both fwd, fwd_splitkv, fwd_appendkv, and bwd
-execute_process(COMMAND python3 ${CMAKE_SOURCE_DIR}/third_party/composable_kernel/example/ck_tile/01_fmha/generate.py --api fwd --receipt 4 --output_dir ${CMAKE_CURRENT_LIST_DIR}
+execute_process(COMMAND python3 ${CMAKE_SOURCE_DIR}/third_party/composable_kernel/example/ck_tile/01_fmha/generate.py --api fwd  --optdim=32,64,128,256 --receipt 4 --filter "*_lse*ntrload*nsink*" --output_dir ${CMAKE_CURRENT_LIST_DIR}
 )
 
 if(ret AND NOT ret EQUAL 0)
   message( FATAL_ERROR "CK Tile FMHA FAILED to generate FWD kernels.")
 endif()
 
-execute_process(COMMAND python3 ${CMAKE_SOURCE_DIR}/third_party/composable_kernel/example/ck_tile/01_fmha/generate.py --api fwd_splitkv --receipt 4 --output_dir ${CMAKE_CURRENT_LIST_DIR}
+execute_process(COMMAND python3 ${CMAKE_SOURCE_DIR}/third_party/composable_kernel/example/ck_tile/01_fmha/generate.py --api fwd_splitkv --optdim=32,64,128,256 --receipt 4 --filter "*psdv*_lse*_nsquant*" --output_dir ${CMAKE_CURRENT_LIST_DIR}
 )
 
 if(ret AND NOT ret EQUAL 0)
     message( FATAL_ERROR "CK Tile FMHA FAILED to generate FWD_SPLITKV kernels.")
 endif()
 
-execute_process(COMMAND python3 ${CMAKE_SOURCE_DIR}/third_party/composable_kernel/example/ck_tile/01_fmha/generate.py --api fwd_appendkv --receipt 4 --output_dir ${CMAKE_CURRENT_LIST_DIR}
+execute_process(COMMAND python3 ${CMAKE_SOURCE_DIR}/third_party/composable_kernel/example/ck_tile/01_fmha/generate.py --api fwd_appendkv --optdim=32,64,128,256 --receipt 4 --filter "*psskddv_*" --output_dir ${CMAKE_CURRENT_LIST_DIR}
 )
 
 if(ret AND NOT ret EQUAL 0)
     message( FATAL_ERROR "CK Tile FMHA FAILED to generate FWD_APPENDKV kernels.")
 endif()
 
-execute_process(COMMAND python3 ${CMAKE_SOURCE_DIR}/third_party/composable_kernel/example/ck_tile/01_fmha/generate.py --api bwd --receipt 4 --output_dir ${CMAKE_CURRENT_LIST_DIR}
+execute_process(COMMAND python3 ${CMAKE_SOURCE_DIR}/third_party/composable_kernel/example/ck_tile/01_fmha/generate.py --api bwd --optdim=32,64,128,256 --receipt 4 --filter "*psdv*@*psd*@*_pd1dv1*_ntrload*" --output_dir ${CMAKE_CURRENT_LIST_DIR}
   RESULT_VARIABLE ret
 )
 

--- a/aten/src/ATen/native/transformers/hip/flash_attn/ck/fav_v3/CMakeLists.txt
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/ck/fav_v3/CMakeLists.txt
@@ -1,14 +1,38 @@
 include(CMakePrintHelpers)
 
-# Generate AITER/CK Asm code
+# Create an isolated venv for codegen.py which requires pandas>=2.1.0 (for
+# the "future.no_silent_downcasting" option).  This avoids polluting the CI /
+# host Python environment while still satisfying the dependency.
+set(CODEGEN_VENV_DIR "${CMAKE_CURRENT_BINARY_DIR}/_codegen_venv")
+
+if(NOT EXISTS "${CODEGEN_VENV_DIR}/bin/python3")
+    message(STATUS "Creating isolated codegen venv at ${CODEGEN_VENV_DIR}")
+    execute_process(
+        COMMAND python3 -m venv "${CODEGEN_VENV_DIR}"
+        RESULT_VARIABLE ret
+    )
+    if(ret AND NOT ret EQUAL 0)
+        message(FATAL_ERROR "Failed to create codegen venv")
+    endif()
+
+    execute_process(
+        COMMAND "${CODEGEN_VENV_DIR}/bin/pip" install --quiet "pandas>=2.1.0,<=2.3.3" numpy
+        RESULT_VARIABLE ret
+    )
+    if(ret AND NOT ret EQUAL 0)
+        message(FATAL_ERROR "Failed to install pandas/numpy into codegen venv")
+    endif()
+endif()
+
+# Generate AITER/CK Asm code (using the venv python so pandas is new enough)
 execute_process(
     COMMAND ${CMAKE_COMMAND} -E env "AITER_GPU_ARCHS=gfx942;gfx950"
-            python3 ${CMAKE_SOURCE_DIR}/third_party/aiter/hsa/codegen.py -m fmha_v3_bwd --output_dir ${CMAKE_CURRENT_LIST_DIR}
+            "${CODEGEN_VENV_DIR}/bin/python3" ${CMAKE_SOURCE_DIR}/third_party/aiter/hsa/codegen.py -m fmha_v3_bwd --output_dir ${CMAKE_CURRENT_LIST_DIR}
     RESULT_VARIABLE ret
 )
 
 if(ret AND NOT ret EQUAL 0)
-    message( FATAL_ERROR "Failed to generate FAv3 CK Kernels")
+    message(FATAL_ERROR "Failed to generate FAv3 CK Kernels")
 endif()
 
 execute_process(COMMAND bash -c "cp ${CMAKE_SOURCE_DIR}/third_party/aiter/csrc/cpp_itfs/mha_bwd.cu ${CMAKE_CURRENT_LIST_DIR}/mha_bwd.hip")

--- a/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_fwd_ck.hip
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_fwd_ck.hip
@@ -6,9 +6,100 @@
 #include <fmha_fwd.hpp>
 #include <mask.hpp>
 
+#include <cstdio>
+
+namespace {
+/* Debug traces. Comment in to aid in debug of 'Invalid argument to fmha_fwd' error
+const char* mask_enum_str(mask_enum m) {
+    switch (m) {
+        case mask_enum::no_mask:          return "no_mask";
+        case mask_enum::mask_top_left:    return "mask_top_left";
+        case mask_enum::mask_bottom_right:return "mask_bottom_right";
+        case mask_enum::window_generic:   return "window_generic";
+        default:                          return "unknown";
+    }
+}
+
+const char* bias_enum_str(bias_enum b) {
+    switch (b) {
+        case bias_enum::no_bias:          return "no_bias";
+        case bias_enum::elementwise_bias: return "elementwise_bias";
+        case bias_enum::alibi:            return "alibi";
+        default:                          return "unknown";
+    }
+}
+
+const char* qscale_enum_str(quant_scale_enum q) {
+    switch (q) {
+        case quant_scale_enum::no_scale:      return "no_scale";
+        case quant_scale_enum::pertensor:      return "pertensor";
+        case quant_scale_enum::blockscale:     return "blockscale";
+        case quant_scale_enum::kv_blockscale:  return "kv_blockscale";
+        default:                               return "unknown";
+    }
+}
+
+void dump_fmha_fwd_kernel_selection_params(const fmha_fwd_traits& t,
+                                           const fmha_fwd_args& a) {
+    std::printf("=== fmha_fwd kernel selection params ===\n");
+    std::printf("--- traits ---\n");
+    std::printf("  data_type          : %s\n",  t.data_type.c_str());
+    std::printf("  hdim_q             : %d\n",  t.hdim_q);
+    std::printf("  hdim_v             : %d\n",  t.hdim_v);
+    std::printf("  is_group_mode      : %s\n",  t.is_group_mode      ? "true" : "false");
+    std::printf("  is_v_rowmajor      : %s\n",  t.is_v_rowmajor      ? "true" : "false");
+    std::printf("  has_logits_soft_cap: %s\n",  t.has_logits_soft_cap ? "true" : "false");
+    std::printf("  mask_type          : %s (%d)\n", mask_enum_str(t.mask_type),
+                static_cast<int>(t.mask_type));
+    std::printf("  bias_type          : %s (%d)\n", bias_enum_str(t.bias_type),
+                static_cast<int>(t.bias_type));
+    std::printf("  has_lse            : %s\n",  t.has_lse             ? "true" : "false");
+    std::printf("  has_dropout        : %s\n",  t.has_dropout         ? "true" : "false");
+    std::printf("  qscale_type        : %s (%d)\n", qscale_enum_str(t.qscale_type),
+                static_cast<int>(t.qscale_type));
+    std::printf("  skip_min_seqlen_q  : %s\n",  t.skip_min_seqlen_q  ? "true" : "false");
+    std::printf("  has_sink           : %s\n",  t.has_sink            ? "true" : "false");
+    std::printf("--- args ---\n");
+    std::printf("  hdim_q             : %d\n",  static_cast<int>(a.hdim_q));
+    std::printf("  hdim_v             : %d\n",  static_cast<int>(a.hdim_v));
+    std::printf("  seqlen_k           : %d\n",  static_cast<int>(a.seqlen_k));
+    std::printf("  cu_seqlen_k_ptr    : %p\n",  a.cu_seqlen_k_ptr);
+    std::printf("  batch              : %d\n",  static_cast<int>(a.batch));
+    std::printf("  nhead_q            : %d\n",  static_cast<int>(a.nhead_q));
+    std::printf("  max_seqlen_q       : %d\n",  static_cast<int>(a.max_seqlen_q));
+    std::printf("========================================\n");
+    std::fflush(stdout);
+}
+*/
+} // anonymous namespace
 
 namespace pytorch_flash {
 
+// SFINAE trait to detect block-scale quantization fields in fmha_fwd_args.
+// Newer versions of composable_kernel add these fields; older versions don't.
+// This lets the PyTorch integration layer work with either version.
+template <typename T, typename = void>
+struct has_fmha_block_scale_fields : std::false_type {};
+
+template <typename T>
+struct has_fmha_block_scale_fields<T,
+    std::void_t<decltype(std::declval<T&>().block_scale_size_q)>> : std::true_type {};
+
+template <typename Args>
+void set_fmha_fwd_block_scale_fields([[maybe_unused]] Args& args) {
+    if constexpr (has_fmha_block_scale_fields<Args>::value) {
+        args.block_scale_seqstart_q_ptr = nullptr;
+        args.block_scale_seqstart_k_ptr = nullptr;
+        args.nhead_stride_q_descale = 0;
+        args.nhead_stride_k_descale = 0;
+        args.nhead_stride_v_descale = 0;
+        args.batch_stride_q_descale = 0;
+        args.batch_stride_k_descale = 0;
+        args.batch_stride_v_descale = 0;
+        args.block_scale_size_q = 0;
+        args.block_scale_size_kv = 0;
+    }
+}
 
 fmha_fwd_traits get_ck_fmha_fwd_traits(const mask_info &mask,
                                        std::string dtype,
@@ -96,61 +187,58 @@ fmha_fwd_args get_ck_fmha_fwd_args(bool has_lse,
         nhead_stride_bias = a_b.stride(1);
         batch_stride_bias = a_b.stride(0);
     }
-    return fmha_fwd_args{q.data_ptr(),
-                         k.data_ptr(),
-                         v.data_ptr(),
-                         attn_bias_ptr, // bias
-                         nullptr, // q_descale_ptr
-                         nullptr, // k_descale_ptr
-                         nullptr, // v_descale_ptr
-                         has_dropout_randval ? dropout_randval.data_ptr() : nullptr,
-                         has_lse ? softmax_lse.data_ptr() : nullptr,
-                         out.data_ptr(),
-                         nullptr, // seqstart_q
-                         nullptr, // seqstart_k
-                         nullptr, // seqlen_q_ptr
-                         nullptr, // seqlen_k_ptr
-                         nullptr, // cu_seqlen_q_ptr
-                         nullptr, // cu_seqlen_k_ptr
-                         nullptr, // sink_ptr
-                         seqlen_q,
-                         seqlen_k,
-                         b,
-                         seqlen_q,                          // max_seqlen_q
-                         d,                                 // hdim_q
-                         d,                                 // hdim_v
-                         h,                                 // nhead
-                         h_k,                               // nhead_k
-                         softmax_scale,                     // scale_s
-                         0.0f,                              // logits_soft_cap
-                         stride_q,
-                         stride_k,
-                         stride_v,
-                         stride_attn_bias,
-                         stride_randval,
-                         stride_o,
-                         nhead_stride_q,
-                         nhead_stride_k,
-                         nhead_stride_v,
-                         nhead_stride_bias,                 // nhead_stride_bias
-                         nhead_stride_randval,
-                         nhead_stride_lse,
-                         nhead_stride_o,
-                         batch_stride_q,
-                         batch_stride_k,
-                         batch_stride_v,
-                         batch_stride_bias,                 // batch_stride_bias
-                         batch_stride_randval,
-                         batch_stride_lse,
-                         batch_stride_o,
-                         mask.left,
-                         mask.right,
-                         0,                                 // sink_size
-                         static_cast<ck_tile::index_t>(mask.type),
-                         -1,                                // min_seqlen_q
-                         p_dropout,
-                         has_dropout_randval,
-                         drop_seed_offset};
+    fmha_fwd_args args{};
+    args.q_ptr = q.data_ptr();
+    args.k_ptr = k.data_ptr();
+    args.v_ptr = v.data_ptr();
+    args.bias_ptr = attn_bias_ptr;
+    args.q_descale_ptr = nullptr;
+    args.k_descale_ptr = nullptr;
+    args.v_descale_ptr = nullptr;
+    args.rand_val_ptr = has_dropout_randval ? dropout_randval.data_ptr() : nullptr;
+    args.lse_ptr = has_lse ? softmax_lse.data_ptr() : nullptr;
+    args.o_ptr = out.data_ptr();
+    args.sink_ptr = nullptr;
+    args.seqlen_q = seqlen_q;
+    args.seqlen_k = seqlen_k;
+    args.batch = b;
+    args.max_seqlen_q = seqlen_q;
+    args.hdim_q = d;
+    args.hdim_v = d;
+    args.nhead_q = h;
+    args.nhead_k = h_k;
+    args.scale_s = softmax_scale;
+    args.logits_soft_cap = 0.0f;
+    args.stride_q = stride_q;
+    args.stride_k = stride_k;
+    args.stride_v = stride_v;
+    args.stride_bias = stride_attn_bias;
+    args.stride_randval = stride_randval;
+    args.stride_o = stride_o;
+    args.nhead_stride_q = nhead_stride_q;
+    args.nhead_stride_k = nhead_stride_k;
+    args.nhead_stride_v = nhead_stride_v;
+    args.nhead_stride_bias = nhead_stride_bias;
+    args.nhead_stride_randval = nhead_stride_randval;
+    args.nhead_stride_lse = nhead_stride_lse;
+    args.nhead_stride_o = nhead_stride_o;
+    args.batch_stride_q = batch_stride_q;
+    args.batch_stride_k = batch_stride_k;
+    args.batch_stride_v = batch_stride_v;
+    args.batch_stride_bias = batch_stride_bias;
+    args.batch_stride_randval = batch_stride_randval;
+    args.batch_stride_lse = batch_stride_lse;
+    args.batch_stride_o = batch_stride_o;
+    args.window_size_left = mask.left;
+    args.window_size_right = mask.right;
+    args.sink_size = 0;
+    args.mask_type = static_cast<ck_tile::index_t>(mask.type);
+    args.min_seqlen_q = -1;
+    args.p_drop = p_dropout;
+    args.s_randval = has_dropout_randval;
+    args.drop_seed_offset = drop_seed_offset;
+    set_fmha_fwd_block_scale_fields(args);
+    return args;
 }
 
 std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor>

--- a/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_varlen_fwd_ck.hip
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_varlen_fwd_ck.hip
@@ -8,6 +8,32 @@
 
 namespace pytorch_flash {
 
+// SFINAE trait to detect block-scale quantization fields in fmha_fwd_args.
+// Newer versions of composable_kernel add these fields; older versions don't.
+// This lets the PyTorch integration layer work with either version.
+template <typename T, typename = void>
+struct has_fmha_block_scale_fields : std::false_type {};
+
+template <typename T>
+struct has_fmha_block_scale_fields<T,
+    std::void_t<decltype(std::declval<T&>().block_scale_size_q)>> : std::true_type {};
+
+template <typename Args>
+void set_fmha_fwd_block_scale_fields([[maybe_unused]] Args& args) {
+    if constexpr (has_fmha_block_scale_fields<Args>::value) {
+        args.block_scale_seqstart_q_ptr = nullptr;
+        args.block_scale_seqstart_k_ptr = nullptr;
+        args.nhead_stride_q_descale = 0;
+        args.nhead_stride_k_descale = 0;
+        args.nhead_stride_v_descale = 0;
+        args.batch_stride_q_descale = 0;
+        args.batch_stride_k_descale = 0;
+        args.batch_stride_v_descale = 0;
+        args.block_scale_size_q = 0;
+        args.block_scale_size_kv = 0;
+    }
+}
+
 fmha_fwd_traits get_ck_fmha_varlen_fwd_traits(const mask_info &mask,
                                               std::string dtype,
                                               int head_size,
@@ -97,61 +123,60 @@ fmha_fwd_args get_ck_fmha_varlen_fwd_args(bool has_lse,
         stride_attn_bias = a_b.stride(0);
     }
 
-    return fmha_fwd_args{q.data_ptr(),
-                         k.data_ptr(),
-                         v.data_ptr(),
-                         attn_bias_ptr, // bias
-                         nullptr, // q_descale_ptr
-                         nullptr, // k_descale_ptr
-                         nullptr, // v_descale_ptr
-                         has_dropout_randval ? dropout_randval.data_ptr() : nullptr,
-                         has_lse ? softmax_lse.data_ptr() : nullptr,
-                         out.data_ptr(),
-                         seqlens_q.data_ptr(), // seqstart_q
-                         seqlens_k.data_ptr(), // seqstart_k
-                         nullptr, // seqlen_q_ptr
-                         nullptr, // seqlen_k_ptr
-                         nullptr, // cu_seqlen_q_ptr
-                         nullptr, // cu_seqlen_k_ptr
-                         nullptr, // sink_ptr
-                         total_q,
-                         total_k,
-                         b,
-                         max_seqlen_q,
-                         d,             // hdim_q
-                         d,             // hdim_v
-                         h,             // nhead
-                         h_k,           // nhead_k
-                         softmax_scale, // scale_s
-                         0.0f,          // logits_soft_cap
-                         stride_q,
-                         stride_k,
-                         stride_v,
-                         stride_attn_bias,
-                         stride_randval,
-                         stride_o,
-                         nhead_stride_q,
-                         nhead_stride_k,
-                         nhead_stride_v,
-                         0, // nhead_stride_bias, FA without bias
-                         nhead_stride_randval,
-                         nhead_stride_lse,
-                         nhead_stride_o,
-                         batch_stride_q,
-                         batch_stride_k,
-                         batch_stride_v,
-                         0, // batch_stride_bias, FA without bias
-                         batch_stride_randval,
-                         batch_stride_lse,
-                         batch_stride_o,
-                         mask.left,
-                         mask.right,
-                         0,             // sink_size
-                         static_cast<ck_tile::index_t>(mask.type),
-                         -1,                                // min_seqlen_q
-                         p_dropout,
-                         has_dropout_randval,
-                         drop_seed_offset};
+    fmha_fwd_args args{};
+    args.q_ptr = q.data_ptr();
+    args.k_ptr = k.data_ptr();
+    args.v_ptr = v.data_ptr();
+    args.bias_ptr = attn_bias_ptr;
+    args.q_descale_ptr = nullptr;
+    args.k_descale_ptr = nullptr;
+    args.v_descale_ptr = nullptr;
+    args.rand_val_ptr = has_dropout_randval ? dropout_randval.data_ptr() : nullptr;
+    args.lse_ptr = has_lse ? softmax_lse.data_ptr() : nullptr;
+    args.o_ptr = out.data_ptr();
+    args.seqstart_q_ptr = seqlens_q.data_ptr();
+    args.seqstart_k_ptr = seqlens_k.data_ptr();
+    args.sink_ptr = nullptr;
+    args.seqlen_q = total_q;
+    args.seqlen_k = total_k;
+    args.batch = b;
+    args.max_seqlen_q = max_seqlen_q;
+    args.hdim_q = d;
+    args.hdim_v = d;
+    args.nhead_q = h;
+    args.nhead_k = h_k;
+    args.scale_s = softmax_scale;
+    args.logits_soft_cap = 0.0f;
+    args.stride_q = stride_q;
+    args.stride_k = stride_k;
+    args.stride_v = stride_v;
+    args.stride_bias = stride_attn_bias;
+    args.stride_randval = stride_randval;
+    args.stride_o = stride_o;
+    args.nhead_stride_q = nhead_stride_q;
+    args.nhead_stride_k = nhead_stride_k;
+    args.nhead_stride_v = nhead_stride_v;
+    args.nhead_stride_bias = 0;
+    args.nhead_stride_randval = nhead_stride_randval;
+    args.nhead_stride_lse = nhead_stride_lse;
+    args.nhead_stride_o = nhead_stride_o;
+    args.batch_stride_q = batch_stride_q;
+    args.batch_stride_k = batch_stride_k;
+    args.batch_stride_v = batch_stride_v;
+    args.batch_stride_bias = 0;
+    args.batch_stride_randval = batch_stride_randval;
+    args.batch_stride_lse = batch_stride_lse;
+    args.batch_stride_o = batch_stride_o;
+    args.window_size_left = mask.left;
+    args.window_size_right = mask.right;
+    args.sink_size = 0;
+    args.mask_type = static_cast<ck_tile::index_t>(mask.type);
+    args.min_seqlen_q = -1;
+    args.p_drop = p_dropout;
+    args.s_randval = has_dropout_randval;
+    args.drop_seed_offset = drop_seed_offset;
+    set_fmha_fwd_block_scale_fields(args);
+    return args;
 }
 
 std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor>


### PR DESCRIPTION
Filter ck and mslk build on ROCm

Validated locally and these changes are compiling fine. Required for gfx1250 arch filtering
