### PR TITLE
[CI] Parity: classify conv2d_backward ROCm skip as PT2.0 - Convolution

### DIFF
--- a/.automation_scripts/pytorch-unit-test-scripts/auto_classify_skip_reasons.py
+++ b/.automation_scripts/pytorch-unit-test-scripts/auto_classify_skip_reasons.py
@@ -46,6 +46,15 @@ RULES = [
     # TIER 1: High-specificity combined rules (message + file/class)
     # ==================================================================
 
+    # --- PT2.0 - Convolution: conv2d backward parametrized skipped on ROCm ---
+    # skipIfRocmArch(...) skips test_conv2d_backward_parametrized (see upstream
+    # #188671, CI timeout). Categorize it as a convolution issue rather than the
+    # generic Misc "test skipped on ('gfx...')" bucket below. Must precede that
+    # Misc arch rule.
+    {"reason": "PT2.0 - Convolution",
+     "msg": r"test skipped on \('gfx",
+     "name": r"(?i)conv2d_backward"},
+
     # --- bfloat16_SDPA_ME: dropout mask in test_transformers with bfloat16 in TEST NAME ---
     # Must be before generic SDPA_ME rule
     {"reason": "bfloat16_SDPA_ME",

--- a/.automation_scripts/pytorch-unit-test-scripts/auto_classify_skip_reasons.py
+++ b/.automation_scripts/pytorch-unit-test-scripts/auto_classify_skip_reasons.py
@@ -53,6 +53,7 @@ RULES = [
     # Misc arch rule.
     {"reason": "PT2.0 - Convolution",
      "msg": r"test skipped on \('gfx",
+     "file": r"^inductor\.test_torchinductor$",
      "name": r"(?i)conv2d_backward"},
 
     # --- bfloat16_SDPA_ME: dropout mask in test_transformers with bfloat16 in TEST NAME ---


### PR DESCRIPTION
Categorizes the `test_conv2d_backward_parametrized` ROCm skip (skipIfRocmArch, upstream #188671 CI timeout) as **PT2.0 - Convolution** in `auto_classify_skip_reasons.py` instead of the generic **Misc** bucket.

Adds a Tier-1 rule matching `conv2d_backward` + `test skipped on ('gfx...')` + `file: ^inductor\.test_torchinductor$` so only inductor-workflow conv2d backward skips are reclassified; unrelated gfx skips stay **Misc**.

## Validation

Ran `auto_classify_skip_reasons.py` over a real mi350 CSV (commit `a7262068`): `test_conv2d_backward_parametrized` and its dynamic-shapes variants classify as **PT2.0 - Convolution**; unrelated `skipIfRocm gfx` skips still classify as **Misc**.
