### PR TITLE
[release/2.12] rocm-smi deprecation

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1100,13 +1100,6 @@ if(USE_ROCM)
       endif()
     endif()
 
-    # ROCM-SMI needed to support symmetric memory
-    if(USE_DISTRIBUTED AND UNIX)
-      list(APPEND Caffe2_PUBLIC_HIP_DEPENDENCY_LIBS
-        rocm_smi64
-      )
-    endif()
-
     # ---[ Kernel asserts
     # Kernel asserts is disabled for ROCm by default.
     # It can be turned on by turning on the env USE_ROCM_KERNEL_ASSERT to the build system.

--- a/cmake/public/LoadHIP.cmake
+++ b/cmake/public/LoadHIP.cmake
@@ -223,7 +223,6 @@ if(HIP_FOUND)
   if(UNIX)
     find_package_and_print_version(rccl)
     find_package_and_print_version(hsa-runtime64 REQUIRED)
-    find_package_and_print_version(rocm_smi REQUIRED)
   endif()
 
   # Optional components.


### PR DESCRIPTION
Validation:
this branch: https://github.com/ROCm/TheRock/actions/runs/29505867726
same rocm nightly on release branch: https://github.com/ROCm/rockrel/actions/runs/28493184944

Cherry-picked to release/2.13 branch via https://github.com/ROCm/pytorch/pull/3479