### PR TITLE
Revert "[AUTOGENERATED] [release/2.12] [ROCm] Skip linalg UT's when MAGMA is not available with ROCM (#178229)"

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -6578,7 +6578,7 @@ class CommonTemplate:
         TEST_WITH_ROCM and not torch.cuda.has_magma,
         "ROCm hipsolver backend does not currently support eig",
     )
-    @skipIfMPS
+    @xfail_if_mps_unimplemented  # aten::linalg_eig not implemented for MPS
     def test_linalg_eig_stride_consistency(self):
         def fn(x):
             eigenvals, eigenvecs = torch.linalg.eig(x)


### PR DESCRIPTION
Reverts ROCm/pytorch#3340, 2.12 doesn't need this change