### PR TITLE
[release/2.11] Update mypy version

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -98,12 +98,11 @@ librosa==0.10.2 ; python_version == "3.12" and platform_machine != "s390x"
 #Pinned versions:
 #test that import:
 
-mypy==1.16.0 ; platform_system == "Linux" and python_version < "3.14"
-mypy==1.17.1 ; platform_system == "Linux" and python_version >= "3.14"
+mypy==1.16.0 ; platform_system == "Linux"
 # Pin MyPy version because new errors are likely to appear with each release
 # Skip on Windows as lots of type annotations are POSIX specific
 #Description: linter
-#Pinned versions: 1.16.0, 1.17.1
+#Pinned versions: 1.16.0
 #test that import: test_typing.py, test_type_hints.py
 
 networkx==2.8.8 ; python_version < "3.14"


### PR DESCRIPTION
https://github.com/ROCm/pytorch/blob/release/2.11/mypy_plugins/check_mypy_version.py#L8-L17 scans the requirements-ci.txt and looks for `mypy==x.x.x`, assuming only 1 match will be found. However, after last Friday's version bump, we now have 2 such lines specifying mypy versions for python <3.14 and >=3.14, causing this function to throw an exception, and therefore causing mypy can't be imported correctly, eventually causing `test_typing` tests to fail.
This change luckily won't break python 3.14 compatibility, as even though mypy ships prebuilt binary, it also provides a pure python wheel that works only slower without the prebuilt binary.