### PR TITLE
[release/2.10] Update dependency pins for python 3.14

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -105,7 +105,8 @@ mypy==1.16.0 ; platform_system == "Linux"
 #Pinned versions: 1.16.0
 #test that import: test_typing.py, test_type_hints.py
 
-networkx==2.8.8
+networkx==2.8.8 ; python_version < "3.13"
+networkx==3.0.0 ; python_version >= "3.13"
 #Description: creation, manipulation, and study of
 #the structure, dynamics, and functions of complex networks
 #Pinned versions: 2.8.8

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -140,9 +140,11 @@ numba==0.64.0 ; python_version >= "3.14" and platform_machine != "s390x"
 #test_jit.py, test_indexing.py, test_datapipe.py, test_dataloader.py,
 #test_binary_ufuncs.py
 numpy==2.0.2 ; python_version == "3.9"
-numpy==2.1.2 ; python_version > "3.9"
+numpy==2.1.2 ; python_version > "3.9" and python_version < "3.14"
+numpy==2.3.2 ; python_version >= "3.14"
 
-pandas==2.2.3
+pandas==2.2.3 ; python_version < "3.14"
+pandas==2.3.3 ; python_version >= "3.14"
 
 #onnxruntime
 #Description: scoring engine for Open Neural Network Exchange (ONNX) models
@@ -168,7 +170,8 @@ optree==0.17.0 ; python_version >= "3.14"
 #test_pointwise_ops.py, test_dtensor_ops.py, test_torchinductor.py, test_fx.py,
 #test_fake_tensor.py, test_mps.py
 
-pillow==11.0.0
+pillow==11.0.0 ; python_version < "3.14"
+pillow==11.3.0 ; python_version >= "3.14"
 #Description:  Python Imaging Library fork
 #Pinned versions: 11.0.0
 #test that import:
@@ -243,7 +246,8 @@ pygments==2.15.0
 #Pinned versions: 14.1.0
 #test that import:
 
-scikit-image==0.22.0
+scikit-image==0.22.0 ; python_version < "3.13"
+scikit-image==0.26.0 ; python_version >= "3.13"
 #Description: image processing routines
 #Pinned versions: 0.22.0
 #test that import: test_nn.py
@@ -321,7 +325,8 @@ tensorboard==2.18.0
 #test that import: test_tensorboard
 
 pywavelets==1.4.1 ; python_version < "3.12"
-pywavelets==1.7.0 ; python_version >= "3.12"
+pywavelets==1.7.0 ; python_version >= "3.12" and python_version < "3.14"
+pywavelets==1.9.0 ; python_version >= "3.14"
 #Description: This is a requirement of scikit-image, we need to pin
 # it here because 1.5.0 conflicts with numpy 1.21.2 used in CI
 #Pinned versions: 1.4.1
@@ -372,7 +377,8 @@ pwlf==2.2.1
 
 # To build PyTorch itself
 pyyaml==6.0.3
-pyzstd==0.16.2
+pyzstd==0.16.2 ; python_version < "3.14"
+pyzstd==0.18.0 ; python_version >= "3.14"
 setuptools==79.0.1
 packaging==25.0
 six==1.17.0


### PR DESCRIPTION
https://github.com/ROCm/TheRock/pull/5866

Updating pins for python 3.14 because the Rock CI can't build binary dependencies from source, therefore needs to bump several dependencies to a minimal version that ships python 3.14 binaries.

Validation:
py3.13: https://github.com/ROCm/TheRock/actions/runs/29517965462
py3.14: https://github.com/ROCm/TheRock/actions/runs/29517708674