### PR TITLE
[CI] Parity: move rocm-nightly job prefix to mi350 (gfx950 runners)

### DIFF
--- a/.automation_scripts/pytorch-unit-test-scripts/parity_job_config.json
+++ b/.automation_scripts/pytorch-unit-test-scripts/parity_job_config.json
@@ -65,9 +65,9 @@
       "checkrun_regex": "rocm.*navi31.*/ test [(]default,"
     },
     "nightly": {
-      "default": [{ "workflow": "rocm-nightly", "job_prefix": "linux-noble-rocm-nightly-py3.12-gfx942" }],
-      "distributed": [{ "workflow": "rocm-nightly", "job_prefix": "linux-noble-rocm-nightly-py3.12-gfx942" }],
-      "inductor": [{ "workflow": "rocm-nightly", "job_prefix": "linux-noble-rocm-nightly-py3.12-gfx942" }],
+      "default": [{ "workflow": "rocm-nightly", "job_prefix": "linux-noble-rocm-nightly-py3.12-mi350" }],
+      "distributed": [{ "workflow": "rocm-nightly", "job_prefix": "linux-noble-rocm-nightly-py3.12-mi350" }],
+      "inductor": [{ "workflow": "rocm-nightly", "job_prefix": "linux-noble-rocm-nightly-py3.12-mi350" }],
       "shard_counts": { "default": 6, "distributed": 3, "inductor": 2 },
       "checkrun_regex": "rocm-nightly.*/ test [(](default|distributed|inductor),"
     }


### PR DESCRIPTION
## Summary

pytorch#190263 moves the `rocm-nightly` workflow from MI300 (gfx942) to MI350 (gfx950) runners, which renames its test jobs from `linux-noble-rocm-nightly-py3.12-gfx942` to `linux-noble-rocm-nightly-py3.12-mi350`. Update the parity `nightly` config `job_prefix` to match so the tooling can resolve/download the nightly results again.

## Validation

Ran parity on pytorch#190263 (SHA c0ada2a) with this change: nightly jobs now resolve and download from `rocm-nightly` run 29947213809 (default 6 / distributed 3 / inductor 2 shards on gfx950), capturing 58 ROCm FAILED tests + 74 log-based failures. (Job flags failed only because that PR has no CUDA baseline run, which is unrelated.): https://github.com/ethanwee1/rocm-pytorch-ethanwee/actions/runs/30014439804/job/89230642489

## Test plan
- [x] JSON validates
- [x] parity run on pytorch#190263 resolves the mi350 nightly jobs and downloads results
