### PR TITLE
[CI] Parity: sync mi200 shard counts (default 10, inductor 4)

### DIFF
--- a/.automation_scripts/pytorch-unit-test-scripts/parity_job_config.json
+++ b/.automation_scripts/pytorch-unit-test-scripts/parity_job_config.json
@@ -54,7 +54,7 @@
         { "workflow": "inductor-rocm-mi200", "job_prefix": "linux-jammy-rocm-py3.10-mi200" },
         { "workflow": "trunk-rocm-sandbox", "job_prefix": "linux-jammy-rocm-py3.10" }
       ],
-      "shard_counts": { "default": 6, "distributed": 3, "inductor": 2 },
+      "shard_counts": { "default": 10, "distributed": 3, "inductor": 4 },
       "checkrun_regex": "(rocm.*(mi200|mi210).*/ test [(](default|distributed|inductor),|linux-jammy-rocm-py3[.]10 / test [(](default|distributed|inductor),)"
     },
     "navi31": {


### PR DESCRIPTION
## Summary

The mi200 CI workflows were re-sharded upstream:
- `rocm-mi200.yml` default: **6 -> 10** shards
- `inductor-rocm-mi200.yml` inductor: **2 -> 4** shards
- `periodic-rocm-mi200.yml` distributed: unchanged (3)

Job prefixes (`linux-jammy-rocm-py3.10-mi200`) and runners (mi210) are unchanged. `derive_shard_count` reads the real totals from the resolved run at runtime, but this syncs the `mi200.shard_counts` fallback so it is accurate when the jobs API is unavailable and for the `trunk-rocm-sandbox` fallback path.

## Test plan
- [x] JSON validates
- [x] Deployed to fork main; mi200 parity resolves 10 default / 4 inductor / 3 distributed shards
