### PR TITLE
[CI] Parity: replace ROCm nightly with scheduled Preview

### DIFF
--- a/.automation_scripts/pytorch-unit-test-scripts/download_testlogs
+++ b/.automation_scripts/pytorch-unit-test-scripts/download_testlogs
@@ -526,7 +526,7 @@ def parse_args():
     parser.add_argument('--no_rocm', action='store_true')
     parser.add_argument('--no_cuda', action='store_true')
     parser.add_argument('--pr_id', type=int, help='The pull request ID')
-    parser.add_argument('--arch', type=str, choices=['mi200', 'mi300', 'mi350', 'navi31', 'nightly'], default='mi350', help='ROCm GPU architecture (mi200, mi300, mi350, navi31, or nightly, default: mi350)')
+    parser.add_argument('--arch', type=str, choices=['mi200', 'mi300', 'mi350', 'navi31', 'nightly', 'preview'], default='mi350', help='ROCm GPU architecture (mi200, mi300, mi350, navi31, nightly, or preview, default: mi350)')
     parser.add_argument('--include_inductor_periodic', action='store_true', help='Also download inductor-periodic benchmark artifacts (into a separate directory, not included in parity CSV)')
     parser.add_argument('--baseline_sha', type=str, help='Baseline commit SHA to compare against. Downloads the same ROCm workflows for this commit into baseline_xml/.')
     return parser.parse_args()

--- a/.automation_scripts/pytorch-unit-test-scripts/download_testlogs
+++ b/.automation_scripts/pytorch-unit-test-scripts/download_testlogs
@@ -526,7 +526,7 @@ def parse_args():
     parser.add_argument('--no_rocm', action='store_true')
     parser.add_argument('--no_cuda', action='store_true')
     parser.add_argument('--pr_id', type=int, help='The pull request ID')
-    parser.add_argument('--arch', type=str, choices=['mi200', 'mi300', 'mi350', 'navi31', 'nightly', 'preview'], default='mi350', help='ROCm GPU architecture (mi200, mi300, mi350, navi31, nightly, or preview, default: mi350)')
+    parser.add_argument('--arch', type=str, choices=['mi200', 'mi300', 'mi350', 'navi31', 'preview'], default='mi350', help='ROCm GPU architecture (mi200, mi300, mi350, navi31, or preview, default: mi350)')
     parser.add_argument('--include_inductor_periodic', action='store_true', help='Also download inductor-periodic benchmark artifacts (into a separate directory, not included in parity CSV)')
     parser.add_argument('--baseline_sha', type=str, help='Baseline commit SHA to compare against. Downloads the same ROCm workflows for this commit into baseline_xml/.')
     return parser.parse_args()
@@ -615,7 +615,7 @@ def main():
     # in, job-name prefixes, shard counts and fallbacks) comes from
     # parity_job_config.json - see PARITY_CONFIG at the top of this file.
     global ROCmWorkflowNames
-    arch = args.arch  # 'mi200', 'mi300', 'mi350', 'navi31', or 'nightly'
+    arch = args.arch  # 'mi200', 'mi300', 'mi350', 'navi31', or 'preview'
     arch_config = PARITY_CONFIG["rocm"][arch]
 
     ROCmWorkflowNames, rocm_job_prefix, arch_fallbacks = parity_config_views(arch_config)

--- a/.automation_scripts/pytorch-unit-test-scripts/parity_job_config.json
+++ b/.automation_scripts/pytorch-unit-test-scripts/parity_job_config.json
@@ -70,6 +70,13 @@
       "inductor": [{ "workflow": "rocm-nightly", "job_prefix": "linux-noble-rocm-nightly-py3.12-gfx942" }],
       "shard_counts": { "default": 6, "distributed": 3, "inductor": 2 },
       "checkrun_regex": "rocm-nightly.*/ test [(](default|distributed|inductor),"
+    },
+    "preview": {
+      "default": [{ "workflow": "rocm-preview", "job_prefix": "linux-noble-rocm-preview-py3.12-gfx942" }],
+      "distributed": [{ "workflow": "rocm-preview", "job_prefix": "linux-noble-rocm-preview-py3.12-gfx942" }],
+      "inductor": [{ "workflow": "rocm-preview", "job_prefix": "linux-noble-rocm-preview-py3.12-gfx942" }],
+      "shard_counts": { "default": 6, "distributed": 3, "inductor": 2 },
+      "checkrun_regex": "linux-noble-rocm-preview-py3.12-gfx942 / test [(](default|distributed|inductor),"
     }
   }
 }

