### PR TITLE
[release/2.9] Fix flaky reentrant backward test by passing explicit grad for non-scalar output (#179704)

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -11755,7 +11755,7 @@ class TestAutogradDeviceType(TestCase):
             @staticmethod
             def backward(ctx, grad):
                 # Reentrant backward in child will take much longer.
-                reentrant_root.backward()
+                reentrant_root.backward(grad)
                 return grad
 
         # Parent gpu graph.


### PR DESCRIPTION
Cherry-pick of upstream pytorch/pytorch#179704 (commit 24cdfbdd4ce3) into release/2.9.

## Why

`test/test_autograd.py::TestAutogradDeviceTypeCUDA::test_reentrant_parent_error_on_cpu_cuda` is flaky on ROCm Linux CI. `ReentrantFunc.backward()` calls `reentrant_root.backward()` on a non-scalar `[3, 3]` tensor with no explicit gradient, which is always invalid. This races two errors through the autograd engine: the intended `"Simulate error"` and an accidental `RuntimeError: grad can be implicitly created only for scalar outputs`. On ROCm the accidental error wins, so `assertRaisesRegex("Simulate error")` fails.

The one-line fix (`reentrant_root.backward()` -> `reentrant_root.backward(grad)`) removes the accidental error source and makes the test deterministic. Already present on upstream `main` and `release/2.10`; this backports it to `release/2.9`.

## Change

test/test_autograd.py - 1 line, inside `_test_reentrant_parent_error_on_cpu`.

Fixes ROCm/TheRock#6170
