### PR TITLE
release/2.13 bringup: pin requirements.txt

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -408,7 +408,7 @@ cuda-bindings==13.3.1 ; platform_machine != "s390x" and platform_machine != "ris
 #Description: required for testing CUDAGraph::raw_cuda_graph(). See https://nvidia.github.io/cuda-python/cuda-bindings/latest/support.html for how this version was chosen. PyTorch CI CUDA builds use CUDA 13, so depend on the matching cuda-bindings major while allowing minor updates within that major.
 #test that import: test_cuda.py
 
-cupti-python>13.0 ; platform_system == "Linux" and (platform_machine == "x86_64" or platform_machine == "aarch64") and python_version < "3.14"
+cupti-python==13.3.0 ; platform_system == "Linux" and (platform_machine == "x86_64" or platform_machine == "aarch64") and python_version < "3.14"
 #Description: required for the experimental CUPTI monitor (torch.profiler._cupti_monitor). >13.0 to match CUDA 13.x toolkits. cupti-python only ships Linux x86_64/aarch64 CPython wheels (no 3.14/free-threaded yet), so guard to those.
 #test that import: test_profiler.py
 

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -42,8 +42,10 @@ expecttest==0.3.0
 #Pinned versions: 0.3.0
 #test that import:
 
-fbscribelogger==0.1.7
+fbscribelogger==0.1.7 ; python_version < "3.14"
 #Description: write to scribe from authenticated jobs on CI
+#fbscribelogger caps thriftpy2<0.6.0, which has no cp314 wheel; skip on 3.14
+#(no-op on OSS/ROCm CI anyway) to avoid a source build in the compiler-less test image
 #Pinned versions: 0.1.6
 #test that import:
 

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -404,7 +404,7 @@ tlparse==0.4.0
 filelock==3.20.3
 #Description: required for inductor testing
 
-cuda-bindings==13.3.1 ; platform_machine != "s390x" and platform_machine != "riscv64" and platform_system != "Darwin"
+cuda-bindings>=13.0,<14.0 ; platform_machine != "s390x" and platform_machine != "riscv64" and platform_system != "Darwin"
 #Description: required for testing CUDAGraph::raw_cuda_graph(). See https://nvidia.github.io/cuda-python/cuda-bindings/latest/support.html for how this version was chosen. PyTorch CI CUDA builds use CUDA 13, so depend on the matching cuda-bindings major while allowing minor updates within that major.
 #test that import: test_cuda.py
 

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -15,7 +15,7 @@ build==1.3.0
 #Pinned versions: 1.3.0
 #test that import:
 
-click
+click==8.3.3
 #Description: Command Line Interface Creation Kit
 #Pinned versions:
 #test that import:
@@ -68,7 +68,7 @@ lark==0.12.0
 #Pinned versions: 0.12.0
 #test that import:
 
-librosa>=0.6.2 ; python_version < "3.11" and platform_machine != "s390x"
+librosa==0.11.0 ; python_version < "3.11" and platform_machine != "s390x"
 librosa==0.10.2 ; python_version == "3.12" and platform_machine != "s390x"
 #Description: A python package for music and audio analysis
 #Pinned versions: >=0.6.2
@@ -179,7 +179,7 @@ protobuf==6.33.5
 #Pinned versions: 6.33.2
 #test that import: test_tensorboard.py, test/onnx/*
 
-psutil
+psutil==7.2.2
 #Description: information on running processes and system utilization
 #Pinned versions:
 #test that import: test_profiler.py, test_openmp.py, test_dataloader.py
@@ -199,7 +199,7 @@ pytest-flakefinder==1.1.0
 #Pinned versions: 1.1.0
 #test that import:
 
-pytest-rerunfailures>=10.3
+pytest-rerunfailures==14.0
 #Description: plugin for rerunning failure tests in pytest
 #Pinned versions:
 #test that import:
@@ -281,7 +281,7 @@ typing-extensions==4.15.0 ; python_version >= "3.14"
 #Pinned versions:
 #test that import:
 
-unittest-xml-reporting<=3.2.0,>=2.0.0
+unittest-xml-reporting==3.2.0
 #Description: saves unit test results to xml
 #Pinned versions:
 #test that import:
