### PR TITLE
Use GitHub App token for IFU workflow auth

### DIFF
--- a/.github/workflows/pytorch_ifu.yml
+++ b/.github/workflows/pytorch_ifu.yml
@@ -46,15 +46,23 @@ jobs:
       DOWNSTREAM_REMOTE: origin                              # IFU target remote name
       DOWNSTREAM_REPO: ${{ inputs.ifu_target_repo }}         # target repo for IFU (fork); actions/checkout sets this to origin
       DOWNSTREAM_BRANCH: ${{ inputs.ifu_target_branch }}     # target branch for IFU
-      GH_TOKEN: ${{ secrets.IFU_GITHUB_TOKEN }}              # used by gh; provided by Action 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ROCm
+          repositories: pytorch
+
       - name: Checkout repository (${{ env.DOWNSTREAM_REPO }}) (full history)
         uses: actions/checkout@v4
         with:
           repository: ${{ env.DOWNSTREAM_REPO }}
           path: ${{ env.DOWNSTREAM_REPO }}
           ref: ${{ env.DOWNSTREAM_BRANCH }}
-          token: ${{ env.GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0 # need full history for merges/tags
           submodules: recursive
 
@@ -120,6 +128,8 @@ jobs:
 
       - name: Authenticate gh (non-interactive)
         working-directory: ${{ env.DOWNSTREAM_REPO }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           # The GitHub-hosted runner has gh preinstalled.
           gh auth status || echo "$GH_TOKEN" | gh auth login --with-token
@@ -127,6 +137,8 @@ jobs:
 
       - name: Create Pull Request with gh
         working-directory: ${{ env.DOWNSTREAM_REPO }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           BASE="${DOWNSTREAM_BRANCH}"
           HEAD="${{ steps.tag.outputs.TAG }}"


### PR DESCRIPTION
## Summary

Switch the **PyTorch IFU (Sync with upstream)** workflow (`.github/workflows/pytorch_ifu.yml`) from a PAT (`IFU_GITHUB_TOKEN`) to a **GitHub App token** for authentication.

The previous run on `develop` failed at the checkout step with `fatal: could not read Username for 'https://github.com'` because the injected token could not authenticate. This change generates a short-lived installation token at runtime instead.

## Changes

- Add a **Generate GitHub App token** step (`actions/create-github-app-token@v1`) using the existing `APP_ID` / `APP_PRIVATE_KEY` secrets, scoped to `ROCm/pytorch`.
- Remove the job-level `GH_TOKEN: ${{ secrets.IFU_GITHUB_TOKEN }}` (job-scope env cannot reference step outputs).
- Use the App token for `actions/checkout` (which persists it for the later `git push`).
- Provide `GH_TOKEN` from the App token at step scope for the **Authenticate gh** and **Create Pull Request** steps.

## Test plan

- [x] Dispatch the workflow from this branch (target `release/2.13`, source `release/2.12`).
- [x] Confirm the **Generate GitHub App token** step succeeds and checkout gets past the auth failure.
- [x] Confirm the full run completes: merge, push branch/tag, and PR creation.


Full successful run here: https://github.com/ROCm/pytorch/actions/runs/29952986477/job/89034987326
