### PR TITLE
[release/2.13] [ROCm] derive the hipcub compatible cccl version from 'HIPCUB_CCCL_VERSION'

### DIFF
--- a/aten/src/ATen/cuda/cub.cuh
+++ b/aten/src/ATen/cuda/cub.cuh
@@ -87,7 +87,11 @@ template<class Iter>
 auto cccl_make_reverse_iterator(Iter it) { return ::thrust::make_reverse_iterator(it); }
 #endif
 
-#if defined(USE_ROCM)
+// Pre ROCm 8.0 we require backporting of FpLimits specialization
+// for 'c10::BFloat16'. However, ROCm 8.0 lifts the compatible
+// CUB version to 3.x which uses libhipcxx and derives numerical
+// limits from there.
+#if defined(USE_ROCM) && CUB_VERSION < 300000
 
 // backport https://github.com/NVIDIA/cub/pull/306 for c10::BFloat16
 

--- a/aten/src/ATen/cuda/cub_definitions.cuh
+++ b/aten/src/ATen/cuda/cub_definitions.cuh
@@ -1,13 +1,19 @@
 #pragma once
 
 #if !defined(USE_ROCM)
-#include <cuda.h>  // for CUDA_VERSION
-#endif
-
-#if !defined(USE_ROCM)
+#include <cuda.h> // for CUDA_VERSION
 #include <cub/version.cuh>
 #else
+// Check if we can find HIPCUB_CCCL_VERSION.
+#include <hipcub/hipcub_version.hpp>
+// Older versions of hipCUB do not support the CUB V3 API.
+#if defined(HIPCUB_CCCL_VERSION) && HIPCUB_CCCL_VERSION >= 300000
+#define CUB_VERSION HIPCUB_CCCL_VERSION
+#else
+// If we cannot find a compatible CCCL version, fallback to
+// a very old version.
 #define CUB_VERSION 200001
+#endif
 #endif
 
 #define USE_GLOBAL_CUB_WRAPPED_NAMESPACE() true
@@ -18,9 +24,11 @@
 #define CUB_V3_4_PLUS() true
 #define CUB_V3_PLUS() false
 #elif CUB_VERSION >= 200800
+// CCCL 2.8 introduced new CUB v3 API.
 #define CUB_V3_4_PLUS() false
 #define CUB_V3_PLUS() true
 #else
+// Pre CCCL 2.8.
 #define CUB_V3_4_PLUS() false
 #define CUB_V3_PLUS() false
 #endif

--- a/cmake/public/LoadHIP.cmake
+++ b/cmake/public/LoadHIP.cmake
@@ -333,6 +333,9 @@ if(PYTORCH_FOUND_HIP)
 
   # Optional components.
   find_package_and_print_version(hipsparselt)  # Will be required when ready.
+  # ROCm 8.0 and later requires libhipcxx! This should be marked as
+  # 'REQUIRED' once minimal ROCm version is bumped to 8.0 or later.
+  find_package_and_print_version(libhipcxx)
 
   list(REMOVE_DUPLICATES ROCM_INCLUDE_DIRS)
 


### PR DESCRIPTION
Cherry-pick of https://github.com/pytorch/pytorch/pull/188072 (commit c8e24736809f13a950d6bb825e395b1f7eb81cc8) onto `release/2.13`.

## Summary
- Introduce dependency on libhipcxx
- Guard `FpLimits` for `c10::BFloat16` backport to pre CCCL 3.x
- Extend `CUB_VERSION` derivation for hipCUB using `HIPCUB_CCCL_VERSION`

## Notes
Cherry-pick applied cleanly.

## Test plan
- [x] Build with ROCm: https://github.com/ROCm/TheRock/actions/runs/29943641797/job/89010396692
- [x] Verify hipCUB/CCCL compatibility glue compiles

Authored with assistance from Cursor

Made with [Cursor](https://cursor.com)