### PR TITLE
[CI] Parity: fix flaky-test misattribution in log-based detection

### DIFF
--- a/.automation_scripts/pytorch-unit-test-scripts/detect_log_failures.py
+++ b/.automation_scripts/pytorch-unit-test-scripts/detect_log_failures.py
@@ -39,10 +39,19 @@ RE_STEPCURRENT = re.compile(
 RE_INDIVIDUAL_TEST = re.compile(
     r"(?P<test_path>\S+\.py::(?P<cls>\w+)::(?P<method>\w+))"
 )
-RE_INDIV_PASSED = re.compile(
-    r"(?:test/)?(?P<file>\S+\.py)::(?P<cls>\w+)::(?P<method>\S+?)\s+PASSED"
+# PyTorch's run_test.py prints an authoritative summary at the end of a shard
+# listing the exact tests that failed and then passed on rerun-in-new-process,
+# e.g.
+#   The following tests failed and then succeeded when run in a new process
+#   ['test/inductor/test_compiled_autograd.py::Cls::test_jacfwd', ...]
+# We parse this directly instead of guessing from nearby PASSED lines, which
+# misattributes flakiness to whatever test happened to pass most recently.
+RE_FLAKY_SUMMARY = re.compile(
+    r"The following tests failed and then succeeded when run in a new process\s*\[(?P<tests>[^\]]*)\]"
 )
-RE_NEW_PROCESS_SUCCESS = re.compile(r"Test succeeded in new process")
+RE_FLAKY_ENTRY = re.compile(
+    r"['\"](?:test/)?(?P<file>\S+?\.py)::(?P<cls>\w+)::(?P<method>[^'\"]+?)['\"]"
+)
 
 CRASH_PATTERNS = [
     (re.compile(r"Segmentation fault", re.IGNORECASE), "SEGFAULT"),
@@ -101,16 +110,16 @@ def parse_log_file(filepath):
     and flaky tests.
 
     A flaky test is one that failed in its normal-process run but PASSED when the
-    CI harness re-ran it alone in a new subprocess (indicated by a PASSED line
-    for the specific test::class::method, followed by 'Test succeeded in new
-    process, continuing with the rest of the tests').
+    CI harness re-ran it alone in a new subprocess. These are read from the
+    authoritative summary run_test.py prints for each shard ('The following
+    tests failed and then succeeded when run in a new process[...]'), which
+    names the exact tests.
     """
     results = {}
     current_test = None
     last_failed_test = None
     consistent_failures = []
     flaky_tests = []
-    last_passed_individual = None
     first_ts = None
     last_ts = None
 
@@ -244,34 +253,27 @@ def parse_log_file(filepath):
                     shard_str = f"{info['shard']}/{info['total']}"
                 consistent_failures.append((m.group("test_path"), shard_str))
 
-            # Detect individual PASSED lines for flaky-rerun tracking.
-            m = RE_INDIV_PASSED.search(stripped)
+            # A test is flaky when it failed in its normal-process run but
+            # PASSED on rerun-in-a-new-process. run_test.py prints an
+            # authoritative summary naming exactly those tests; parse it
+            # directly rather than guessing from the most recent PASSED line
+            # (which misattributes flakiness to an unrelated test that merely
+            # happened to pass just before the rerun marker).
+            m = RE_FLAKY_SUMMARY.search(stripped)
             if m:
-                last_passed_individual = {
-                    "file": m.group("file"),
-                    "cls": m.group("cls"),
-                    "method": m.group("method"),
-                    "active": active,
-                }
-
-            # When we see 'Test succeeded in new process' after a PASSED
-            # individual test, that test was originally failing in the main
-            # process (CI only falls back to rerun-in-new-process for tests
-            # that crashed or failed) but passed on retry -> flaky.
-            if RE_NEW_PROCESS_SUCCESS.search(stripped) and last_passed_individual:
-                lp = last_passed_individual
-                lp_active = lp.get("active")
-                test_shard = ""
-                if lp_active and lp_active in results:
-                    info = results[lp_active]
-                    test_shard = f"{info['shard']}/{info['total']}"
-                flaky_tests.append({
-                    "file": lp["file"],
-                    "cls": lp["cls"],
-                    "method": lp["method"],
-                    "test_shard": test_shard,
-                })
-                last_passed_individual = None
+                for em in RE_FLAKY_ENTRY.finditer(m.group("tests")):
+                    f_file = em.group("file")
+                    test_shard = ""
+                    for info in results.values():
+                        if info["test_file"] and f_file == info["test_file"] + ".py":
+                            test_shard = f"{info['shard']}/{info['total']}"
+                            break
+                    flaky_tests.append({
+                        "file": f_file,
+                        "cls": em.group("cls"),
+                        "method": em.group("method"),
+                        "test_shard": test_shard,
+                    })
 
             if active and active in results:
                 for pattern, label in CRASH_PATTERNS:

--- a/.automation_scripts/pytorch-unit-test-scripts/detect_log_failures.py
+++ b/.automation_scripts/pytorch-unit-test-scripts/detect_log_failures.py
@@ -78,13 +78,23 @@ LOG_FILE_MAP = {
 
 
 def classify_log_file(filename):
-    """Return (platform, test_config, shard_num) from a log filename like rocm3.txt."""
+    """Return (platform, test_config, shard_num) from a log filename like rocm3.txt.
+
+    Commit-vs-commit parity prefixes log files with the short commit SHA
+    (for example, 09e0c59b_rocm3.txt). In that mode the SHA label is the
+    platform name used by generate_summary.py, so preserve it here.
+    """
     stem = Path(filename).stem
+    label = None
+    m = re.match(r"(?P<label>[0-9a-f]{8,40})_(?P<stem>.+)", stem)
+    if m:
+        label = m.group("label")[:8]
+        stem = m.group("stem")
     for prefix, (platform, test_config) in sorted(LOG_FILE_MAP.items(), key=lambda x: -len(x[0])):
         if stem.startswith(prefix):
             remainder = stem[len(prefix):]
             if remainder.isdigit():
-                return platform, test_config, int(remainder)
+                return label or platform, test_config, int(remainder)
     return None, None, None
 
 


### PR DESCRIPTION
## Summary

The log-based flaky-test detector in `detect_log_failures.py` misattributes flakiness to the wrong test.

It inferred flakiness from the **last individual `... PASSED` line** seen before a `Test succeeded in new process` marker. That heuristic tags whichever test happened to pass most recently — usually an unrelated test that passed normally much earlier in the shard — rather than the test that actually crashed/failed and then passed on rerun.

### Concrete example
From autoparity run [`29255582284`](https://github.com/ROCm/pytorch/actions/runs/29255582284) (mi350, `inductor/test_compiled_autograd`):

- `WrapTestClassTests::test_wrap_recreates_contexts_for_repeated_runs` passed **normally** at ~16% into the shard (log line 4486), yet was reported as flaky.
- The test that truly failed-then-passed on rerun was `FuncTorchHigherOrderOpTestsWithCompiledAutograd::test_jacfwd` (named on log line 5244).

### Fix
`run_test.py` already prints an authoritative per-shard summary naming the exact tests:

```
The following tests failed and then succeeded when run in a new process
['test/inductor/test_compiled_autograd.py::...::test_jacfwd']
```

Parse that line directly instead of guessing from nearby `PASSED` lines. Scoped entirely to the flaky-detection path; no other behavior changes.

## Links / evidence

- Autoparity run that flagged the false positive: https://github.com/ROCm/pytorch/actions/runs/29255582284
- Upstream ROCm shard job (shard 5/8) whose log was parsed: https://github.com/pytorch/pytorch/actions/runs/29231370182/job/86759068151
- Upstream CUDA shard job (shard 3/5) whose log was parsed: https://github.com/pytorch/pytorch/actions/runs/29231370182/job/86760098157
- Raw ROCm shard log (the exact file the detector reads): https://ossci-raw-job-status.s3.amazonaws.com/log/86759068151
- Raw CUDA shard log: https://ossci-raw-job-status.s3.amazonaws.com/log/86760098157
- Upstream PR that introduced the rerun-in-new-process behavior we parse: https://github.com/pytorch/pytorch/pull/189232

In the raw ROCm log above: line 4486 is `... test_wrap_recreates_contexts_for_repeated_runs PASSED` (normal pass), and line 5244 is `The following tests failed and then succeeded when run in a new process['...::test_jacfwd']` (the real flaky test).

## Testing

### 1. `py_compile`
```
python -m py_compile .automation_scripts/pytorch-unit-test-scripts/detect_log_failures.py   # passes
```

### 2. Regression check against the real logs from run 29255582284
Download the two upstream shard logs that produced the false positive ([rocm job 86759068151](https://github.com/pytorch/pytorch/actions/runs/29231370182/job/86759068151), [cuda job 86760098157](https://github.com/pytorch/pytorch/actions/runs/29231370182/job/86760098157)) and run the parser directly:

```bash
# rocm shard 5/8 (job 86759068151) and cuda shard 3/5 (job 86760098157)
for job in 86759068151 86760098157; do
  curl -s "https://ossci-raw-job-status.s3.amazonaws.com/log/${job}" | gunzip -c > ${job}.txt
done

python3 - <<'PY'
import detect_log_failures as d
for label, path in [("rocm", "86759068151.txt"), ("cuda", "86760098157.txt")]:
    _, _, flaky, _ = d.parse_log_file(path)
    print(label, [(f["cls"], f["method"], f["test_shard"]) for f in flaky])
PY
```

**Before this change (buggy heuristic):**
```
rocm [('WrapTestClassTests', 'test_wrap_recreates_contexts_for_repeated_runs', '5/8')]
cuda [('WrapTestClassTests', 'test_wrap_recreates_contexts_for_repeated_runs', '4/8')]
```

**After this change:**
```
rocm [('FuncTorchHigherOrderOpTestsWithCompiledAutograd', 'test_jacfwd', '1/2')]
cuda [('FuncTorchHigherOrderOpTestsWithCompiledAutograd', 'test_jacfwd', '1/1')]
```

- [x] `test_wrap_recreates_contexts_for_repeated_runs` (which passed normally) is no longer flagged
- [x] `test_jacfwd` (the test that actually failed-then-passed on rerun) is correctly reported on **both** rocm and cuda, with the correct test shard
- [x] `py_compile` passes

### 3. End-to-end
Ran a full parity dispatch on the fork with this change and confirmed `flaky_tests_mi350.csv` reports `test_jacfwd` (not `test_wrap_...`) for `inductor.test_compiled_autograd`.

## Deployment status
Merged to the fork `ethanwee1/pytorch:main` so it is live on autoparity while this PR is under review. This PR remains the upstream landing target for `ROCm/pytorch:develop`.


## Commit-vs-commit alignment

The branch now also preserves short-SHA platform labels in prefixed log names (for example `09e0c59b_rocm3.txt`), matching the fork behavior. Normal ROCm/CUDA names and 8-40 character SHA prefixes are covered by focused regression assertions.
