### PR TITLE
[release/2.11] Fix Triton wheel build: preserve TDMCommon.h in package_triton_wheel.sh

### DIFF
--- a/.github/scripts/amd/package_triton_wheel.sh
+++ b/.github/scripts/amd/package_triton_wheel.sh
@@ -28,8 +28,15 @@ if [[ -z "${TRITON_ROCM_DIR}" ]]; then
     export TRITON_ROCM_DIR=third_party/amd/backend
 fi
 
-# Remove packaged libs and headers
-rm -rf $TRITON_ROCM_DIR/include/*
+# Remove previously packaged ROCm headers only.
+# NOTE: do not wipe the whole include dir ("include/*") - it also contains
+# Triton's own AMD backend headers (e.g. TDMCommon.h, required by
+# TritonAMDGPUToLLVM/TDMUtility.cpp as of Triton 3.8.x). Removing them breaks
+# the build with: fatal error: '../../backend/include/TDMCommon.h' file not found.
+rm -rf $TRITON_ROCM_DIR/include/hip \
+       $TRITON_ROCM_DIR/include/roctracer \
+       $TRITON_ROCM_DIR/include/hsa \
+       $TRITON_ROCM_DIR/include/hipblas-common
 
 LIBNUMA_PATH="/usr/lib64/libnuma.so.1"
 LIBELF_PATH="/usr/lib64/libelf.so.1"


### PR DESCRIPTION
## Why

Advancing the Triton pin to the 3.8.x branch tip (#3452) broke the ROCm Triton wheel build:

```
FAILED: third_party/amd/lib/TritonAMDGPUToLLVM/CMakeFiles/TritonAMDGPUToLLVM.dir/TDMUtility.cpp.o
.../triton/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.cpp:8:10: fatal error: '../../backend/include/TDMCommon.h' file not found
    8 | #include "../../backend/include/TDMCommon.h"
ninja: build stopped: subcommand failed.
```

`.github/scripts/amd/package_triton_wheel.sh` runs before `setup.py bdist_wheel` and did `rm -rf $TRITON_ROCM_DIR/include/*`, wiping `third_party/amd/backend/include/` and then copying back only the ROCm system headers (`hip`, `roctracer`, `hsa`, `hipblas-common`). Triton's own `TDMCommon.h` was never restored. Triton 3.8.x newly added `TDMUtility.cpp` which includes `TDMCommon.h`, so the wipe now breaks the build; 3.7.x had no such dependency, which is why it only surfaced after the 3.8.x bump.

## Fix

Remove only the ROCm-vendored header directories that are re-copied later, instead of wiping the entire include directory, so Triton-shipped headers such as `TDMCommon.h` are preserved.

https://rocm-ci.amd.com/job/pytorch2.11-manylinux-wheels_rel-7.2/13/