@@ -297,7 +297,7 @@ spin==0.17
 #Pinned versions: 0.17
 #test that import:
 
-redis>=4.0.0
+redis==8.0.1
 #Description: redis database
 #test that import: anything that tests OSS caching/mocking (inductor/test_codecache.py, inductor/test_max_autotune.py)
 
@@ -377,10 +377,11 @@ pwlf==2.2.1
 # To build PyTorch itself
 pip==26.0.1
 pyyaml==6.0.3
-pyzstd
+pyzstd==0.16.2 ; python_version < "3.13"
+pyzstd==0.19.1 ; python_version >= "3.13"
 setuptools==78.1.1
 packaging==24.2
-six
+six==1.17.0
 
 scons==4.5.2 ; platform_machine == "aarch64"
 
@@ -403,7 +404,7 @@ tlparse==0.4.0
 filelock==3.20.3
 #Description: required for inductor testing
 
-cuda-bindings>=13.0,<14.0 ; platform_machine != "s390x" and platform_machine != "riscv64" and platform_system != "Darwin"
+cuda-bindings==13.3.1 ; platform_machine != "s390x" and platform_machine != "riscv64" and platform_system != "Darwin"
 #Description: required for testing CUDAGraph::raw_cuda_graph(). See https://nvidia.github.io/cuda-python/cuda-bindings/latest/support.html for how this version was chosen. PyTorch CI CUDA builds use CUDA 13, so depend on the matching cuda-bindings major while allowing minor updates within that major.
 #test that import: test_cuda.py
 
@@ -417,7 +418,7 @@ pyre-extensions==0.0.32
 tabulate==0.9.0
 #Description: These package are needed to build FBGEMM and torchrec on PyTorch CI
 
-tqdm>=4.66.0
+tqdm==4.68.4
 #Description: progress bar library required for dynamo benchmarks
 #test that import: benchmarks/dynamo/*
 
@@ -429,7 +430,7 @@ spin==0.17
 #Pinned versions: 0.17
 #test that import: spincli/test_spin.py
 
-uv
+uv==0.11.29
 #Description: required for running spin commands via uvx
 #Pinned version:
 #test that import:

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,11 +1,11 @@
 # Build System requirements
-setuptools>=77.0.0,<82  # 77.0 is the first release with PEP 639 license-files support
-cmake>=3.27
-ninja
-numpy
-packaging>=24.2  # required by setuptools>=77 to validate PEP 639 license expressions
-pyyaml
-requests
-six  # dependency chain: NNPACK -> PeachPy -> six
-typing-extensions>=4.15.0
-pip  # not technically needed, but this makes setup.py invocation work
+setuptools==79.0.1  # 77.0 is the first release with PEP 639 license-files support
+cmake==4.4.0
+ninja==1.13.0
+numpy==2.4.6
+packaging==26.2  # required by setuptools>=77 to validate PEP 639 license expressions
+pyyaml==6.0.3
+requests==2.34.2
+six==1.17.0  # dependency chain: NNPACK -> PeachPy -> six
+typing-extensions==4.16.0
+pip==26.1.2  # not technically needed, but this makes setup.py invocation work

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -2,7 +2,9 @@
 setuptools==81.0.0  # 77.0 is the first release with PEP 639 license-files support (constraint was >=77.0.0,<82)
 cmake==4.4.0
 ninja==1.13.0
-numpy==2.5.1
+numpy==2.2.6 ; python_version < "3.11"
+numpy==2.4.6 ; python_version == "3.11"
+numpy==2.5.1 ; python_version >= "3.12"
 packaging==26.2  # required by setuptools>=77 to validate PEP 639 license expressions
 pyyaml==6.0.3
 requests==2.34.2

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -8,4 +8,4 @@ pyyaml==6.0.3
 requests==2.34.2
 six==1.17.0  # dependency chain: NNPACK -> PeachPy -> six
 typing-extensions==4.16.0
-pip==26.1.2  # not technically needed
+pip==26.1.2  # not technically needed, but this makes setup.py invocation work

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,11 +1,11 @@
 # Build System requirements
-setuptools==79.0.1  # 77.0 is the first release with PEP 639 license-files support
+setuptools==81.0.0  # 77.0 is the first release with PEP 639 license-files support (constraint was >=77.0.0,<82)
 cmake==4.4.0
 ninja==1.13.0
