### PR TITLE
[release/2.12] drop fbscribelogger for python 3.14

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -42,7 +42,7 @@ expecttest==0.3.0
 #Pinned versions: 0.3.0
 #test that import:
 
-fbscribelogger==0.1.7
+fbscribelogger==0.1.7 ; python_version < "3.14"
 #Description: write to scribe from authenticated jobs on CI
 #Pinned versions: 0.1.6
 #test that import:


### PR DESCRIPTION
Solves https://github.com/ROCm/TheRock/issues/6723
In the rock core UT workflow, fbscribelogger's transitive dependency thriftpy2 doesn't ship a python 3.14 prebuilt wheel and causing installation to fail because there isn't any compiler available in the environment.
This wasn't observed in previous dependency bump PR runs because those were run on the `test_pytorch_wheels_full` workflow, where a compiler is available, but some headers and libraries are missing. Presumably this dependency doesn't need any of those missing components and therefore able to be built.
Example core UT workflow run: https://github.com/ROCm/TheRock/actions/runs/29853620514 (installation succeeded)