### PR TITLE
[release/2.12] Fix reentrant deadlock in torch.cuda._lazy_call

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1074,28 +1074,34 @@ print(t.is_pinned())
             self.assertEqual(torch.cuda.initial_seed(), 2)
 
     def test_lazy_call_reentrant_set_rng_state_does_not_deadlock(self):
-        code = r"""
-import torch
-
-torch.cuda.init()
-state = torch.cuda.get_rng_state()
-
-def cb():
-    torch.cuda.set_rng_state(state)
-
-torch.cuda._lazy_call(cb)
-print("done")
-"""
-        proc = subprocess.run(
-            [sys.executable, "-c", code],
-            capture_output=True,
-            text=True,
-            timeout=20,
+        # Separate process: a regression deadlocks the interpreter (non-reentrant lock).
+        # Happy path is usually a few seconds; allow margin for slow CI / CUDA init.
+        timeout_sec = 15
+        script = (
+            "import torch; "
+            "torch.cuda.init(); "
+            "state = torch.cuda.get_rng_state(); "
+            "torch.cuda._lazy_call(lambda: torch.cuda.set_rng_state(state)); "
+            "print('done')"
         )
-        if proc.returncode != 0:
-            self.fail(
-                f"subprocess failed rc={proc.returncode}\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+        try:
+            proc = subprocess.run(
+                [sys.executable, "-c", script],
+                capture_output=True,
+                text=True,
+                timeout=timeout_sec,
             )
+        except subprocess.TimeoutExpired as e:
+            self.fail(
+                f"lazy_call reentrancy subprocess did not finish within {timeout_sec}s "
+                "(likely deadlock in torch.cuda._lazy_call); "
+                f"cmd={e.cmd!r}"
+            )
+        self.assertEqual(
+            proc.returncode,
+            0,
+            msg=f"stdout={proc.stdout!r}\nstderr={proc.stderr!r}",
+        )
         self.assertIn("done", proc.stdout)
 
     def test_specify_improper_device_name(self):

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1073,6 +1073,32 @@ print(t.is_pinned())
             self.assertEqual(a, b)
             self.assertEqual(torch.cuda.initial_seed(), 2)
 
+    def test_lazy_call_reentrant_set_rng_state_does_not_deadlock(self):
+        code = r"""
+import torch
+
+torch.cuda.init()
+state = torch.cuda.get_rng_state()
+
+def cb():
+    torch.cuda.set_rng_state(state)
+
+torch.cuda._lazy_call(cb)
+print("done")
+"""
+        proc = subprocess.run(
+            [sys.executable, "-c", code],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=20,
+        )
+        if proc.returncode != 0:
+            self.fail(
+                f"subprocess failed rc={proc.returncode}\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+            )
+        self.assertIn("done", proc.stdout)
+
     def test_specify_improper_device_name(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             fname = os.path.join(tmpdir, "tempfile.pt")

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1088,8 +1088,7 @@ print("done")
 """
         proc = subprocess.run(
             [sys.executable, "-c", code],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            capture_output=True,
             text=True,
             timeout=20,
         )

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -417,9 +417,14 @@ def is_initialized():
 
 
 def _lazy_call(callable, **kwargs):
+    if is_initialized():
+        callable()
+        return
+
+    run_now = False
     with _initialization_lock:
         if is_initialized():
-            callable()
+            run_now = True
         else:
             # TODO(torch_deploy): this accesses linecache, which attempts to read the
             # file system to get traceback info. Patch linecache or do something
@@ -432,6 +437,9 @@ def _lazy_call(callable, **kwargs):
             else:
                 # Don't store the actual traceback to avoid memory cycle
                 _queued_calls.append((callable, traceback.format_stack()))
+
+    if run_now:
+        callable()
 
 
 _lazy_call(_check_capability)

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -417,6 +417,8 @@ def is_initialized():
 
 
 def _lazy_call(callable, **kwargs):
+    # Do not invoke user callbacks while holding _initialization_lock
+    # they may call back into _lazy_call.
     if is_initialized():
         callable()
         return


### PR DESCRIPTION
This fixes deadlock with torch.compile while running bigger models in MAD engine.

This is a cherry-pick of upstream PR: https://github.com/pytorch/pytorch/pull/182948

Made with [Cursor](https://cursor.com)