### PR TITLE
[release/2.13] bringup: related_commits + requirements.txt pins

### DIFF
--- a/related_commits
+++ b/related_commits
@@ -1,3 +1,3 @@
 ubuntu|pytorch|apex|release/1.13.0|68f9dc9e316c24ab9c974fafd302e8a7a56fdcff|https://github.com/ROCm/apex
-ubuntu|pytorch|torchvision|release/0.28|8fb87713a24951e639c494b0f2a8a81b5f8e33a6|https://github.com/ROCm/vision
+ubuntu|pytorch|torchvision|release/0.28|8fb87713a24951e639c494b0f2a8a81b5f8e33a6|https://github.com/pytorch/vision
 ubuntu|pytorch|torchaudio|release/2.11.0.2|207d52908b0851523042640485c8c6d0e1198765|https://github.com/ROCm/audio

--- a/related_commits
+++ b/related_commits
@@ -1,0 +1,3 @@
+ubuntu|pytorch|apex|release/1.13.0|68f9dc9e316c24ab9c974fafd302e8a7a56fdcff|https://github.com/ROCm/apex
+ubuntu|pytorch|torchvision|release/0.28|8fb87713a24951e639c494b0f2a8a81b5f8e33a6|https://github.com/ROCm/vision
+ubuntu|pytorch|torchaudio|release/2.11.0.2|207d52908b0851523042640485c8c6d0e1198765|https://github.com/ROCm/audio

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,16 +4,17 @@
 --requirement requirements-build.txt
 
 # Install / Development extra requirements
-build[uv]  # for building sdist and wheel
-expecttest>=0.3.0
-filelock
-fsspec>=0.8.5
-hypothesis
-jinja2
-lintrunner ; platform_machine != "s390x"
-networkx>=2.5.1
-optree>=0.13.0
-psutil
-spin
-sympy>=1.13.3
-wheel
+build[uv]==1.3.0  # for building sdist and wheel
+expecttest==0.3.0
+filelock==3.20.3
+fsspec==2026.2.0
+hypothesis==6.56.4
+jinja2==3.1.6
+lintrunner==0.12.11 ; platform_machine != "s390x"
+networkx==2.8.8
+optree==0.13.0 ; python_version < "3.14"
+optree==0.17.0 ; python_version >= "3.14"
+psutil==7.2.2
+spin==0.17
+sympy==1.13.3
+wheel==0.46.3


### PR DESCRIPTION
## Summary

release/2.13 bringup for ROCm/pytorch (ROCm/frameworks-internal#17260).

- Add `related_commits` pinning the companion repos for the 2.13 release:
  - apex `release/1.13.0` (ROCm/apex, `68f9dc9`)
  - torchvision `release/0.28` (upstream pytorch/vision, `8fb8771`) — no ROCm-specific patches on top of 0.28, so point at the upstream branch directly (same pattern as torchaudio in 2.12), rather than creating a ROCm/vision fork branch.
  - torchaudio `release/2.11.0.2` (ROCm/audio, `207d529`)
- Pin `requirements.txt` to the same versions used on `release/2.12` (identical package set; `optree` kept split on `python_version` `3.14` as in 2.12).