--- a/.automation_scripts/pytorch-unit-test-scripts/parity_job_config.json
+++ b/.automation_scripts/pytorch-unit-test-scripts/parity_job_config.json
@@ -64,19 +64,12 @@
       "shard_counts": { "default": 2, "distributed": 3, "inductor": 2 },
       "checkrun_regex": "rocm.*navi31.*/ test [(]default,"
     },
-    "nightly": {
-      "default": [{ "workflow": "rocm-nightly", "job_prefix": "linux-noble-rocm-nightly-py3.12-gfx942" }],
-      "distributed": [{ "workflow": "rocm-nightly", "job_prefix": "linux-noble-rocm-nightly-py3.12-gfx942" }],
-      "inductor": [{ "workflow": "rocm-nightly", "job_prefix": "linux-noble-rocm-nightly-py3.12-gfx942" }],
-      "shard_counts": { "default": 6, "distributed": 3, "inductor": 2 },
-      "checkrun_regex": "rocm-nightly.*/ test [(](default|distributed|inductor),"
-    },
     "preview": {
-      "default": [{ "workflow": "rocm-preview", "job_prefix": "linux-noble-rocm-preview-py3.12-gfx942" }],
-      "distributed": [{ "workflow": "rocm-preview", "job_prefix": "linux-noble-rocm-preview-py3.12-gfx942" }],
-      "inductor": [{ "workflow": "rocm-preview", "job_prefix": "linux-noble-rocm-preview-py3.12-gfx942" }],
-      "shard_counts": { "default": 6, "distributed": 3, "inductor": 2 },
-      "checkrun_regex": "linux-noble-rocm-preview-py3.12-gfx942 / test [(](default|distributed|inductor),"
+      "default": [{ "workflow": "rocm-preview", "job_prefix": "linux-noble-rocm-preview-py3.12-mi350" }],
+      "distributed": [{ "workflow": "rocm-preview", "job_prefix": "linux-noble-rocm-preview-py3.12-mi350" }],
+      "inductor": [{ "workflow": "rocm-preview", "job_prefix": "linux-noble-rocm-preview-py3.12-mi350" }],
+      "shard_counts": { "default": 8, "distributed": 3, "inductor": 2 },
+      "checkrun_regex": "linux-noble-rocm-preview-py3[.]12-mi350 / test [(](default|distributed|inductor),"
     }
   }
 }

--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -31,7 +31,7 @@ on:
         required: false
         type: string
       arch:
-        description: 'ROCm architectures, comma or space separated. Options: mi350, mi300, mi200, nightly, navi31. Example: "nightly, mi350" or "mi300"'
+        description: 'ROCm architectures, comma or space separated. Options: mi350, mi300, mi200, nightly, navi31, preview. Example: "nightly, mi350" or "preview"'
         required: false
         default: 'mi350, mi300, mi200'
         type: string

--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -31,7 +31,7 @@ on:
         required: false
         type: string
       arch:
-        description: 'ROCm architectures, comma or space separated. Options: mi350, mi300, mi200, nightly, navi31, preview. Example: "nightly, mi350" or "preview"'
+        description: 'ROCm architectures, comma or space separated. Options: mi350, mi300, mi200, navi31, preview. Example: "preview, mi350" or "mi300"'
         required: false
         default: 'mi350, mi300, mi200'
         type: string
@@ -72,7 +72,7 @@ on:
         type: boolean
       # summarize_xml_testreports flags
       set1_name:
-        description: 'Label for ROCm columns in output CSV. Examples: rocm, nightly, mi300. Default: rocm'
+        description: 'Label for ROCm columns in output CSV. Examples: rocm, preview, mi300. Default: rocm'
         required: false
         default: 'rocm'
         type: string


### PR DESCRIPTION
## Summary

Replaces the retired `nightly` parity topology with the current daily scheduled `rocm-preview` lane.

## Changes

- `preview` is the only Preview CLI/config key; `nightly` is removed.
- All configs use `rocm-preview` and `linux-noble-rocm-preview-py3.12-mi350`.
- Fallback shard metadata matches the live matrix: 8 default, 3 distributed, 2 inductor.
- The check-run regex matches current Preview test jobs.
- `parity.yml` documents `preview` instead of `nightly`.

Auto-trigger discovery is implemented in #3397 so this PR remains focused on downloader/config support.

## Validation

- [x] JSON parses
- [x] `download_testlogs` compiles
- [x] `parity.yml` parses as YAML
- [x] Configuration matches all 13 test shards in daily scheduled [pytorch/pytorch run 31344407133](https://github.com/pytorch/pytorch/actions/runs/31344407133)
- [ ] End-to-end Preview parity dispatch after #3397 is updated

## Dependencies

Land before or with #3397. Downloader topology discovery in #3535 should consume this configuration without hardcoded shard dependence.