### PR TITLE
release/2.13 bringup: add related_commits

### DIFF
--- a/related_commits
+++ b/related_commits
@@ -1,0 +1,3 @@
+ubuntu|pytorch|apex|release/1.13.0|68f9dc9e316c24ab9c974fafd302e8a7a56fdcff|https://github.com/ROCm/apex
+ubuntu|pytorch|torchvision|release/0.28|8fb87713a24951e639c494b0f2a8a81b5f8e33a6|https://github.com/pytorch/vision
+ubuntu|pytorch|torchaudio|release/2.11.0.2|207d52908b0851523042640485c8c6d0e1198765|https://github.com/ROCm/audio


### PR DESCRIPTION
## Summary

Add `related_commits` for the release/2.13 bringup, pinning the companion repos:

- apex `release/1.13.0` (ROCm/apex, `68f9dc9`)
- torchvision `release/0.28` (upstream pytorch/vision, `8fb8771`) — no ROCm-specific patches on top of 0.28, so pinned to the upstream branch directly (same pattern as torchaudio), rather than creating a ROCm/vision fork branch.
- torchaudio `release/2.11.0.2` (ROCm/audio, `207d529`)
