### PR TITLE
[release/2.12] [ROCm] Fixed memory errors in SymmetricMemory caused by repeated call…

### DIFF
--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryUtils.cpp
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryUtils.cpp
@@ -251,12 +251,6 @@ void map_block(
       0,
       reinterpret_cast<hipMemGenericAllocationHandle_t>(handle),
       0ULL));
-  C10_CUDA_CHECK(hipMemMap(
-      *ptr,
-      size,
-      0,
-      reinterpret_cast<hipMemGenericAllocationHandle_t>(handle),
-      0ULL));
 
   hipMemAccessDesc desc;
   desc.location.type = hipMemLocationTypeDevice;


### PR DESCRIPTION
This is a cherry-pick of https://github.com/pytorch/pytorch/pull/188673

Removing a repeated call of hipMemMap which is causing the errors in SymmetricMemory.

Cherry-picked to release/2.11 branch via https://github.com/ROCm/pytorch/pull/3404

Cherry-picked to release/2.10 branch via https://github.com/ROCm/pytorch/pull/3405