### PR TITLE
[release/2.11] [ROCm] derive the hipcub compatible cccl version from 'HIPCUB_CCCL_VERSION'

### DIFF
--- a/aten/src/ATen/cuda/cub.cuh
+++ b/aten/src/ATen/cuda/cub.cuh
@@ -70,7 +70,11 @@
 #define ATEN_CUB_MAXIMUM() NO_ROCM(at_cuda_detail)ROCM_HIPCUB(::cub)::Max()
 #endif
 
-#if defined(USE_ROCM)
+// Pre ROCm 8.0 we require backporting of FpLimits specialization
+// for 'c10::BFloat16'. However, ROCm 8.0 lifts the compatible
+// CUB version to 3.x which uses libhipcxx and derives numerical
+// limits from there.
+#if defined(USE_ROCM) && CUB_VERSION < 300000
 
 // backport https://github.com/NVIDIA/cub/pull/306 for c10::BFloat16
 

--- a/aten/src/ATen/cuda/cub_definitions.cuh
+++ b/aten/src/ATen/cuda/cub_definitions.cuh
@@ -1,13 +1,19 @@
 #pragma once
 
 #if !defined(USE_ROCM)
-#include <cuda.h>  // for CUDA_VERSION
-#endif
-
-#if !defined(USE_ROCM)
+#include <cuda.h> // for CUDA_VERSION
 #include <cub/version.cuh>
 #else
+// Check if we can find HIPCUB_CCCL_VERSION.
+#include <hipcub/hipcub_version.hpp>
+// Older versions of hipCUB do not support the CUB V3 API.
+#if defined(HIPCUB_CCCL_VERSION) && HIPCUB_CCCL_VERSION >= 300000
+#define CUB_VERSION HIPCUB_CCCL_VERSION
+#else
+// If we cannot find a compatible CCCL version, fallback to
+// a very old version.
 #define CUB_VERSION 200001
+#endif
 #endif
 
 // cub support for CUB_WRAPPED_NAMESPACE is added to cub 1.13.1 in:
@@ -21,9 +27,23 @@
 #endif
 
 // There were many bc-breaking changes in major version release of CCCL v3.0.0
+<<<<<<< HEAD
 // Please see https://nvidia.github.io/cccl/cccl/3.0_migration_guide.html
 #if CUB_VERSION >= 200800
 #define CUB_V3_PLUS() true
 #else
+=======
+// Please see https://github.com/NVIDIA/cccl/blob/main/docs/cccl/3.0_migration_guide.rst
+#if CUB_VERSION >= 300400
+#define CUB_V3_4_PLUS() true
+#define CUB_V3_PLUS() false
+#elif CUB_VERSION >= 200800
+// CCCL 2.8 introduced new CUB v3 API.
+#define CUB_V3_4_PLUS() false
+#define CUB_V3_PLUS() true
+#else
+// Pre CCCL 2.8.
+#define CUB_V3_4_PLUS() false
+>>>>>>> c8e24736809 ([ROCm] derive the hipcub compatible cccl version from 'HIPCUB_CCCL_VERSION' (#188072))
 #define CUB_V3_PLUS() false
 #endif

--- a/aten/src/ATen/cuda/cub_definitions.cuh
+++ b/aten/src/ATen/cuda/cub_definitions.cuh
@@ -27,23 +27,9 @@
 #endif
 
 // There were many bc-breaking changes in major version release of CCCL v3.0.0
-<<<<<<< HEAD
 // Please see https://nvidia.github.io/cccl/cccl/3.0_migration_guide.html
 #if CUB_VERSION >= 200800
 #define CUB_V3_PLUS() true
 #else
-=======
-// Please see https://github.com/NVIDIA/cccl/blob/main/docs/cccl/3.0_migration_guide.rst
-#if CUB_VERSION >= 300400
-#define CUB_V3_4_PLUS() true
-#define CUB_V3_PLUS() false
-#elif CUB_VERSION >= 200800
-// CCCL 2.8 introduced new CUB v3 API.
-#define CUB_V3_4_PLUS() false
-#define CUB_V3_PLUS() true
-#else
-// Pre CCCL 2.8.
-#define CUB_V3_4_PLUS() false
->>>>>>> c8e24736809 ([ROCm] derive the hipcub compatible cccl version from 'HIPCUB_CCCL_VERSION' (#188072))
 #define CUB_V3_PLUS() false
 #endif

--- a/cmake/public/LoadHIP.cmake
+++ b/cmake/public/LoadHIP.cmake
@@ -203,6 +203,9 @@ if(HIP_FOUND)
 
   # Optional components.
   find_package_and_print_version(hipsparselt)  # Will be required when ready.
+  # ROCm 8.0 and later requires libhipcxx! This should be marked as
+  # 'REQUIRED' once minimal ROCm version is bumped to 8.0 or later.
+  find_package_and_print_version(libhipcxx)
 
   list(REMOVE_DUPLICATES ROCM_INCLUDE_DIRS)
 


### PR DESCRIPTION
Cherry-pick of https://github.com/pytorch/pytorch/pull/188072 (commit c8e24736809f13a950d6bb825e395b1f7eb81cc8) onto `release/2.11`.

## Summary
- Introduce dependency on libhipcxx
- Guard `FpLimits` for `c10::BFloat16` backport to pre CCCL 3.x
- Extend `CUB_VERSION` derivation for hipCUB using `HIPCUB_CCCL_VERSION`

## Notes
This PR has merge conflicts that need to be resolved manually (conflict markers committed as requested).

## Test plan
- [x] Build with ROCm
  - We were able to run the core PyTorch tests with the changes and verify that they are passing here: https://github.com/ROCm/TheRock/actions/runs/29543286656
- [x] Verify hipCUB/CCCL compatibility glue compiles

Authored with assistance from Cursor

Made with [Cursor](https://cursor.com)