### PR TITLE
[release/2.10][CI] Fix expandable_segments allocator state leak in test_cuda.py (#1…

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -4068,6 +4068,14 @@ print(ret)
 @unittest.skipIf(not TEST_CUDA, "CUDA not available, skipping tests")
 @torch.testing._internal.common_utils.markDynamoStrictTest
 class TestCudaMallocAsync(TestCase):
+    def tearDown(self):
+        super().tearDown()
+        # Regression check: no test in this class should leave the runtime
+        # expandable_segments knob mismatched against the suite's env-derived
+        # baseline. This is the only class that toggles it.
+        md = torch.cuda.memory._snapshot()["allocator_settings"]
+        self.assertEqual(md["expandable_segments"], EXPANDABLE_SEGMENTS)
+
     @unittest.skipIf(
         TEST_CUDAMALLOCASYNC, "setContextRecorder not supported by CUDAMallocAsync"
     )
@@ -4474,6 +4482,11 @@ class TestCudaMallocAsync(TestCase):
             alloc(120)
         finally:
             torch.cuda.memory.set_per_process_memory_fraction(orig)
+            # Test toggles expandable_segments internally; restore the
+            # suite's baseline so subsequent tests see consistent state.
+            torch.cuda.memory._set_allocator_settings(
+                f"expandable_segments:{EXPANDABLE_SEGMENTS}"
+            )
 
     @serialTest()
     def test_garbage_collect_expandable(self):
@@ -4506,6 +4519,11 @@ class TestCudaMallocAsync(TestCase):
             alloc(80)
         finally:
             torch.cuda.memory.set_per_process_memory_fraction(orig)
+            # Test toggles expandable_segments internally; restore the
+            # suite's baseline so subsequent tests see consistent state.
+            torch.cuda.memory._set_allocator_settings(
+                f"expandable_segments:{EXPANDABLE_SEGMENTS}"
+            )
 
     def test_allocator_settings(self):
         def power2_div(size, div_factor):
@@ -5970,7 +5988,6 @@ class TestMemPool(TestCase):
     @unittest.skipIf(IS_FBCODE or IS_SANDCASTLE, "Load_inline doesn't work in fbcode")
     def test_mempool_expandable(self):
         torch.cuda.empty_cache()
-        torch.cuda.memory._set_allocator_settings("expandable_segments:True")
         allocator, _ = self.get_dummy_allocator(check_vars=False)
         pool = torch.cuda.MemPool(allocator.allocator())
 
@@ -5993,8 +6010,6 @@ class TestMemPool(TestCase):
         self.assertEqual(
             num_expandable_segments, 1, "Expected to have 1 expandable segment only"
         )
-
-        torch.cuda.memory._set_allocator_settings("expandable_segments:False")
 
     @serialTest()
     def test_mempool_ctx_multithread(self):

--- a/test/test_cuda_expandable_segments.py
+++ b/test/test_cuda_expandable_segments.py
@@ -1,6 +1,20 @@
 # Owner(s): ["module: cuda"]
 # run time cuda tests, but with the allocator using expandable segments
 
+import os
+
+
+# Must precede the test_cuda import: EXPANDABLE_SEGMENTS in
+# torch.testing._internal.common_utils reads PYTORCH_CUDA_ALLOC_CONF once at
+# import time. Setting it here lets the @skipIf(not EXPANDABLE_SEGMENTS, ...)
+# guards on expandable-only tests in test_cuda.py run in this runner. We
+# restore the prior env state below (after the import) so subprocesses
+# spawned by tests don't inherit expandable_segments:True, which would
+# conflict with backend:cudaMallocAsync and similar settings those
+# subprocesses set themselves.
+_PRIOR_ALLOC_CONF = os.environ.get("PYTORCH_CUDA_ALLOC_CONF")
+os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
+
 import pathlib
 import sys
 
@@ -8,12 +22,21 @@ from test_cuda import (  # noqa: F401
     TestBlockStateAbsorption,
     TestCuda,
     TestCudaMallocAsync,
+    TestMemPool,
 )
 
 import torch
 from torch.testing._internal.common_cuda import IS_JETSON, IS_WINDOWS
 from torch.testing._internal.common_utils import run_tests
 
+
+# Restore prior env state. EXPANDABLE_SEGMENTS has already been resolved at
+# import time above; the runtime allocator is forced into expandable mode
+# via _set_allocator_settings in __main__ below.
+if _PRIOR_ALLOC_CONF is None:
+    os.environ.pop("PYTORCH_CUDA_ALLOC_CONF", None)
+else:
+    os.environ["PYTORCH_CUDA_ALLOC_CONF"] = _PRIOR_ALLOC_CONF
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
@@ -27,9 +50,5 @@ sys.path.remove(str(REPO_ROOT))
 if __name__ == "__main__":
     if torch.cuda.is_available() and not IS_JETSON and not IS_WINDOWS:
         get_disabled_tests(".")
-
         torch.cuda.memory._set_allocator_settings("expandable_segments:True")
-        TestCuda.expandable_segments = lambda _: True
-        TestBlockStateAbsorption.expandable_segments = lambda _: True
-
         run_tests()


### PR DESCRIPTION
…81992)

test_garbage_collect_expandable left expandable_segments:True in the runtime allocator config because parseArgs doesn't auto-reset that sticky knob. Later tests like test_allocate_in_thread_to_pool then saw a runtime/EXPANDABLE_SEGMENTS mismatch, making #158764 flaky.

The toggling tests now restore the suite's baseline (EXPANDABLE_SEGMENTS) in their finally; test_cuda_expandable_segments.py sets the env var before importing test_cuda; and TestCudaAllocator gets a tearDown that fails fast if any future test leaks the knob.

Fixes #158764
Fixes #180263

Authored with Claude.
Pull Request resolved: https://github.com/pytorch/pytorch/pull/181992 Approved by: https://github.com/albanD

(cherry picked from commit 6dd5f10c066f2246e9b2eea7341a860b72cea0b9)
