### PR TITLE
[release/2.11] Update pandas version for python-3.12 to 2.2.3

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -142,8 +142,8 @@ numpy==2.0.2 ; python_version == "3.9"
 numpy==2.1.2 ; python_version > "3.9" and python_version < "3.14"
 numpy==2.3.4; python_version >= "3.14"
 
-pandas==2.0.3; python_version < "3.13"
-pandas==2.2.3; python_version >= "3.13" and python_version < "3.14"
+pandas==2.0.3; python_version < "3.12"
+pandas==2.2.3; python_version >= "3.12" and python_version < "3.14"
 pandas==2.3.3; python_version >= "3.14"
 
 #onnxruntime


### PR DESCRIPTION
## Status

**Superseded by [ROCm/pytorch#3423](https://github.com/ROCm/pytorch/pull/3423)** (merged 2026-07-10), which bumps pandas and other dependencies for Python 3.12+ on `release/2.11`.

This draft only moved the pandas 2.2.3 boundary from py3.13 → py3.12 in `requirements-ci.txt`. Keeping it open for reference; safe to close.
