### PR TITLE
[release/2.11] Fix CUDA allocator/mempool flake cluster (memory snapshot, mempool, OOM retry) (#190160)

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -16,6 +16,7 @@ import threading
 import time
 import unittest
 import warnings
+from unittest.mock import patch
 from collections import defaultdict
 from copy import deepcopy
 from itertools import product
@@ -487,6 +488,9 @@ print(t.is_pinned())
     @unittest.skipIf(
         TEST_CUDAMALLOCASYNC or IS_JETSON, "Segmentation fault (core dumped)"
     )
+    # On MI350 (gfx950) allocating ~1.02x of the reported free memory does not
+    # raise an OOM RuntimeError, so the assertRaisesRegex below fails.
+    @skipIfRocmArch(MI350_ARCH)
     @serialTest()
     def test_out_of_memory_retry(self):
         torch.cuda.empty_cache()
@@ -6739,6 +6743,10 @@ class TestMemPool(TestCase):
 
     @serialTest()
     def test_mempool_ctx_multithread(self):
+        # Collect first: a tensor leaked by a prior test that is only reachable
+        # through a reference cycle keeps its segment active, so empty_cache
+        # can't reclaim it and the "empty pool" assertion below flakes.
+        gc.collect()
         torch._C._cuda_clearCublasWorkspaces()
         torch.cuda.empty_cache()
         segments = torch.cuda.memory._snapshot()["segments"]
@@ -8623,6 +8631,38 @@ instantiate_parametrized_tests(TestCompileKernel)
 instantiate_parametrized_tests(TestCachingHostAllocatorCudaGraph)
 instantiate_device_type_tests(TestCudaOptims, globals())
 instantiate_device_type_tests(TestCudaDeviceParametrized, globals())
+
+class TestMemoryViz(TestCase):
+    def test_format_flamegraph_download_moves_temp_file(self):
+        # Regression test: format_flamegraph downloads flamegraph.pl into a temp
+        # file and moves it into place. Previously the temp file was created by a
+        # delete=True NamedTemporaryFile, so after os.rename moved it away the
+        # context manager raised FileNotFoundError on exit (a CI flake, since the
+        # download only happens when the cached script is absent).
+        from torch.cuda import _memory_viz
+
+        def fake_urlretrieve(url, filename):
+            with open(filename, "wb") as f:
+                f.write(b"#!/usr/bin/perl\n")
+            return filename, None
+
+        @contextlib.contextmanager
+        def fake_popen(*args, **kwargs):
+            proc = unittest.mock.MagicMock()
+            proc.stdout.read.return_value = "FLAMEGRAPH_OUTPUT"
+            proc.wait.return_value = 0
+            yield proc
+
+        with tempfile.TemporaryDirectory() as cache_dir:
+            script = os.path.join(cache_dir, "flamegraph.pl")
+            with (
+                patch("urllib.request.urlretrieve", fake_urlretrieve),
+                patch.object(_memory_viz.subprocess, "Popen", fake_popen),
+            ):
+                result = _memory_viz.format_flamegraph("stack 1\n", script)
+            self.assertEqual(result, "FLAMEGRAPH_OUTPUT")
+            self.assertTrue(os.path.exists(script))
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/cuda/_memory_viz.py
+++ b/torch/cuda/_memory_viz.py
@@ -97,17 +97,26 @@ def format_flamegraph(flamegraph_lines, flamegraph_script=None):
         import urllib.request
 
         print(f"Downloading flamegraph.pl to: {flamegraph_script}")
-        with tempfile.NamedTemporaryFile(mode="wb", suffix=".pl") as f:
+        # Download to a temp file next to the target, then atomically move it
+        # into place so a concurrent reader never sees a partial file. The temp
+        # file lives in the same directory (same filesystem) so os.replace is
+        # atomic, and is created with delete=False + manual cleanup: moving a
+        # delete=True NamedTemporaryFile out from under its context manager makes
+        # __exit__ fail to unlink the now-missing file.
+        fd, tmp_name = tempfile.mkstemp(
+            suffix=".pl", dir=os.path.dirname(flamegraph_script) or None
+        )
+        os.close(fd)
+        try:
             urllib.request.urlretrieve(
                 "https://raw.githubusercontent.com/brendangregg/FlameGraph/master/flamegraph.pl",
-                f.name,
+                tmp_name,
             )
-            try:
-                os.chmod(f.name, 0o755)
-                os.rename(f.name, flamegraph_script)
-            except OSError:  # noqa: B001,E722
-                # Ok to skip, the file will be removed by tempfile
-                pass
+            os.chmod(tmp_name, 0o755)
+            os.replace(tmp_name, flamegraph_script)
+        finally:
+            if os.path.exists(tmp_name):
+                os.remove(tmp_name)
     args = [flamegraph_script, "--countname", "bytes"]
     with subprocess.Popen(
         args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, encoding="utf-8"


### PR DESCRIPTION
Addresses three distinct issues that greendog surfaced together as a single "CUDA allocator/mempool" flake cluster in test_cuda.py. They have three different root causes, so review them independently.

1. test_memory_snapshot (format_flamegraph, torch/cuda/_memory_viz.py)

   Real helper bug. format_flamegraph downloads flamegraph.pl into a NamedTemporaryFile(delete=True) and then os.rename's it into ~/.cache/flamegraph.pl. When the context manager exits it tries to unlink the file it just renamed away, raising FileNotFoundError. It looked like a flake because the rename succeeds, so on retry the cached script exists and the download path (and the crash) is skipped entirely.

   Fix: download to a mkstemp file created in the target directory (same filesystem, so os.replace is atomic) with delete=False and manual cleanup in finally. This also removes a latent second bug where the old code silently swallowed a cross-device rename OSError and then ran a subprocess on a script that was never installed.

2. test_mempool_ctx_multithread

   A CUDA tensor leaked by a prior test that is reachable only through a reference cycle stays active (refcounting cannot free it), so empty_cache cannot reclaim its segment and the "Expected empty pool in the beginning" assertion intermittently sees 1 segment. Fix: gc.collect() before empty_cache(), matching the existing idiom used elsewhere in this file.

3. test_out_of_memory_retry

   Not a flake: a persistent failure on MI350 (gfx950), where allocating ~1.02x of the reported free memory does not raise an OOM RuntimeError, so assertRaisesRegex fails. Skip on MI350 only (skipIfRocmArch(MI350_ARCH)) so the test keeps running on CUDA and other ROCm archs.

Test Plan:

Reproduced the format_flamegraph crash and the mempool leak locally on 8xA100, confirmed the fixes, and confirmed the OOM test still passes on CUDA.

```
python -m pytest \
  test/test_cuda.py::TestMemoryViz::test_format_flamegraph_download_moves_temp_file \
  -x -q
rm -f ~/.cache/flamegraph.pl
python -m pytest test/test_cuda.py::TestCudaAllocator::test_memory_snapshot -x -q
python -m pytest test/test_cuda.py::TestMemPool::test_mempool_ctx_multithread -x -q
python -m pytest test/test_cuda.py::TestCuda::test_out_of_memory_retry -x -q
```

The new TestMemoryViz regression test reproduces the exact CI FileNotFoundError before the fix and passes after it.

Authored with Claude.
Pull Request resolved: https://github.com/pytorch/pytorch/pull/190160 Approved by: https://github.com/eqy
ghstack dependencies: #190151

(cherry picked from commit 215f5703cb9c19303edd1c83246de8cae37e4a3c)

