### PR TITLE
[Profiler] Add opt-in ROCTx ranges to record_function

### DIFF
--- a/test/profiler/test_record_function.py
+++ b/test/profiler/test_record_function.py
@@ -1,9 +1,12 @@
 # Owner(s): ["oncall: profiler"]
 # ruff: noqa: F841
 
+import sys
 from typing import Any
+from unittest import mock
 
 import torch
+import torch.autograd.profiler as autograd_profiler
 import torch.optim
 import torch.utils.data
 import torch.utils.data.datapipes as dp
@@ -35,6 +38,18 @@ Json = dict[str, Any]
 
 
 class TestRecordFunction(TestCase):
+    class _FakeRoctx:
+        def __init__(self):
+            self.events = []
+
+        def rangePush(self, name):
+            self.events.append(("push", name))
+            return 0
+
+        def rangePop(self):
+            self.events.append(("pop", None))
+            return 0
+
     def _record_function_with_param(self):
         u = torch.randn(3, 4, 5, requires_grad=True)
         with _profile(
@@ -73,6 +88,159 @@ class TestRecordFunction(TestCase):
         self.assertTrue(found_test_2)
         self.assertTrue(found_test_3)
         self.assertTrue(found_test_4)
+
+    def test_record_function_roctx_ranges(self):
+        roctx = self._FakeRoctx()
+        with (
+            mock.patch.object(autograd_profiler, "_roctx_markers_enabled", True),
+            mock.patch.object(autograd_profiler, "_roctx_module", roctx),
+            mock.patch.object(
+                autograd_profiler, "_nvtx_profiler_active", return_value=False
+            ),
+        ):
+            with record_function("outer"):
+                with record_function("inner"):
+                    pass
+
+        self.assertEqual(
+            roctx.events,
+            [
+                ("push", "outer"),
+                ("push", "inner"),
+                ("pop", None),
+                ("pop", None),
+            ],
+        )
+
+    def test_record_function_roctx_balanced_on_exception(self):
+        roctx = self._FakeRoctx()
+        with (
+            mock.patch.object(autograd_profiler, "_roctx_markers_enabled", True),
+            mock.patch.object(autograd_profiler, "_roctx_module", roctx),
+            mock.patch.object(
+                autograd_profiler, "_nvtx_profiler_active", return_value=False
+            ),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "expected"):
+                with record_function("failing"):
+                    raise RuntimeError("expected")
+
+        self.assertEqual(roctx.events, [("push", "failing"), ("pop", None)])
+
+    def test_record_function_roctx_disabled_or_nvtx_active(self):
+        roctx = self._FakeRoctx()
+        with (
+            mock.patch.object(autograd_profiler, "_roctx_markers_enabled", False),
+            mock.patch.object(autograd_profiler, "_roctx_module", roctx),
+        ):
+            with record_function("disabled"):
+                pass
+
+        with (
+            mock.patch.object(autograd_profiler, "_roctx_markers_enabled", True),
+            mock.patch.object(autograd_profiler, "_roctx_module", roctx),
+            mock.patch.object(
+                autograd_profiler, "_nvtx_profiler_active", return_value=True
+            ),
+        ):
+            with record_function("nvtx"):
+                pass
+
+        self.assertEqual(roctx.events, [])
+
+    def test_record_function_roctx_closes_before_deferred_callbacks(self):
+        roctx = self._FakeRoctx()
+        with (
+            mock.patch.object(autograd_profiler, "_roctx_markers_enabled", True),
+            mock.patch.object(autograd_profiler, "_roctx_module", roctx),
+            mock.patch.object(
+                autograd_profiler, "_nvtx_profiler_active", return_value=False
+            ),
+        ):
+            future: torch.futures.Future[int] = torch.futures.Future()
+            with record_function("deferred") as rf:
+                profiled_future = rf._call_end_callbacks_on_future(future)
+
+            self.assertEqual(roctx.events, [("push", "deferred"), ("pop", None)])
+            future.set_result(1)
+            self.assertEqual(profiled_future.wait(), 1)
+
+    def test_record_function_roctx_lazy_import(self):
+        roctx = self._FakeRoctx()
+        with (
+            mock.patch.object(autograd_profiler, "_roctx_markers_enabled", True),
+            mock.patch.object(autograd_profiler, "_roctx_module", None),
+            mock.patch.object(
+                autograd_profiler, "_nvtx_profiler_active", return_value=False
+            ),
+            mock.patch.object(
+                autograd_profiler.importlib,
+                "import_module",
+                return_value=roctx,
+            ) as import_module,
+        ):
+            with record_function("first"):
+                pass
+            with record_function("second"):
+                pass
+
+        import_module.assert_called_once_with("roctx")
+        self.assertEqual(
+            roctx.events,
+            [
+                ("push", "first"),
+                ("pop", None),
+                ("push", "second"),
+                ("pop", None),
+            ],
+        )
+
+    def test_record_function_roctx_missing_module(self):
+        rf = record_function("missing_roctx")
+        with (
+            mock.patch.object(autograd_profiler, "_roctx_markers_enabled", True),
+            mock.patch.object(autograd_profiler, "_roctx_module", None),
+            mock.patch.object(
+                autograd_profiler, "_nvtx_profiler_active", return_value=False
+            ),
+            mock.patch.dict(sys.modules, {"roctx": None}),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "requires.*roctx.*module"):
+                rf.__enter__()
+
+        self.assertIsNone(rf.record)
+
+    def test_record_function_roctx_pop_failure_can_be_retried(self):
+        class FailOnceRoctx(TestRecordFunction._FakeRoctx):
+            def __init__(self):
+                super().__init__()
+                self.fail_pop = True
+
+            def rangePop(self):
+                if self.fail_pop:
+                    self.fail_pop = False
+                    raise RuntimeError("pop failed")
+                return super().rangePop()
+
+        roctx = FailOnceRoctx()
+        with (
+            mock.patch.object(autograd_profiler, "_roctx_markers_enabled", True),
+            mock.patch.object(autograd_profiler, "_roctx_module", roctx),
+            mock.patch.object(
+                autograd_profiler, "_nvtx_profiler_active", return_value=False
+            ),
+        ):
+            rf = record_function("retry")
+            rf.__enter__()
+            with self.assertRaisesRegex(RuntimeError, "pop failed"):
+                rf.__exit__(None, None, None)
+            self.assertTrue(rf._roctx_range_active)
+
+            rf.run_callbacks_on_exit = False
+            rf.__exit__(None, None, None)
+            self.assertFalse(rf._roctx_range_active)
+
+        self.assertEqual(roctx.events, [("push", "retry"), ("pop", None)])
 
     def test_datapipe_with_record_function(self):
         with _profile(

--- a/test/profiler/test_record_function.py
+++ b/test/profiler/test_record_function.py
@@ -2,6 +2,7 @@
 # ruff: noqa: F841
 
 import sys
+import threading
 from typing import Any
 from unittest import mock
 
@@ -19,7 +20,6 @@ from torch.autograd import (
 from torch.autograd.profiler import profile as _profile
 from torch.profiler import kineto_available, record_function
 from torch.testing._internal.common_utils import run_tests, TestCase
-
 
 # if tqdm is not shutdown properly, it will leave the monitor thread alive.
 # This causes an issue in the multithreading test because we check all events
@@ -41,6 +41,7 @@ class TestRecordFunction(TestCase):
     class _FakeRoctx:
         def __init__(self):
             self.events = []
+            self.profiler_count = 0
 
         def rangePush(self, name):
             self.events.append(("push", name))
@@ -48,6 +49,16 @@ class TestRecordFunction(TestCase):
 
         def rangePop(self):
             self.events.append(("pop", None))
+            return 0
+
+        def profilerResume(self, tid=0):
+            self.events.append(("resume", tid))
+            self.profiler_count += 1
+            return 0
+
+        def profilerPause(self, tid=0):
+            self.events.append(("pause", tid))
+            self.profiler_count -= 1
             return 0
 
     def _record_function_with_param(self):
@@ -93,6 +104,9 @@ class TestRecordFunction(TestCase):
         roctx = self._FakeRoctx()
         with (
             mock.patch.object(autograd_profiler, "_roctx_markers_enabled", True),
+            mock.patch.object(
+                autograd_profiler, "_roctx_selected_regions_enabled", False
+            ),
             mock.patch.object(autograd_profiler, "_roctx_module", roctx),
             mock.patch.object(
                 autograd_profiler, "_nvtx_profiler_active", return_value=False
@@ -116,6 +130,9 @@ class TestRecordFunction(TestCase):
         roctx = self._FakeRoctx()
         with (
             mock.patch.object(autograd_profiler, "_roctx_markers_enabled", True),
+            mock.patch.object(
+                autograd_profiler, "_roctx_selected_regions_enabled", False
+            ),
             mock.patch.object(autograd_profiler, "_roctx_module", roctx),
             mock.patch.object(
                 autograd_profiler, "_nvtx_profiler_active", return_value=False
@@ -138,6 +155,9 @@ class TestRecordFunction(TestCase):
 
         with (
             mock.patch.object(autograd_profiler, "_roctx_markers_enabled", True),
+            mock.patch.object(
+                autograd_profiler, "_roctx_selected_regions_enabled", False
+            ),
             mock.patch.object(autograd_profiler, "_roctx_module", roctx),
             mock.patch.object(
                 autograd_profiler, "_nvtx_profiler_active", return_value=True
@@ -152,6 +172,9 @@ class TestRecordFunction(TestCase):
         roctx = self._FakeRoctx()
         with (
             mock.patch.object(autograd_profiler, "_roctx_markers_enabled", True),
+            mock.patch.object(
+                autograd_profiler, "_roctx_selected_regions_enabled", False
+            ),
             mock.patch.object(autograd_profiler, "_roctx_module", roctx),
             mock.patch.object(
                 autograd_profiler, "_nvtx_profiler_active", return_value=False
@@ -169,6 +192,9 @@ class TestRecordFunction(TestCase):
         roctx = self._FakeRoctx()
         with (
             mock.patch.object(autograd_profiler, "_roctx_markers_enabled", True),
+            mock.patch.object(
+                autograd_profiler, "_roctx_selected_regions_enabled", False
+            ),
             mock.patch.object(autograd_profiler, "_roctx_module", None),
             mock.patch.object(
                 autograd_profiler, "_nvtx_profiler_active", return_value=False
@@ -199,6 +225,9 @@ class TestRecordFunction(TestCase):
         rf = record_function("missing_roctx")
         with (
             mock.patch.object(autograd_profiler, "_roctx_markers_enabled", True),
+            mock.patch.object(
+                autograd_profiler, "_roctx_selected_regions_enabled", False
+            ),
             mock.patch.object(autograd_profiler, "_roctx_module", None),
             mock.patch.object(
                 autograd_profiler, "_nvtx_profiler_active", return_value=False
@@ -225,6 +254,9 @@ class TestRecordFunction(TestCase):
         roctx = FailOnceRoctx()
         with (
             mock.patch.object(autograd_profiler, "_roctx_markers_enabled", True),
+            mock.patch.object(
+                autograd_profiler, "_roctx_selected_regions_enabled", False
+            ),
             mock.patch.object(autograd_profiler, "_roctx_module", roctx),
             mock.patch.object(
                 autograd_profiler, "_nvtx_profiler_active", return_value=False
@@ -241,6 +273,388 @@ class TestRecordFunction(TestCase):
             self.assertFalse(rf._roctx_range_active)
 
         self.assertEqual(roctx.events, [("push", "retry"), ("pop", None)])
+
+    def test_record_function_roctx_selected_regions(self):
+        roctx = self._FakeRoctx()
+        with (
+            mock.patch.object(autograd_profiler, "_roctx_markers_enabled", True),
+            mock.patch.object(
+                autograd_profiler, "_roctx_selected_regions_enabled", True
+            ),
+            mock.patch.object(autograd_profiler, "_roctx_module", roctx),
+            mock.patch.object(
+                autograd_profiler, "_nvtx_profiler_active", return_value=False
+            ),
+        ):
+            with record_function("outer"):
+                with record_function("inner"):
+                    pass
+
+        self.assertEqual(
+            roctx.events,
+            [
+                ("resume", 0),
+                ("push", "outer"),
+                ("resume", 0),
+                ("push", "inner"),
+                ("pop", None),
+                ("pause", 0),
+                ("pop", None),
+                ("pause", 0),
+            ],
+        )
+
+    def test_record_function_roctx_selected_regions_overlapping_threads(self):
+        roctx = self._FakeRoctx()
+        entered = threading.Barrier(3)
+        exit_range = threading.Barrier(3)
+        errors = []
+
+        @record_function("worker")
+        def decorated_worker():
+            entered.wait(timeout=10)
+            exit_range.wait(timeout=10)
+
+        def worker():
+            try:
+                decorated_worker()
+            except Exception as error:
+                errors.append(error)
+
+        with (
+            mock.patch.object(autograd_profiler, "_roctx_markers_enabled", True),
+            mock.patch.object(
+                autograd_profiler, "_roctx_selected_regions_enabled", True
+            ),
+            mock.patch.object(autograd_profiler, "_roctx_module", roctx),
+            mock.patch.object(
+                autograd_profiler, "_nvtx_profiler_active", return_value=False
+            ),
+        ):
+            threads = [threading.Thread(target=worker) for _ in range(2)]
+            for thread in threads:
+                thread.start()
+            entered.wait(timeout=10)
+            exit_range.wait(timeout=10)
+            for thread in threads:
+                thread.join(timeout=10)
+                self.assertFalse(thread.is_alive())
+
+        self.assertEqual(errors, [])
+        self.assertEqual(len(roctx.events), 8)
+        self.assertEqual(sum(event[0] == "resume" for event in roctx.events), 2)
+        self.assertEqual(sum(event[0] == "push" for event in roctx.events), 2)
+        self.assertEqual(sum(event[0] == "pop" for event in roctx.events), 2)
+        self.assertEqual(sum(event[0] == "pause" for event in roctx.events), 2)
+        self.assertEqual(
+            {event[1] for event in roctx.events if event[0] == "push"},
+            {"worker"},
+        )
+        self.assertEqual(roctx.profiler_count, 0)
+
+    def test_record_function_roctx_selected_regions_balanced_on_exception(self):
+        roctx = self._FakeRoctx()
+        with (
+            mock.patch.object(autograd_profiler, "_roctx_markers_enabled", True),
+            mock.patch.object(
+                autograd_profiler, "_roctx_selected_regions_enabled", True
+            ),
+            mock.patch.object(autograd_profiler, "_roctx_module", roctx),
+            mock.patch.object(
+                autograd_profiler, "_nvtx_profiler_active", return_value=False
+            ),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "expected"):
+                with record_function("failing"):
+                    raise RuntimeError("expected")
+
+        self.assertEqual(
+            roctx.events,
+            [
+                ("resume", 0),
+                ("push", "failing"),
+                ("pop", None),
+                ("pause", 0),
+            ],
+        )
+
+    def test_record_function_roctx_selected_regions_with_nvtx(self):
+        roctx = self._FakeRoctx()
+        with (
+            mock.patch.object(autograd_profiler, "_roctx_markers_enabled", True),
+            mock.patch.object(
+                autograd_profiler, "_roctx_selected_regions_enabled", True
+            ),
+            mock.patch.object(autograd_profiler, "_roctx_module", roctx),
+            mock.patch.object(
+                autograd_profiler, "_nvtx_profiler_active", return_value=True
+            ),
+        ):
+            with record_function("nvtx"):
+                pass
+
+        self.assertEqual(roctx.events, [("resume", 0), ("pause", 0)])
+
+    def test_record_function_roctx_selected_regions_deferred_callbacks(self):
+        roctx = self._FakeRoctx()
+        with (
+            mock.patch.object(autograd_profiler, "_roctx_markers_enabled", True),
+            mock.patch.object(
+                autograd_profiler, "_roctx_selected_regions_enabled", True
+            ),
+            mock.patch.object(autograd_profiler, "_roctx_module", roctx),
+            mock.patch.object(
+                autograd_profiler, "_nvtx_profiler_active", return_value=False
+            ),
+        ):
+            future: torch.futures.Future[int] = torch.futures.Future()
+            with record_function("deferred") as rf:
+                profiled_future = rf._call_end_callbacks_on_future(future)
+
+            self.assertEqual(
+                roctx.events,
+                [
+                    ("resume", 0),
+                    ("push", "deferred"),
+                    ("pop", None),
+                    ("pause", 0),
+                ],
+            )
+            future.set_result(1)
+            self.assertEqual(profiled_future.wait(), 1)
+
+    def test_record_function_roctx_selected_regions_push_failure_pauses(self):
+        class FailPushRoctx(TestRecordFunction._FakeRoctx):
+            def rangePush(self, name):
+                raise RuntimeError("push failed")
+
+        roctx = FailPushRoctx()
+        rf = record_function("failing_push")
+        with (
+            mock.patch.object(autograd_profiler, "_roctx_markers_enabled", True),
+            mock.patch.object(
+                autograd_profiler, "_roctx_selected_regions_enabled", True
+            ),
+            mock.patch.object(autograd_profiler, "_roctx_module", roctx),
+            mock.patch.object(
+                autograd_profiler, "_nvtx_profiler_active", return_value=False
+            ),
+            self.assertRaisesRegex(RuntimeError, "push failed"),
+        ):
+            rf.__enter__()
+
+        self.assertIsNone(rf.record)
+        self.assertFalse(rf._roctx_range_active)
+        self.assertFalse(rf._roctx_profiler_region_active)
+        self.assertEqual(roctx.events, [("resume", 0), ("pause", 0)])
+        self.assertEqual(roctx.profiler_count, 0)
+
+    def test_record_function_roctx_selected_regions_resume_failure_does_not_enter(
+        self,
+    ):
+        class FailResumeRoctx(TestRecordFunction._FakeRoctx):
+            def profilerResume(self, tid=0):
+                super().profilerResume(tid)
+                return 1
+
+        roctx = FailResumeRoctx()
+        rf = record_function("failing_resume")
+        with (
+            mock.patch.object(autograd_profiler, "_roctx_markers_enabled", True),
+            mock.patch.object(
+                autograd_profiler, "_roctx_selected_regions_enabled", True
+            ),
+            mock.patch.object(autograd_profiler, "_roctx_module", roctx),
+            self.assertRaisesRegex(RuntimeError, "resume failed"),
+        ):
+            rf.__enter__()
+
+        self.assertIsNone(rf.record)
+        self.assertFalse(rf._roctx_range_active)
+        self.assertFalse(rf._roctx_profiler_region_active)
+        self.assertEqual(roctx.events, [("resume", 0), ("pause", 0)])
+        self.assertEqual(roctx.profiler_count, 0)
+
+    def test_record_function_roctx_selected_regions_pop_failure_can_be_retried(self):
+        class FailOnceRoctx(TestRecordFunction._FakeRoctx):
+            def __init__(self):
+                super().__init__()
+                self.fail_pop = True
+
+            def rangePop(self):
+                if self.fail_pop:
+                    self.fail_pop = False
+                    raise RuntimeError("pop failed")
+                return super().rangePop()
+
+        roctx = FailOnceRoctx()
+        with (
+            mock.patch.object(autograd_profiler, "_roctx_markers_enabled", True),
+            mock.patch.object(
+                autograd_profiler, "_roctx_selected_regions_enabled", True
+            ),
+            mock.patch.object(autograd_profiler, "_roctx_module", roctx),
+            mock.patch.object(
+                autograd_profiler, "_nvtx_profiler_active", return_value=False
+            ),
+        ):
+            rf = record_function("retry")
+            rf.__enter__()
+            with self.assertRaisesRegex(RuntimeError, "pop failed"):
+                rf.__exit__(None, None, None)
+
+            self.assertTrue(rf._roctx_range_active)
+            self.assertTrue(rf._roctx_range_pop_pending)
+            self.assertFalse(rf._roctx_profiler_region_active)
+
+            rf.run_callbacks_on_exit = False
+            rf.__exit__(None, None, None)
+
+        self.assertFalse(rf._roctx_range_active)
+        self.assertFalse(rf._roctx_range_pop_pending)
+        self.assertFalse(rf._roctx_profiler_region_active)
+        self.assertEqual(roctx.profiler_count, 0)
+        self.assertEqual(
+            roctx.events,
+            [
+                ("resume", 0),
+                ("push", "retry"),
+                ("pause", 0),
+                ("resume", 0),
+                ("pop", None),
+                ("pause", 0),
+            ],
+        )
+
+    def test_record_function_roctx_selected_regions_nested_pop_failure(self):
+        class FailOnceRoctx(TestRecordFunction._FakeRoctx):
+            def __init__(self):
+                super().__init__()
+                self.fail_pop = True
+
+            def rangePop(self):
+                if self.fail_pop:
+                    self.fail_pop = False
+                    raise RuntimeError("pop failed")
+                return super().rangePop()
+
+        roctx = FailOnceRoctx()
+        with (
+            mock.patch.object(autograd_profiler, "_roctx_markers_enabled", True),
+            mock.patch.object(
+                autograd_profiler, "_roctx_selected_regions_enabled", True
+            ),
+            mock.patch.object(autograd_profiler, "_roctx_module", roctx),
+            mock.patch.object(
+                autograd_profiler, "_nvtx_profiler_active", return_value=False
+            ),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "pop failed"):
+                with record_function("outer") as outer:
+                    with record_function("inner") as inner:
+                        pass
+
+        self.assertFalse(inner._roctx_range_active)
+        self.assertFalse(inner._roctx_range_pop_pending)
+        self.assertFalse(outer._roctx_range_active)
+        self.assertFalse(outer._roctx_range_pop_pending)
+        self.assertEqual(roctx.profiler_count, 0)
+        self.assertEqual(
+            roctx.events,
+            [
+                ("resume", 0),
+                ("push", "outer"),
+                ("resume", 0),
+                ("push", "inner"),
+                ("pause", 0),
+                ("pop", None),
+                ("pop", None),
+                ("pause", 0),
+            ],
+        )
+
+    def test_record_function_roctx_range_pop_underflow_is_reported(self):
+        class UnderflowRoctx(TestRecordFunction._FakeRoctx):
+            def rangePop(self):
+                self.events.append(("pop", None))
+                return -1
+
+        roctx = UnderflowRoctx()
+        with (
+            mock.patch.object(autograd_profiler, "_roctx_markers_enabled", True),
+            mock.patch.object(
+                autograd_profiler, "_roctx_selected_regions_enabled", True
+            ),
+            mock.patch.object(autograd_profiler, "_roctx_module", roctx),
+            mock.patch.object(
+                autograd_profiler, "_nvtx_profiler_active", return_value=False
+            ),
+        ):
+            rf = record_function("underflow")
+            rf.__enter__()
+            with self.assertRaisesRegex(RuntimeError, "range pop failed"):
+                rf.__exit__(None, None, None)
+
+        self.assertFalse(rf._roctx_range_active)
+        self.assertFalse(rf._roctx_range_pop_pending)
+        self.assertFalse(rf._roctx_profiler_region_active)
+        self.assertEqual(roctx.profiler_count, 0)
+        self.assertEqual(
+            roctx.events,
+            [
+                ("resume", 0),
+                ("push", "underflow"),
+                ("pop", None),
+                ("pause", 0),
+            ],
+        )
+
+    def test_record_function_roctx_selected_regions_pause_error_stays_balanced(self):
+        class FailOnceRoctx(TestRecordFunction._FakeRoctx):
+            def __init__(self):
+                super().__init__()
+                self.fail_pause = True
+
+            def profilerPause(self, tid=0):
+                result = super().profilerPause(tid)
+                if self.fail_pause:
+                    self.fail_pause = False
+                    return 1
+                return result
+
+        roctx = FailOnceRoctx()
+        with (
+            mock.patch.object(autograd_profiler, "_roctx_markers_enabled", True),
+            mock.patch.object(
+                autograd_profiler, "_roctx_selected_regions_enabled", True
+            ),
+            mock.patch.object(autograd_profiler, "_roctx_module", roctx),
+            mock.patch.object(
+                autograd_profiler, "_nvtx_profiler_active", return_value=False
+            ),
+        ):
+            rf = record_function("retry_pause")
+            rf.__enter__()
+            with self.assertRaisesRegex(RuntimeError, "pause failed"):
+                rf.__exit__(None, None, None)
+
+            self.assertFalse(rf._roctx_range_active)
+            self.assertFalse(rf._roctx_profiler_region_active)
+
+            rf.run_callbacks_on_exit = False
+            rf.__exit__(None, None, None)
+
+        self.assertFalse(rf._roctx_profiler_region_active)
+        self.assertEqual(roctx.profiler_count, 0)
+        self.assertEqual(
+            roctx.events,
+            [
+                ("resume", 0),
+                ("push", "retry_pause"),
+                ("pop", None),
+                ("pause", 0),
+            ],
+        )
 
     def test_datapipe_with_record_function(self):
         with _profile(

--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import re
+import threading
 import uuid
 from bisect import bisect_left
 from collections import defaultdict
@@ -15,13 +16,13 @@ from time import perf_counter_ns
 from typing import Any, Optional
 from warnings import warn
 
-
 log = logging.getLogger(__name__)
 
 import torch
 import torch.cuda
 from torch._C import _get_privateuse1_backend_name
 from torch._C._profiler import _ExperimentalConfig
+from torch._jit_internal import unused as _jit_unused
 from torch.autograd import (
     _disable_profiler,
     _enable_profiler,
@@ -47,7 +48,6 @@ from torch.autograd.profiler_util import (
     OUT_OF_MEMORY_EVENT_NAME,
 )
 from torch.futures import Future
-
 
 __all__ = [
     "profile",
@@ -90,15 +90,24 @@ except ImportError:
 _is_profiler_enabled: bool = False
 
 _ROCTX_MARKER_ENV_VAR = "TORCH_PROFILER_EMIT_ROCTX"
-_roctx_markers_enabled: bool = getattr(
-    torch.version, "hip", None
-) is not None and os.environ.get(_ROCTX_MARKER_ENV_VAR, "").strip().lower() in {
+_ROCTX_SELECTED_REGIONS_ENV_VAR = "TORCH_PROFILER_ROCTX_SELECTED_REGIONS"
+_ROCTX_TRUE_VALUES = {
     "1",
     "true",
     "yes",
     "on",
 }
+_roctx_markers_enabled: bool = (
+    getattr(torch.version, "hip", None) is not None
+    and os.environ.get(_ROCTX_MARKER_ENV_VAR, "").strip().lower() in _ROCTX_TRUE_VALUES
+)
+_roctx_selected_regions_enabled: bool = (
+    _roctx_markers_enabled
+    and os.environ.get(_ROCTX_SELECTED_REGIONS_ENV_VAR, "").strip().lower()
+    in _ROCTX_TRUE_VALUES
+)
 _roctx_module: Any | None = None
+_roctx_range_state = threading.local()
 
 
 def _get_roctx_module() -> Any | None:
@@ -124,6 +133,21 @@ def _nvtx_profiler_active() -> bool:
         torch._C._autograd._profiler_type()
         == torch._C._profiler.ActiveProfilerType.NVTX
     )
+
+
+def _get_roctx_range_stack() -> list[Any]:
+    stack = getattr(_roctx_range_state, "stack", None)
+    if stack is None:
+        stack = []
+        _roctx_range_state.stack = stack
+    return stack
+
+
+def _check_roctx_profiler_result(operation: str, result: int) -> None:
+    if result != 0:
+        raise RuntimeError(
+            f"ROCTx profiler {operation} failed with error code {result}"
+        )
 
 
 # https://github.com/pytorch/kineto/blob/a054a4be0db117c579a21747debf19c863631f26/libkineto/src/output_json.cpp#L559
@@ -1327,8 +1351,10 @@ class record_function(_ContextDecorator):  # pyrefly: ignore [invalid-inheritanc
     Label will only appear if CPU activity tracing is enabled.
 
     On ROCm, profiler launchers can set ``TORCH_PROFILER_EMIT_ROCTX=1`` to
-    emit the same label as an ROCTx range. This requires the rocprofiler-sdk
-    ``roctx`` Python module to be importable.
+    emit the same label as an ROCTx range. A launcher can additionally set
+    ``TORCH_PROFILER_ROCTX_SELECTED_REGIONS=1`` to resume profiling while at
+    least one such range is active and pause it outside those ranges. This
+    requires the rocprofiler-sdk ``roctx`` Python module to be importable.
 
     It is useful when tracing the code profile.
 
@@ -1379,65 +1405,196 @@ class record_function(_ContextDecorator):  # pyrefly: ignore [invalid-inheritanc
         )
         self._cupti_monitor_external_id: int | None = None
         self._roctx_range_active: bool = False
+        self._roctx_range_pop_pending: bool = False
+        self._roctx_profiler_region_active: bool = False
+
+    @_jit_unused
+    def _recreate_cm(self):
+        return record_function(self.name, self.args)
 
     def __enter__(self):
-        self.record = torch.ops.profiler._record_function_enter_new(
-            self.name, self.args
-        )
-        # Route the region to the active cupti_monitor observer, if any. The reference is
-        # None unless a cupti_monitor profile is running, so a non-cupti run never touches
-        # the cupti chain. Guarded by is_scripting() (the global access doesn't compile under
-        # TorchScript), and the global is read inside the guard so it is dead-code-eliminated.
-        if not torch.jit.is_scripting():
-            if _roctx_markers_enabled and not _nvtx_profiler_active():
-                try:
-                    roctx = _get_roctx_module()
-                    if roctx is None:
-                        raise AssertionError("Expected ROCTX module to be loaded")
-                    roctx.rangePush(self.name)
-                    self._roctx_range_active = True
-                except Exception:
-                    record = self.record
-                    if record is not None:
-                        with torch._C.DisableTorchFunctionSubclass():
-                            torch.ops.profiler._record_function_exit._RecordFunction(
-                                record
-                            )
-                        self.record = None
-                    raise
+        if torch.jit.is_scripting():
+            self.record = torch.ops.profiler._record_function_enter_new(
+                self.name, self.args
+            )
+        elif not _roctx_markers_enabled:
+            self.record = torch.ops.profiler._record_function_enter_new(
+                self.name, self.args
+            )
             observer = _active_cupti_profiler_observer
             if observer is not None:
                 self._cupti_monitor_external_id = observer.push_annotation(self.name)
+        else:
+            self._enter_eager()
         return self
 
+    @_jit_unused
+    def _enter_eager(self) -> None:
+        roctx = None
+        try:
+            if _roctx_markers_enabled and _roctx_selected_regions_enabled:
+                roctx = _get_roctx_module()
+                if roctx is None:
+                    raise AssertionError("Expected ROCTX module to be loaded")
+                self._resume_roctx_profiler(roctx)
+
+            self.record = torch.ops.profiler._record_function_enter_new(
+                self.name, self.args
+            )
+            if _roctx_markers_enabled and not _nvtx_profiler_active():
+                if roctx is None:
+                    roctx = _get_roctx_module()
+                if roctx is None:
+                    raise AssertionError("Expected ROCTX module to be loaded")
+                range_level = roctx.rangePush(self.name)
+                if range_level < 0:
+                    raise RuntimeError(
+                        f"ROCTx range push failed with error code {range_level}"
+                    )
+                self._roctx_range_active = True
+                _get_roctx_range_stack().append(self)
+
+            # Route the region to the active cupti_monitor observer, if any. The reference
+            # is None unless a cupti_monitor profile is running, so a non-cupti run never
+            # touches the cupti chain.
+            observer = _active_cupti_profiler_observer
+            if observer is not None:
+                self._cupti_monitor_external_id = observer.push_annotation(self.name)
+        except Exception:
+            try:
+                record = self.record
+                if record is not None:
+                    with torch._C.DisableTorchFunctionSubclass():
+                        torch.ops.profiler._record_function_exit._RecordFunction(record)
+                    self.record = None
+            finally:
+                try:
+                    if self._roctx_range_active:
+                        if roctx is None:
+                            roctx = _get_roctx_module()
+                        if roctx is None:
+                            raise AssertionError("Expected ROCTX module to be loaded")
+                        self._pop_roctx_range(roctx)
+                finally:
+                    if self._roctx_profiler_region_active:
+                        if roctx is None:
+                            roctx = _get_roctx_module()
+                        if roctx is None:
+                            raise AssertionError("Expected ROCTX module to be loaded")
+                        self._pause_roctx_profiler(roctx)
+            raise
+
+    @_jit_unused
+    def _resume_roctx_profiler(self, roctx: Any) -> None:
+        result = roctx.profilerResume(0)
+        # rocprofv3 observes the control call regardless of its return value.
+        self._roctx_profiler_region_active = True
+        _check_roctx_profiler_result("resume", result)
+
+    @_jit_unused
+    def _pause_roctx_profiler(self, roctx: Any) -> None:
+        result = roctx.profilerPause(0)
+        # rocprofv3 observes the control call regardless of its return value.
+        self._roctx_profiler_region_active = False
+        _check_roctx_profiler_result("pause", result)
+
+    @_jit_unused
+    def _pop_roctx_range(self, roctx: Any) -> None:
+        stack = _get_roctx_range_stack()
+
+        # If a nested pop raised before returning, retry that pending pop before
+        # touching this range. This prevents an outer exit from popping the
+        # still-active inner native range.
+        while stack and stack[-1] is not self:
+            pending = stack[-1]
+            if not pending._roctx_range_pop_pending:
+                raise RuntimeError("ROCTx ranges must exit in stack order")
+            try:
+                pending._pop_roctx_range(roctx)
+            except Exception:
+                if pending._roctx_range_active:
+                    raise
+
+        if not stack or stack[-1] is not self:
+            raise RuntimeError("ROCTx range stack is inconsistent")
+
+        self._roctx_range_pop_pending = True
+        result = roctx.rangePop()
+
+        stack.pop()
+        self._roctx_range_active = False
+        self._roctx_range_pop_pending = False
+        if result < 0:
+            raise RuntimeError(f"ROCTx range pop failed with error code {result}")
+
     def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any):
-        if not torch.jit.is_scripting():
+        if torch.jit.is_scripting():
+            if self.run_callbacks_on_exit:
+                # Local variable is needed by TorchScript to refine Optional[T] to T
+                record = self.record
+                if record is None:
+                    raise AssertionError("Expected record to be set")
+                torch.ops.profiler._record_function_exit(record)
+        elif not self._roctx_range_active and not self._roctx_profiler_region_active:
             if self._cupti_monitor_external_id is not None:
                 observer = _active_cupti_profiler_observer
                 if observer is not None:
                     observer.pop_annotation()
                 self._cupti_monitor_external_id = None
 
-        if self.run_callbacks_on_exit:
-            # Local variable is needed by TorchScript to refine Optional[T] to T
-            record = self.record
-            if record is None:
-                raise AssertionError("Expected record to be set")
-
-            # TODO: Too slow with __torch_function__ handling enabled
-            # See https://github.com/pytorch/pytorch/issues/76410
-            if not torch.jit.is_scripting():
+            if self.run_callbacks_on_exit:
+                record = self.record
+                if record is None:
+                    raise AssertionError("Expected record to be set")
                 with torch._C.DisableTorchFunctionSubclass():
                     torch.ops.profiler._record_function_exit._RecordFunction(record)
-            else:
-                torch.ops.profiler._record_function_exit(record)
+        else:
+            self._exit_eager()
 
-        if not torch.jit.is_scripting() and self._roctx_range_active:
-            roctx = _get_roctx_module()
-            if roctx is None:
-                raise AssertionError("Expected ROCTX module to be loaded")
-            roctx.rangePop()
-            self._roctx_range_active = False
+    @_jit_unused
+    def _exit_eager(self) -> None:
+        try:
+            if self._cupti_monitor_external_id is not None:
+                observer = _active_cupti_profiler_observer
+                if observer is not None:
+                    observer.pop_annotation()
+                self._cupti_monitor_external_id = None
+
+            if self.run_callbacks_on_exit:
+                record = self.record
+                if record is None:
+                    raise AssertionError("Expected record to be set")
+
+                # TODO: Too slow with __torch_function__ handling enabled
+                # See https://github.com/pytorch/pytorch/issues/76410
+                with torch._C.DisableTorchFunctionSubclass():
+                    torch.ops.profiler._record_function_exit._RecordFunction(record)
+        finally:
+            roctx = None
+            try:
+                if self._roctx_range_active:
+                    if (
+                        _roctx_markers_enabled
+                        and _roctx_selected_regions_enabled
+                        and not self._roctx_profiler_region_active
+                    ):
+                        roctx = _get_roctx_module()
+                        if roctx is None:
+                            raise AssertionError("Expected ROCTX module to be loaded")
+                        self._resume_roctx_profiler(roctx)
+
+                    if roctx is None:
+                        roctx = _get_roctx_module()
+                    if roctx is None:
+                        raise AssertionError("Expected ROCTX module to be loaded")
+                    self._pop_roctx_range(roctx)
+            finally:
+                if self._roctx_profiler_region_active:
+                    if roctx is None:
+                        roctx = _get_roctx_module()
+                    if roctx is None:
+                        raise AssertionError("Expected ROCTX module to be loaded")
+                    self._pause_roctx_profiler(roctx)
 
     def _call_end_callbacks_on_future(self, fut: Future[Any]) -> Future[Any]:
         """Use for profiling async calls that return a future.

--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -1,8 +1,10 @@
 # mypy: allow-untyped-defs
 import ast
 import copy
+import importlib
 import json
 import logging
+import os
 import re
 import uuid
 from bisect import bisect_left
@@ -86,6 +88,43 @@ except ImportError:
 # global python state - whether profiler is currently enabled
 # useful for fast python checks to reduce latency
 _is_profiler_enabled: bool = False
+
+_ROCTX_MARKER_ENV_VAR = "TORCH_PROFILER_EMIT_ROCTX"
+_roctx_markers_enabled: bool = getattr(
+    torch.version, "hip", None
+) is not None and os.environ.get(_ROCTX_MARKER_ENV_VAR, "").strip().lower() in {
+    "1",
+    "true",
+    "yes",
+    "on",
+}
+_roctx_module: Any | None = None
+
+
+def _get_roctx_module() -> Any | None:
+    global _roctx_module
+
+    if not _roctx_markers_enabled:
+        return None
+
+    if _roctx_module is None:
+        try:
+            _roctx_module = importlib.import_module("roctx")
+        except ImportError as exc:
+            raise RuntimeError(
+                f"{_ROCTX_MARKER_ENV_VAR}=1 requires the rocprofiler-sdk "
+                "'roctx' Python module to be importable by this interpreter"
+            ) from exc
+
+    return _roctx_module
+
+
+def _nvtx_profiler_active() -> bool:
+    return (
+        torch._C._autograd._profiler_type()
+        == torch._C._profiler.ActiveProfilerType.NVTX
+    )
+
 
 # https://github.com/pytorch/kineto/blob/a054a4be0db117c579a21747debf19c863631f26/libkineto/src/output_json.cpp#L559
 # Kernel and CUDA runtime API events are connected by ac2g; forward and backward
@@ -1287,6 +1326,10 @@ class record_function(_ContextDecorator):  # pyrefly: ignore [invalid-inheritanc
     """Context manager/function decorator that adds a label to a code block/function when running autograd profiler.
     Label will only appear if CPU activity tracing is enabled.
 
+    On ROCm, profiler launchers can set ``TORCH_PROFILER_EMIT_ROCTX=1`` to
+    emit the same label as an ROCTx range. This requires the rocprofiler-sdk
+    ``roctx`` Python module to be importable.
+
     It is useful when tracing the code profile.
 
     Args:
@@ -1335,6 +1378,7 @@ class record_function(_ContextDecorator):  # pyrefly: ignore [invalid-inheritanc
             None,
         )
         self._cupti_monitor_external_id: int | None = None
+        self._roctx_range_active: bool = False
 
     def __enter__(self):
         self.record = torch.ops.profiler._record_function_enter_new(
@@ -1345,6 +1389,22 @@ class record_function(_ContextDecorator):  # pyrefly: ignore [invalid-inheritanc
         # the cupti chain. Guarded by is_scripting() (the global access doesn't compile under
         # TorchScript), and the global is read inside the guard so it is dead-code-eliminated.
         if not torch.jit.is_scripting():
+            if _roctx_markers_enabled and not _nvtx_profiler_active():
+                try:
+                    roctx = _get_roctx_module()
+                    if roctx is None:
+                        raise AssertionError("Expected ROCTX module to be loaded")
+                    roctx.rangePush(self.name)
+                    self._roctx_range_active = True
+                except Exception:
+                    record = self.record
+                    if record is not None:
+                        with torch._C.DisableTorchFunctionSubclass():
+                            torch.ops.profiler._record_function_exit._RecordFunction(
+                                record
+                            )
+                        self.record = None
+                    raise
             observer = _active_cupti_profiler_observer
             if observer is not None:
                 self._cupti_monitor_external_id = observer.push_annotation(self.name)
@@ -1357,21 +1417,27 @@ class record_function(_ContextDecorator):  # pyrefly: ignore [invalid-inheritanc
                 if observer is not None:
                     observer.pop_annotation()
                 self._cupti_monitor_external_id = None
-        if not self.run_callbacks_on_exit:
-            return
 
-        # Local variable is needed by TorchScript to refine Optional[T] to T
-        record = self.record
-        if record is None:
-            raise AssertionError("Expected record to be set")
+        if self.run_callbacks_on_exit:
+            # Local variable is needed by TorchScript to refine Optional[T] to T
+            record = self.record
+            if record is None:
+                raise AssertionError("Expected record to be set")
 
-        # TODO: Too slow with __torch_function__ handling enabled
-        # See https://github.com/pytorch/pytorch/issues/76410
-        if not torch.jit.is_scripting():
-            with torch._C.DisableTorchFunctionSubclass():
-                torch.ops.profiler._record_function_exit._RecordFunction(record)
-        else:
-            torch.ops.profiler._record_function_exit(record)
+            # TODO: Too slow with __torch_function__ handling enabled
+            # See https://github.com/pytorch/pytorch/issues/76410
+            if not torch.jit.is_scripting():
+                with torch._C.DisableTorchFunctionSubclass():
+                    torch.ops.profiler._record_function_exit._RecordFunction(record)
+            else:
+                torch.ops.profiler._record_function_exit(record)
+
+        if not torch.jit.is_scripting() and self._roctx_range_active:
+            roctx = _get_roctx_module()
+            if roctx is None:
+                raise AssertionError("Expected ROCTX module to be loaded")
+            roctx.rangePop()
+            self._roctx_range_active = False
 
     def _call_end_callbacks_on_future(self, fut: Future[Any]) -> Future[Any]:
         """Use for profiling async calls that return a future.


### PR DESCRIPTION
## Motivation

Allow ROCm profiling tools to capture PyTorch `record_function` annotations as ROCTx ranges and collect profiling data only while those ranges are active.

## Technical Details

- Add opt-in ROCTx emission through `TORCH_PROFILER_EMIT_ROCTX`.
- Lazily import `roctx` and report a clear error when unavailable.
- Add balanced profiler resume/pause calls for selected-region collection.
- Make `rocprofv3 --pytorch-trace` enable marker tracing and reference-counted selected regions.
- Preserve nested, overlapping, exceptional, and deferred range lifecycles.
- Avoid duplicate markers while the NVTX profiler is active.
- Reject profiling modes that cannot honor `record_function` boundaries.

## Test Plan

1. Run targeted PyTorch lifecycle, configuration, import, concurrency, and failure tests.
2. Run rocprofv3 option, environment-propagation, conflict, and selected-region integration tests.
3. Build rocprof-sys and run its CLI help and environment-propagation tests.
4. Profile a real ROCm PyTorch workload and verify its markers and GPU work are captured while out-of-region sentinel work is excluded.


## Test Result

- All targeted rocprofv3 integration tests passed.
- rocprof-sys built successfully and its targeted tests passed.
- Validated on an AMD Instinct MI300X with PyTorch 2.10.0 and ROCm 7.1.
- rocprofv3 and rocprof-sys both captured the `optimizer_step` range.
- Each captured range enclosed the expected optimizer GPU kernel.