-numpy==2.4.6
+numpy==2.5.1
 packaging==26.2  # required by setuptools>=77 to validate PEP 639 license expressions
 pyyaml==6.0.3
 requests==2.34.2
 six==1.17.0  # dependency chain: NNPACK -> PeachPy -> six
 typing-extensions==4.16.0
-pip==26.1.2  # not technically needed, but this makes setup.py invocation work
+pip==26.1.2  # not technically needed

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,16 +4,17 @@
 --requirement requirements-build.txt
 
 # Install / Development extra requirements
-build[uv]  # for building sdist and wheel
-expecttest>=0.3.0
-filelock
-fsspec>=0.8.5
-hypothesis
-jinja2
-lintrunner ; platform_machine != "s390x"
-networkx>=2.5.1
-optree>=0.13.0
-psutil
-spin
-sympy>=1.13.3
-wheel
+build[uv]==1.3.0  # for building sdist and wheel
+expecttest==0.3.0
+filelock==3.20.3
+fsspec==2026.2.0
+hypothesis==6.56.4
+jinja2==3.1.6
+lintrunner==0.12.11 ; platform_machine != "s390x"
+networkx==2.8.8
+optree==0.13.0 ; python_version < "3.14"
+optree==0.17.0 ; python_version >= "3.14"
+psutil==7.2.2
+spin==0.17
+sympy==1.13.3
+wheel==0.46.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,8 @@ fsspec==2026.6.0
 hypothesis==6.156.6
 jinja2==3.1.6
 lintrunner==0.13.1 ; platform_machine != "s390x"
-networkx==3.6.1
+networkx==3.4.2 ; python_version < "3.11"
+networkx==3.6.1 ; python_version >= "3.11"
 optree==0.19.1
 psutil==7.2.2
 spin==0.18

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,17 +4,16 @@
 --requirement requirements-build.txt
 
 # Install / Development extra requirements
-build[uv]==1.3.0  # for building sdist and wheel
+build[uv]==1.5.0  # for building sdist and wheel
 expecttest==0.3.0
-filelock==3.20.3
-fsspec==2026.2.0
-hypothesis==6.56.4
+filelock==3.29.7
+fsspec==2026.6.0
+hypothesis==6.156.6
 jinja2==3.1.6
-lintrunner==0.12.11 ; platform_machine != "s390x"
-networkx==2.8.8
-optree==0.13.0 ; python_version < "3.14"
-optree==0.17.0 ; python_version >= "3.14"
+lintrunner==0.13.1 ; platform_machine != "s390x"
+networkx==3.6.1
+optree==0.19.1
 psutil==7.2.2
-spin==0.17
-sympy==1.13.3
-wheel==0.46.3
+spin==0.18
+sympy==1.14.0
+wheel==0.47.0


### PR DESCRIPTION
## Summary

Pin Python dependencies for the release/2.13 bringup so CI and builds are reproducible.

- `requirements.txt` — pin all direct dev deps (with a `python_version` split for `networkx`).
- `requirements-build.txt` — pin all build-system deps (with a `python_version` split for `numpy`).
- `.ci/docker/requirements-ci.txt` — pin the 12 previously-loose entries: `click`, `librosa` (`<3.11`), `psutil`, `pytest-rerunfailures`, `unittest-xml-reporting`, `redis`, `pyzstd` (`<3.13` / `>=3.13`), `six`, `tqdm`, `cuda-bindings`, `cupti-python`, `uv`. Everything else in the file was already pinned.

Versions were resolved with `uv pip compile` and verified to resolve cleanly on Python 3.10–3.14.

## Tested/Verified:

TESTED on different versions; good enough results (build steps passed + test failures unrelated to changes):
Py3.10: https://github.com/ROCm/TheRock/actions/runs/29779170268/job/88480432450
Py3.11: https://github.com/ROCm/TheRock/actions/runs/29779138751/job/88480277806
Py3.12: https://github.com/ROCm/TheRock/actions/runs/29593825191/job/87929269396
Py3.13: https://github.com/ROCm/TheRock/actions/runs/29779082237/job/88479960891
Py3.14: https://github.com/ROCm/TheRock/actions/runs/29783793885/job/88490775157

