### PR TITLE
[CI] Parity: enable auto_classify by default

### DIFF
--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -98,7 +98,7 @@ on:
       auto_classify:
         description: 'Auto-classify skip reasons for SKIPPED/MISSED tests in the output CSV'
         required: false
-        default: false
+        default: true
         type: boolean
 
 jobs:


### PR DESCRIPTION
Flips the `parity.yml` `auto_classify` input default from `false` to `true`, so skip-reason classification runs on **every** dispatch — including **autoparity** commits, which don't pass the input and therefore inherit the default. Previously auto-triggered runs left `skip_reason` blank; now the disagreement subset (SKIPPED/MISSED on ROCm + PASSED on CUDA) is auto-categorized in the output CSV. No other change; manual runs can still pass `auto_classify=false` to opt out.

Made with [Cursor](https://cursor.com)