### PR TITLE
[release/2.13] Update torchaudio commit hash in related_commits

### DIFF
--- a/related_commits
+++ b/related_commits
@@ -1,3 +1,3 @@
 ubuntu|pytorch|apex|release/1.13.0|68f9dc9e316c24ab9c974fafd302e8a7a56fdcff|https://github.com/ROCm/apex
 ubuntu|pytorch|torchvision|release/0.28|8fb87713a24951e639c494b0f2a8a81b5f8e33a6|https://github.com/pytorch/vision
-ubuntu|pytorch|torchaudio|release/2.11.0.2|207d52908b0851523042640485c8c6d0e1198765|https://github.com/ROCm/audio
+ubuntu|pytorch|torchaudio|release/2.11.0.2|b3ec2afa3ae504ca600d5e08956eb13d6e2aee31|https://github.com/ROCm/audio


### PR DESCRIPTION
## Motivation

Pick up changes from https://github.com/ROCm/audio/pull/18 to resolve torchaudio build issues with CCCL changes added to PyTorch 2.13 in  https://github.com/ROCm/pytorch/pull/3442

## Technical Details

[2.13 build](https://github.com/ROCm/TheRock/actions/runs/29541268387/job/87816472633) failed with a torchaudio build error:
```
2026-07-17T06:17:07.2596766Z [3/3] /opt/python/cp312-cp312/lib/python3.12/site-packages/_rocm_sdk_devel/bin/hipcc  -I/__w/TheRock/TheRock/external-builds/pytorch/pytorch_audio/src/libtorchaudio/cuctc -I/__w/TheRock/TheRock/external-builds/pytorch/pytorch_audio/src -I/opt/python/cp312-cp312/lib/python3.12/site-packages/torch/include -I/opt/python/cp312-cp312/lib/python3.12/site-packages/torch/include/torch/csrc/api/include -I/opt/python/cp312-cp312/lib/python3.12/site-packages/torch/include/THH -I/opt/python/cp312-cp312/lib/python3.12/site-packages/_rocm_sdk_devel/include -I/opt/_internal/cpython-3.12.10/include/python3.12 -c -c /__w/TheRock/TheRock/external-builds/pytorch/pytorch_audio/src/libtorchaudio/cuctc/src/ctc_prefix_decoder_kernel_v2.hip -o /__w/TheRock/TheRock/external-builds/pytorch/pytorch_audio/build/temp.linux-x86_64-cpython-312/src/libtorchaudio/cuctc/src/ctc_prefix_decoder_kernel_v2.o -D__HIP_PLATFORM_AMD__=1 -DUSE_ROCM=1 -DHIPBLAS_V2 -fPIC -DCUDA_HAS_FP16=1 -D__HIP_NO_HALF_OPERATORS__=1 -D__HIP_NO_HALF_CONVERSIONS__=1 -DHIP_ENABLE_WARP_SYNC_BUILTINS=1 -O3 -DTORCH_HIP_VERSION=715 -DTORCH_API_INCLUDE_EXTENSION_H -DPy_LIMITED_API=0x030A0000 -DTORCH_EXTENSION_NAME=torchaudio_prefixctc --offload-arch=gfx942 -fno-gpu-rdc -std=c++20
2026-07-17T06:17:07.2599074Z Traceback (most recent call last):
2026-07-17T06:17:07.2599366Z   File "/opt/python/cp312-cp312/lib/python3.12/site-packages/torch/utils/cpp_extension.py", line 2893, in _run_ninja_build
2026-07-17T06:17:07.2599875Z FAILED: [code=1] /__w/TheRock/TheRock/external-builds/pytorch/pytorch_audio/build/temp.linux-x86_64-cpython-312/src/libtorchaudio/cuctc/src/ctc_prefix_decoder_kernel_v2.o 
2026-07-17T06:17:07.2602243Z /opt/python/cp312-cp312/lib/python3.12/site-packages/_rocm_sdk_devel/bin/hipcc  -I/__w/TheRock/TheRock/external-builds/pytorch/pytorch_audio/src/libtorchaudio/cuctc -I/__w/TheRock/TheRock/external-builds/pytorch/pytorch_audio/src -I/opt/python/cp312-cp312/lib/python3.12/site-packages/torch/include -I/opt/python/cp312-cp312/lib/python3.12/site-packages/torch/include/torch/csrc/api/include -I/opt/python/cp312-cp312/lib/python3.12/site-packages/torch/include/THH -I/opt/python/cp312-cp312/lib/python3.12/site-packages/_rocm_sdk_devel/include -I/opt/_internal/cpython-3.12.10/include/python3.12 -c -c /__w/TheRock/TheRock/external-builds/pytorch/pytorch_audio/src/libtorchaudio/cuctc/src/ctc_prefix_decoder_kernel_v2.hip -o /__w/TheRock/TheRock/external-builds/pytorch/pytorch_audio/build/temp.linux-x86_64-cpython-312/src/libtorchaudio/cuctc/src/ctc_prefix_decoder_kernel_v2.o -D__HIP_PLATFORM_AMD__=1 -DUSE_ROCM=1 -DHIPBLAS_V2 -fPIC -DCUDA_HAS_FP16=1 -D__HIP_NO_HALF_OPERATORS__=1 -D__HIP_NO_HALF_CONVERSIONS__=1 -DHIP_ENABLE_WARP_SYNC_BUILTINS=1 -O3 -DTORCH_HIP_VERSION=715 -DTORCH_API_INCLUDE_EXTENSION_H -DPy_LIMITED_API=0x030A0000 -DTORCH_EXTENSION_NAME=torchaudio_prefixctc --offload-arch=gfx942 -fno-gpu-rdc -std=c++20
2026-07-17T06:17:07.2604662Z /__w/TheRock/TheRock/external-builds/pytorch/pytorch_audio/src/libtorchaudio/cuctc/src/ctc_prefix_decoder_kernel_v2.hip:449:15: error: no member named 'FpLimits' in namespace 'hipcub'
2026-07-17T06:17:07.2605073Z   449 |       hipcub::FpLimits<float>::Lowest(),
2026-07-17T06:17:07.2605234Z       |               ^~~~~~~~
2026-07-17T06:17:07.2605613Z /__w/TheRock/TheRock/external-builds/pytorch/pytorch_audio/src/libtorchaudio/cuctc/src/ctc_prefix_decoder_kernel_v2.hip:449:29: error: expected '(' for function-style cast or type construction
2026-07-17T06:17:07.2606041Z   449 |       hipcub::FpLimits<float>::Lowest(),
2026-07-17T06:17:07.2606201Z       |                        ~~~~~^
2026-07-17T06:17:07.2606574Z /__w/TheRock/TheRock/external-builds/pytorch/pytorch_audio/src/libtorchaudio/cuctc/src/ctc_prefix_decoder_kernel_v2.hip:449:32: error: no member named 'Lowest' in the global namespace
2026-07-17T06:17:07.2606961Z   449 |       hipcub::FpLimits<float>::Lowest(),
2026-07-17T06:17:07.2607121Z       |                                ^~~~~~
2026-07-17T06:17:07.2607282Z 3 errors generated when compiling for gfx942.
2026-07-17T06:17:07.2609497Z failed to execute:"/usr/local/bin/sccache" "/opt/python/cp312-cp312/lib/python3.12/site-packages/_rocm_sdk_devel/lib/llvm/bin/clang++"  --offload-arch=gfx942  -I/__w/TheRock/TheRock/external-builds/pytorch/pytorch_audio/src/libtorchaudio/cuctc -I/__w/TheRock/TheRock/external-builds/pytorch/pytorch_audio/src -I/opt/python/cp312-cp312/lib/python3.12/site-packages/torch/include -I/opt/python/cp312-cp312/lib/python3.12/site-packages/torch/include/torch/csrc/api/include -I/opt/python/cp312-cp312/lib/python3.12/site-packages/torch/include/THH -I/opt/python/cp312-cp312/lib/python3.12/site-packages/_rocm_sdk_devel/include -I/opt/_internal/cpython-3.12.10/include/python3.12 -c -c -x hip /__w/TheRock/TheRock/external-builds/pytorch/pytorch_audio/src/libtorchaudio/cuctc/src/ctc_prefix_decoder_kernel_v2.hip -o "/__w/TheRock/TheRock/external-builds/pytorch/pytorch_audio/build/temp.linux-x86_64-cpython-312/src/libtorchaudio/cuctc/src/ctc_prefix_decoder_kernel_v2.o" -D__HIP_PLATFORM_AMD__=1 -DUSE_ROCM=1 -DHIPBLAS_V2 -fPIC -DCUDA_HAS_FP16=1 -D__HIP_NO_HALF_OPERATORS__=1 -D__HIP_NO_HALF_CONVERSIONS__=1 -DHIP_ENABLE_WARP_SYNC_BUILTINS=1 -O3 -DTORCH_HIP_VERSION=715 -DTORCH_API_INCLUDE_EXTENSION_H -DPy_LIMITED_API=0x030A0000 -DTORCH_EXTENSION_NAME=torchaudio_prefixctc -fno-gpu-rdc -std=c++20
2026-07-17T06:17:07.2611802Z ninja: build stopped: subcommand failed.
```

## Test Plan

Tested using https://github.com/ROCm/TheRock/actions/runs/29943641797/job/89010396692, which used 
a temporary branch with [this change](https://github.com/ROCm/pytorch/commit/d41798d317ab129ae395e2b7576e707aaedfa7f7) to test out the torchaudio fix.

## Test Result

From https://github.com/ROCm/TheRock/actions/runs/29943641797/job/89010396692: `2026-07-22T18:11:26.3489091Z Found built wheel: /__w/TheRock/TheRock/external-builds/pytorch/pytorch_audio/dist/torchaudio-2.11.0.2+devrocm7.15.0.dev0.a703bfe5b151ffb3333cd6bed241373adef42300-cp312-cp312-linux_x86_64.whl`

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
