### PR TITLE
[release/2.11] Bump torchvision pin to ROCm/vision rocJPEG backport (ROCm/vision#10)

### DIFF
--- a/related_commits
+++ b/related_commits
@@ -1,7 +1,7 @@
 ubuntu|pytorch|apex|release/1.11.0|c0f56f7eccd343a08a1b0d0be59f1e7e0e9b90b7|https://github.com/ROCm/apex
 centos|pytorch|apex|release/1.11.0|c0f56f7eccd343a08a1b0d0be59f1e7e0e9b90b7|https://github.com/ROCm/apex
-ubuntu|pytorch|torchvision|release/0.26|8ced453e49d3cf57f8a713f13fc49bc0b513aa0d|https://github.com/ROCm/vision
-centos|pytorch|torchvision|release/0.26|8ced453e49d3cf57f8a713f13fc49bc0b513aa0d|https://github.com/ROCm/vision
+ubuntu|pytorch|torchvision|release/0.26|3d50b2155c02d26e78b9c09baf99f5c707d70215|https://github.com/ROCm/vision
+centos|pytorch|torchvision|release/0.26|3d50b2155c02d26e78b9c09baf99f5c707d70215|https://github.com/ROCm/vision
 ubuntu|pytorch|torchdata|release/0.11|377e64c1be69a9be6649d14c9e3664070323e464|https://github.com/pytorch/data
 centos|pytorch|torchdata|release/0.11|377e64c1be69a9be6649d14c9e3664070323e464|https://github.com/pytorch/data
 ubuntu|pytorch|torchaudio|release/2.11|34c52a67e8941bbd8e6adaca0eb0b9eabec11d78|https://github.com/pytorch/audio

--- a/related_commits
+++ b/related_commits
@@ -1,7 +1,7 @@
 ubuntu|pytorch|apex|release/1.11.0|c0f56f7eccd343a08a1b0d0be59f1e7e0e9b90b7|https://github.com/ROCm/apex
 centos|pytorch|apex|release/1.11.0|c0f56f7eccd343a08a1b0d0be59f1e7e0e9b90b7|https://github.com/ROCm/apex
-ubuntu|pytorch|torchvision|release/0.26|f37951448379bca5dfb29f6f345a80e721ea477c|https://github.com/ROCm/vision
-centos|pytorch|torchvision|release/0.26|f37951448379bca5dfb29f6f345a80e721ea477c|https://github.com/ROCm/vision
+ubuntu|pytorch|torchvision|release/0.26|8ced453e49d3cf57f8a713f13fc49bc0b513aa0d|https://github.com/ROCm/vision
+centos|pytorch|torchvision|release/0.26|8ced453e49d3cf57f8a713f13fc49bc0b513aa0d|https://github.com/ROCm/vision
 ubuntu|pytorch|torchdata|release/0.11|377e64c1be69a9be6649d14c9e3664070323e464|https://github.com/pytorch/data
 centos|pytorch|torchdata|release/0.11|377e64c1be69a9be6649d14c9e3664070323e464|https://github.com/pytorch/data
 ubuntu|pytorch|torchaudio|release/2.11|34c52a67e8941bbd8e6adaca0eb0b9eabec11d78|https://github.com/pytorch/audio


### PR DESCRIPTION
## What this does

Bumps the torchvision pin in `related_commits` for `release/2.11` so ROCm PyTorch picks up rocJPEG GPU JPEG decoding.

- `torchvision | release/0.26`: `f37951448379bca5dfb29f6f345a80e721ea477c` -> `8ced453e49d3cf57f8a713f13fc49bc0b513aa0d` (ubuntu + centos lines). Repo/branch stay `ROCm/vision` / `release/0.26`.

The new commit is the backport of **pytorch/vision#9342** (rocJPEG decode), adapted to the `release/0.26` classic (non stable-ABI) layout.

## Companion PR

torchvision backport: ROCm/vision#10

## Validation

Built via TheRock "Multi-Arch Build Portable Linux PyTorch Wheels" against this branch: https://github.com/ROCm/TheRock/actions/runs/28960912700
- Build (torch + rocJPEG torchvision, gfx94X, py3.12): **success** (cloned ROCm/pytorch at this branch, resolved vision via `related_commits`).
- PyTorch test suite: 39627 passed; the only 4 failures are unrelated (`test_unary_ufuncs.py` uint8 `threshold` OverflowError), not JPEG/torchvision.
