### PR TITLE
[release/2.11] fix test_memory_compile_regions (#190358)

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -4492,6 +4492,10 @@ class TestCudaMallocAsync(TestCase):
 
         try:
             torch.cuda.memory.empty_cache()
+            # Region ids come from Dynamo's process-global frame counter, which
+            # reset() zeroes; do it before compiling so the region strings are
+            # deterministic.
+            torch._dynamo.reset()
             input_tensor = torch.randn(1, 10, device="cuda")
             # Create an instance of the model
             model = MyModel()
@@ -4515,14 +4519,19 @@ class TestCudaMallocAsync(TestCase):
                 if len(allocation_sequence) > 0 and allocation_sequence[-1] == context:
                     continue
                 allocation_sequence.append(context)
-            self.assertTrue(allocation_sequence == expected_allocation_sequence)
+            self.assertEqual(allocation_sequence, expected_allocation_sequence)
         except RuntimeError as e:
             pass
         finally:
             torch.cuda.memory._record_memory_history(None)
+            # Clean up the model and input tensor to fix memory leaks in other tests
+            del compiled_model, model, input_tensor
+            ss = None
+            torch._dynamo.reset()
             # This test requires to run gc.collec() to fix other memory tests
-            torch.cuda.synchronize()
             gc.collect()
+            torch.cuda.synchronize()
+            torch.cuda.empty_cache()
 
     @unittest.skipIf(
         TEST_CUDAMALLOCASYNC, "setContextRecorder not supported by CUDAMallocAsync"


### PR DESCRIPTION
## Summary

Make `test_cuda.py::TestCudaAllocator.test_memory_compile_regions` deterministic by resetting Dynamo's process-global frame counter before `torch.compile()`. Region labels in memory snapshots depend on that counter, so running this test after other compile tests could produce non-zero region ids and fail the golden sequence check.

## Problem 1

`test_memory_compile_regions` records CUDA allocations with `compile_context=True` and asserts the observed compile-region labels match a fixed sequence:

```python
[
    "Torch-Compiled Region: 0/0",
    "Torch-Compiled Region: 1/0",
    "Torch-Compiled Region: 0/0",
]
```

Those region ids come from Dynamo's process-global frame counter. When other `torch.compile` tests run first in the same process, the counter is already non-zero, so the snapshot can contain labels like `"Torch-Compiled Region: 2/0"` instead of `"0/0"`, causing order-dependent failures.

Example of a falling test sequence for `test_memory_compile_regions`:
```
python test_cuda.py \
       TestFXMemoryProfiler.test_fx_memory_profiler_augmentation \
       TestCudaAllocator.test_memory_compile_regions
```

## Problem 2

`test_memory_plots` and `test_memory_plots_free_segment_stack` are failed due to insufficient teardown in test_memory_compile_regions Example of a falling test sequence for `test_memory_plots`:
```
python test_cuda.py \
       TestCudaAllocator.test_memory_compile_regions \
       TestCudaAllocator.test_memory_plots \
       TestCudaAllocator.test_memory_plots_free_segment_stack
```

## Fix

- test_cuda.py::TestCudaAllocatortest_memory_compile_regions - call `torch._dynamo.reset()` after `empty_cache()` and before compiling, so region ids start from zero and the expected sequence is stable regardless of test order.
- Improved teardown to fix `test_cuda.py::TestCudaAllocator::test_memory_plots` and `test_cuda.py::TestCudaAllocator::test_memory_plots_free_segment_stack`

Fixes https://github.com/pytorch/pytorch/issues/163202 Fixes https://github.com/pytorch/pytorch/issues/179744 Fixes https://github.com/pytorch/pytorch/issues/179798 Pull Request resolved: https://github.com/pytorch/pytorch/pull/190358 Approved by: https://github.com/Skylion007, https://github.com/jeffdaily

(cherry picked from commit 9c751e37cab66e57c6de629cb44e30ae533250fb)

