### PR TITLE
[ROCm] Optimize AMD normalization backward kernel by using tiled and two pass implementations where they are most efficient.

### DIFF
--- a/aten/src/ATen/native/cuda/layer_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/layer_norm_kernel.cu
@@ -1387,11 +1387,11 @@ void cuComputeGradGammaBeta(
     }
 }
 
-// Legacy two-pass gamma/beta backward: cuComputePartGradGammaBeta reduces
+// Two-pass gamma/beta backward: cuComputePartGradGammaBeta reduces
 // dgamma/dbeta partial sums across part_size row-blocks, then
 // cuComputeGradGammaBeta finishes the reduction across those partial sums.
 template <typename T, typename T_ACC, bool rms_norm>
-void LaunchLegacyGammaBetaBackwardCUDAKernel(
+void LaunchTwoPassGammaBetaBackwardCUDAKernel(
     const T* dY_data,
     const T* X_data,
     const Tensor& X,
@@ -1669,19 +1669,14 @@ void LayerNormBackwardKernelImplInternal(
       constexpr int block_dim_x = 64; // matches LaunchGammaBetaBackwardCUDAKernel's ROCm tile width
       const int sm_count = at::cuda::getCurrentDeviceProperties()->multiProcessorCount;
       // LaunchGammaBetaBackwardCUDAKernel already special-cases M >> N (huge M, small N)
-      // with its own two-pass reduction, which benchmarks ~2-6x faster than the legacy
-      // kernel below for that regime (see layer_norm_gamma_beta_backward perf reproducer:
-      // two_pass_huge_M, llm_hidden_4096, rms_llm, rms_two_pass). For every other M >= 256
-      // shape we measured (tile256_large/_bf16/_fp32, gpt2_style, rms_tile256), the legacy
-      // two-pass kernel is faster than LaunchGammaBetaBackwardCUDAKernel's tile-256 config,
-      // so we use it here instead.
+      // hich benchmarks ~2-6x faster than the two-pass kernel below for that regime.
       const bool use_tiled_huge_M_kernel =
           M > 64 * 1024 && N / block_dim_x < sm_count / 2;
       if (use_tiled_huge_M_kernel) {
         LaunchGammaBetaBackwardCUDAKernel<T, T_ACC, rms_norm>(
           dY_data, X_data, mean_data, rstd_data, M, N, dgamma, dbeta, cuda_stream);
       } else {
-        LaunchLegacyGammaBetaBackwardCUDAKernel<T, T_ACC, rms_norm>(
+        LaunchTwoPassGammaBetaBackwardCUDAKernel<T, T_ACC, rms_norm>(
           dY_data, X_data, X, gamma, mean_data, rstd_data, M, N, dgamma_data, dbeta_data, cuda_stream);
       }
     }

--- a/aten/src/ATen/native/cuda/layer_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/layer_norm_kernel.cu
@@ -1387,6 +1387,51 @@ void cuComputeGradGammaBeta(
     }
 }
 
+// Legacy two-pass gamma/beta backward: cuComputePartGradGammaBeta reduces
+// dgamma/dbeta partial sums across part_size row-blocks, then
+// cuComputeGradGammaBeta finishes the reduction across those partial sums.
+template <typename T, typename T_ACC, bool rms_norm>
+void LaunchLegacyGammaBetaBackwardCUDAKernel(
+    const T* dY_data,
+    const T* X_data,
+    const Tensor& X,
+    const Tensor& gamma,
+    const T_ACC* mean_data,
+    const T_ACC* rstd_data,
+    int64_t M,
+    int64_t N,
+    T* dgamma_data,
+    T* dbeta_data,
+    cudaStream_t cuda_stream) {
+  const int warp_size = at::cuda::warp_size();
+  const int part_size = warp_size;
+  const dim3 threads2(warp_size, 4, 1);
+  const dim3 blocks2((N + threads2.x - 1) / threads2.x, part_size, 1);
+  const int nshared2_a = 2 * sizeof(T_ACC) * threads2.y * threads2.y * (threads2.x + 1);
+  const int nshared2_b = threads2.x * threads2.y * sizeof(T_ACC);
+  const int nshared2 = nshared2_a > nshared2_b ? nshared2_a : nshared2_b;
+
+  const auto part_grad_dtype = at::toAccumulateType(X.scalar_type(), true);
+  Tensor part_grad_gamma = at::empty({part_size, N}, gamma.options().dtype(part_grad_dtype));
+  Tensor part_grad_beta = at::native::empty_like(part_grad_gamma);
+
+  cuComputePartGradGammaBeta<T, T_ACC, rms_norm><<<blocks2, threads2, nshared2, cuda_stream>>>(
+      dY_data, X_data, M, N, mean_data, rstd_data,
+      part_grad_gamma.template data_ptr<T_ACC>(),
+      part_grad_beta.template data_ptr<T_ACC>());
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+  const dim3 threads3(warp_size, 8, 1); // Optimization for ROCm
+  const dim3 blocks3((N + threads3.x - 1) / threads3.x, 1, 1);
+  const int nshared3 = threads3.x * threads3.y * sizeof(T_ACC);
+
+  cuComputeGradGammaBeta<T, T_ACC, rms_norm><<<blocks3, threads3, nshared3, cuda_stream>>>(
+      part_grad_gamma.template data_ptr<T_ACC>(),
+      part_grad_beta.template data_ptr<T_ACC>(),
+      part_size, M, N, dgamma_data, dbeta_data);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
 template<typename T, typename T_ACC, bool rms_norm> __global__
 void cuComputeGradInput(
     const T* __restrict__ dout,
@@ -1621,12 +1666,24 @@ void LayerNormBackwardKernelImplInternal(
               dbeta_data);
       C10_CUDA_KERNEL_LAUNCH_CHECK();
     } else {
-      // Use the optimized tiled kernel adapted for wavefront-64.
-      // This replaces the legacy two-pass cuComputePartGradGammaBeta +
-      // cuComputeGradGammaBeta approach with a single-pass tiled reduction
-      // that has coalesced memory access and adaptive tile sizing.
-      LaunchGammaBetaBackwardCUDAKernel<T, T_ACC, rms_norm>(
-        dY_data, X_data, mean_data, rstd_data, M, N, dgamma, dbeta, cuda_stream);
+      constexpr int block_dim_x = 64; // matches LaunchGammaBetaBackwardCUDAKernel's ROCm tile width
+      const int sm_count = at::cuda::getCurrentDeviceProperties()->multiProcessorCount;
+      // LaunchGammaBetaBackwardCUDAKernel already special-cases M >> N (huge M, small N)
+      // with its own two-pass reduction, which benchmarks ~2-6x faster than the legacy
+      // kernel below for that regime (see layer_norm_gamma_beta_backward perf reproducer:
+      // two_pass_huge_M, llm_hidden_4096, rms_llm, rms_two_pass). For every other M >= 256
+      // shape we measured (tile256_large/_bf16/_fp32, gpt2_style, rms_tile256), the legacy
+      // two-pass kernel is faster than LaunchGammaBetaBackwardCUDAKernel's tile-256 config,
+      // so we use it here instead.
+      const bool use_tiled_huge_M_kernel =
+          M > 64 * 1024 && N / block_dim_x < sm_count / 2;
+      if (use_tiled_huge_M_kernel) {
+        LaunchGammaBetaBackwardCUDAKernel<T, T_ACC, rms_norm>(
+          dY_data, X_data, mean_data, rstd_data, M, N, dgamma, dbeta, cuda_stream);
+      } else {
+        LaunchLegacyGammaBetaBackwardCUDAKernel<T, T_ACC, rms_norm>(
+          dY_data, X_data, X, gamma, mean_data, rstd_data, M, N, dgamma_data, dbeta_data, cuda_stream);
+      }
     }
 #else
     LaunchGammaBetaBackwardCUDAKernel<T, T_ACC, rms_norm>(

--- a/aten/src/ATen/native/cuda/layer_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/layer_norm_kernel.cu
@@ -938,6 +938,14 @@ void ConfigureAndLaunchGammaBetaBackwardKernel(
 
 }
 
+// We have a situation where M >> N and N is small: parallelizing gamma/beta
+// backward across the M dimension in a separate kernel (below) pays off vs.
+// the single fused-tile kernel. Shared by LaunchGammaBetaBackwardCUDAKernel's
+// internal check and its ROCm caller so the two conditions cannot diverge.
+inline bool ShouldUseHugeMGammaBetaBackwardKernel(int64_t M, int64_t N, int block_dim_x, int sm_count) {
+  return M > 64 * 1024 && N / block_dim_x < sm_count / 2;
+}
+
 template<typename T, typename T_ACC, bool rms_norm>
 void LaunchGammaBetaBackwardCUDAKernel(
     const T* dY_data,
@@ -955,7 +963,7 @@ void LaunchGammaBetaBackwardCUDAKernel(
   constexpr int block_dim_x = 32;
 #endif
   const int sm_count = at::cuda::getCurrentDeviceProperties()->multiProcessorCount;
-  if (M > 64 * 1024 && N / block_dim_x < sm_count / 2) {
+  if (ShouldUseHugeMGammaBetaBackwardKernel(M, N, block_dim_x, sm_count)) {
     // We have a situation where M >> N and N is small.
     // In this case we can speed up the computation by parallelizing in the M dimension.
     // We launch multiple blocks in the y-dimension, and compute partial sums for the
@@ -1008,13 +1016,11 @@ void LaunchGammaBetaBackwardCUDAKernel(
     } else if (M < 256) {
       ConfigureAndLaunchGammaBetaBackwardKernel<T, T_ACC, block_dim_x, 16, 128, rms_norm>(dY_data, X_data, mean_data, rstd_data, M, N, dgamma, dbeta, cuda_stream);
     } else {
-#ifdef USE_ROCM
-      // Cap block_dim_y at 16 to keep total threads (64*16=1024) within GPU limits.
-      // rows_per_thread_y = 256/16 = 16, still within warp size constraint.
-      ConfigureAndLaunchGammaBetaBackwardKernel<T, T_ACC, block_dim_x, 16, 256, rms_norm>(dY_data, X_data, mean_data, rstd_data, M, N, dgamma, dbeta, cuda_stream);
-#else
+      // Note: under USE_ROCM, LayerNormBackwardKernelImplInternal only reaches
+      // this function when ShouldUseHugeMGammaBetaBackwardKernel(...) is true
+      // (the huge-M/small-N regime handled above), so this branch is CUDA-only
+      // in practice; there is no ROCm-specific tile shape here.
       ConfigureAndLaunchGammaBetaBackwardKernel<T, T_ACC, block_dim_x, 32, 256, rms_norm>(dY_data, X_data, mean_data, rstd_data, M, N, dgamma, dbeta, cuda_stream);
-#endif
     }
   }
 }
@@ -1395,14 +1401,15 @@ void LaunchTwoPassGammaBetaBackwardCUDAKernel(
     const T* dY_data,
     const T* X_data,
     const Tensor& X,
-    const Tensor& gamma,
     const T_ACC* mean_data,
     const T_ACC* rstd_data,
     int64_t M,
     int64_t N,
-    T* dgamma_data,
-    T* dbeta_data,
+    Tensor* dgamma,
+    Tensor* dbeta,
     cudaStream_t cuda_stream) {
+  T* dgamma_data = dgamma->defined() ? dgamma->template data_ptr<T>() : nullptr;
+  T* dbeta_data = dbeta->defined() ? dbeta->template data_ptr<T>() : nullptr;
   const int warp_size = at::cuda::warp_size();
   const int part_size = warp_size;
   const dim3 threads2(warp_size, 4, 1);
@@ -1412,7 +1419,7 @@ void LaunchTwoPassGammaBetaBackwardCUDAKernel(
   const int nshared2 = nshared2_a > nshared2_b ? nshared2_a : nshared2_b;
 
   const auto part_grad_dtype = at::toAccumulateType(X.scalar_type(), true);
-  Tensor part_grad_gamma = at::empty({part_size, N}, gamma.options().dtype(part_grad_dtype));
+  Tensor part_grad_gamma = at::empty({part_size, N}, X.options().dtype(part_grad_dtype));
   Tensor part_grad_beta = at::native::empty_like(part_grad_gamma);
 
   cuComputePartGradGammaBeta<T, T_ACC, rms_norm><<<blocks2, threads2, nshared2, cuda_stream>>>(
@@ -1668,16 +1675,16 @@ void LayerNormBackwardKernelImplInternal(
     } else {
       constexpr int block_dim_x = 64; // matches LaunchGammaBetaBackwardCUDAKernel's ROCm tile width
       const int sm_count = at::cuda::getCurrentDeviceProperties()->multiProcessorCount;
-      // LaunchGammaBetaBackwardCUDAKernel already special-cases M >> N (huge M, small N)
-      // hich benchmarks ~2-6x faster than the two-pass kernel below for that regime.
+      // LaunchGammaBetaBackwardCUDAKernel already special-cases M >> N (huge M, small N),
+      // which benchmarks ~2-6x faster than the two-pass kernel below for that regime.
       const bool use_tiled_huge_M_kernel =
-          M > 64 * 1024 && N / block_dim_x < sm_count / 2;
+          ShouldUseHugeMGammaBetaBackwardKernel(M, N, block_dim_x, sm_count);
       if (use_tiled_huge_M_kernel) {
         LaunchGammaBetaBackwardCUDAKernel<T, T_ACC, rms_norm>(
           dY_data, X_data, mean_data, rstd_data, M, N, dgamma, dbeta, cuda_stream);
       } else {
         LaunchTwoPassGammaBetaBackwardCUDAKernel<T, T_ACC, rms_norm>(
-          dY_data, X_data, X, gamma, mean_data, rstd_data, M, N, dgamma_data, dbeta_data, cuda_stream);
+          dY_data, X_data, X, mean_data, rstd_data, M, N, dgamma, dbeta, cuda_stream);
       }
     }
 #else


### PR DESCRIPTION
Hugging Face model dropped **5-10%** after switching to tiled kernel (10+ model and tests). 

Implemented mixed approach, using combination of Tiled and Two Pass:

Hugging Face (huggingface_bart) performance is back:
Legacy Two pass performance=1652, 1644
Tiled performance                   =**1574, 1568**
Mixed performance                 =1649, 1652

Synthetic reproducer where performance from chess board like became  uniform, keeping benefits from both implementation:

# Layer Norm Backward Benchmark: Tiled only vs Tiled+Two pass

**Device:** AMD Instinct MI350X | **Warmup:** 20 | **Iters:** 100 | **Runs averaged:** 3  
**Tiled only:** PID 3151521 (built from PID 3155055)  
**Tiled+Two pass:** PID 3160321  

## Summary (avg µs over 3 runs)

| Benchmark | Op | Shape | dtype | Branch | Tiled only | Tiled+Two pass | Δ (µs) | Speedup | Winner |
|-----------|-----|-------|-------|--------|------------|----------------|--------|---------|--------|
| tile8_small | layer_norm | (32, 512) | float16 | Tile-8 | 7.94 | 7.97 | +0.03 | 1.00× | ~tie |
| tile64_medium | layer_norm | (96, 768) | float16 | Tile-64 | 20.71 | 20.72 | +0.01 | 1.00× | ~tie |
| tile128_medium | layer_norm | (192, 1024) | bfloat16 | Tile-128 | 8.20 | 12.47 | +4.27 | 0.66× | Tiled only |
| tile256_large | layer_norm | (4096, 1024) | float16 | Tile-256 | 31.07 | 12.52 | -18.55 | 2.48× | Two pass |
| tile256_bert | layer_norm | (1024, 768) | float16 | Tile-256 BERT | 11.15 | 12.64 | +1.49 | 0.88× | Tiled only |
| tile256_large_bf16 | layer_norm | (4096, 1024) | bfloat16 | Tile-256 | 31.28 | 12.46 | -17.82 | 2.51× | Two pass |
| tile256_large_fp32 | layer_norm | (4096, 1024) | float32 | Tile-256 | 30.87 | 15.82 | -15.05 | 1.95× | Two pass |
| two_pass_huge_M | layer_norm | (131072, 64) | float16 | Two-pass M-parallel | 26.48 | 26.69 | +0.21 | 0.99× | ~tie |
| llm_hidden_4096 | layer_norm | (32, 4096, 4096) | bfloat16 | Tile-256 LLM | 509.65 | 510.26 | +0.61 | 1.00× | ~tie |
| gpt2_style | layer_norm | (8, 1024, 768) | float16 | Tile-256 GPT2 | 58.22 | 16.62 | -41.60 | 3.50× | Two pass |
| rms_tile256 | rms_norm | (4096, 1024) | float16 | Tile-256 rms | 22.34 | 11.60 | -10.74 | 1.93× | Two pass |
| rms_llm | rms_norm | (32, 4096, 4096) | bfloat16 | Tile-256 rms LLM | 476.18 | 473.47 | -2.71 | 1.01× | ~tie |
| rms_two_pass | rms_norm | (131072, 64) | float16 | Two-pass rms | 16.73 | 16.61 | -0.12 | 1.01× | ~tie |

Δ = Tiled only − Tiled+Two pass (negative = Two pass faster). Speedup = Tiled only / Tiled+Two pass.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang
## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
