### PR TITLE
Fix FSDP2 reduce-scatter memory & performance regression on release/2.12

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_comm.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_comm.py
@@ -290,6 +290,7 @@ class TestFullyShardCollectiveOps(FSDPTestMultiThread):
         (
             _,
             _,
+            _,
             post_reduce_event,
             _,
             _,

--- a/test/distributed/_composable/fsdp/test_fully_shard_comm.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_comm.py
@@ -548,6 +548,124 @@ class TestFullyShardCommunication(FSDPTest):
             check_sharded_parity(self, ref_model, model)
 
     @skip_if_lt_x_gpu(2)
+    def test_set_reduce_scatter_max_input_buffers(self):
+        """
+        Tests that ``set_reduce_scatter_max_input_buffers`` is a pure
+        scheduling change: changing the in-flight reduce-scatter copy-in buffer
+        cap (``2``, or an explicit ``1`` that matches the default) produces
+        identical parameters and gradients to the default single-buffer
+        behavior, across FSDP/HSDP and reshard-after-forward (under bf16 mixed
+        precision, where the retained buffer is in the reduce dtype).
+        """
+        self.run_subtests(
+            {
+                "mesh_shape": [(self.world_size,), (self.world_size // 2, 2)],
+                "reshard_after_forward": [True, False],
+                "max_input_buffers": [1, 2],
+            },
+            self._test_set_reduce_scatter_max_input_buffers,
+        )
+
+    def _test_set_reduce_scatter_max_input_buffers(
+        self,
+        mesh_shape: tuple[int] | tuple[int, int],
+        reshard_after_forward: bool,
+        max_input_buffers: int,
+    ):
+        torch.manual_seed(42)
+        model_args = ModelArgs(dropout_p=0.0, weight_tying=False)
+        ref_model = Transformer(model_args)
+        model = copy.deepcopy(ref_model)
+        mesh_dim_names = ("outer",) if len(mesh_shape) == 1 else ("outer", "inner")
+        mesh = init_device_mesh(
+            device_type.type, mesh_shape, mesh_dim_names=mesh_dim_names
+        )
+        mp_policy = MixedPrecisionPolicy(
+            param_dtype=torch.bfloat16, reduce_dtype=torch.bfloat16
+        )
+        fsdp_kwargs = {
+            "reshard_after_forward": reshard_after_forward,
+            "mesh": mesh,
+            "mp_policy": mp_policy,
+        }
+        # Reference model keeps the default (copy-in on the compute stream)
+        for module in ref_model.modules():
+            if isinstance(module, TransformerBlock):
+                fully_shard(module, **fsdp_kwargs)
+        ref_model = fully_shard(ref_model, **fsdp_kwargs)
+        ref_optim = torch.optim.AdamW(ref_model.parameters(), lr=1e-2)
+        # Test model retains multiple reduce-scatter copy-in buffers in flight
+        for module in model.modules():
+            if isinstance(module, TransformerBlock):
+                fully_shard(module, **fsdp_kwargs)
+        model = fully_shard(model, **fsdp_kwargs)
+        model.set_reduce_scatter_max_input_buffers(max_input_buffers)
+        optim = torch.optim.AdamW(model.parameters(), lr=1e-2)
+
+        torch.manual_seed(42 + self.rank)
+        inp = torch.randint(0, model_args.vocab_size, (2, 16), device=device_type.type)
+        for _ in range(3):
+            ref_loss = ref_model(inp).sum()
+            ref_loss.backward()
+            ref_optim.step()
+            loss = model(inp).sum()
+            loss.backward()
+            optim.step()
+            self.assertEqual(ref_loss, loss)
+            # Check parity before zero_grad so gradients are compared too
+            check_sharded_parity(self, ref_model, model)
+            ref_optim.zero_grad()
+            optim.zero_grad()
+
+    @skip_if_lt_x_gpu(2)
+    def test_reduce_scatter_max_input_buffers_resolves_to_max(self):
+        """
+        Per-module reduce-scatter input-buffer caps share one pipeline (a single
+        ``comm_ctx.reduce_scatter_states`` list), so mixed caps must resolve to
+        the max on the shared comm context: a lower-cap module cannot silently
+        undo a higher-cap module's retention. The per-group values stay as set.
+        """
+        torch.manual_seed(42)
+        model_args = ModelArgs(dropout_p=0.0)
+        model = Transformer(model_args)
+        blocks = [m for m in model.modules() if isinstance(m, TransformerBlock)]
+        self.assertGreaterEqual(len(blocks), 2)
+        for block in blocks:
+            fully_shard(block)
+        model = fully_shard(model)
+        # Set a non-default cap on a single block only (recurse=False); every
+        # other group (including the root) keeps the default of 1.
+        expected_max = 3
+        blocks[0].set_reduce_scatter_max_input_buffers(expected_max, recurse=False)
+
+        # Resolution runs in lazy init on the first forward.
+        inp = torch.randint(0, model_args.vocab_size, (2, 16), device=device_type.type)
+        model(inp).sum().backward()
+
+        comm_ctx = model._get_fsdp_state()._comm_ctx
+        self.assertEqual(comm_ctx.reduce_scatter_max_input_buffers, expected_max)
+        # Resolution leaves the per-group input values untouched.
+        block0_pg = blocks[0]._get_fsdp_state()._fsdp_param_groups[0]
+        block1_pg = blocks[1]._get_fsdp_state()._fsdp_param_groups[0]
+        self.assertEqual(block0_pg.reduce_scatter_max_input_buffers, expected_max)
+        self.assertEqual(block1_pg.reduce_scatter_max_input_buffers, 1)
+
+    @skip_if_lt_x_gpu(2)
+    def test_set_reduce_scatter_max_input_buffers_validation(self):
+        model = fully_shard(nn.Linear(16, 16))
+        # Non-positive -> ValueError
+        with self.assertRaises(ValueError):
+            model.set_reduce_scatter_max_input_buffers(0)
+        # Non-int -> TypeError, even though 2.5 >= 1 numerically
+        with self.assertRaises(TypeError):
+            model.set_reduce_scatter_max_input_buffers(2.5)
+        # bool is an int subclass but is not a valid count -> TypeError
+        with self.assertRaises(TypeError):
+            model.set_reduce_scatter_max_input_buffers(True)
+        # A valid value is accepted
+        model.set_reduce_scatter_max_input_buffers(2)
+
+    @skip_if_lt_x_gpu(2)
     def test_set_reshard_after_forward(self):
         """
         Tests that FSDP issues the expected number of all-gathers and

--- a/test/distributed/_composable/fsdp/test_fully_shard_init.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_init.py
@@ -1021,6 +1021,27 @@ class TestFullyShardProcessGroupInit(FSDPTestMultiThread):
             self.assertEqual(param, ref_param)
             self.assertEqual(param.grad, ref_param.grad)
 
+        # Also cover the opt-in reduce-scatter PG setup on HSDP meshes. Each
+        # rank creates the communicator for its shard group, so the
+        # implementation must use local synchronization internally to avoid
+        # waiting for nonmember ranks in new_group's post-init barrier.
+        model.set_separate_reduce_scatter_group()
+        rs_process_groups = set()
+        for module in model.modules():
+            if isinstance(module, FSDPModule):
+                for param_group in module._get_fsdp_state()._fsdp_param_groups:
+                    self.assertIsNotNone(
+                        param_group.mesh_info.reduce_scatter_process_group
+                    )
+                    self.assertIsNot(
+                        param_group._reduce_scatter_process_group,
+                        param_group.mesh_info.shard_process_group,
+                    )
+                    rs_process_groups.add(
+                        id(param_group.mesh_info.reduce_scatter_process_group)
+                    )
+        self.assertEqual(len(rs_process_groups), 1)
+
 
 class TestFullyShardHSDPBroadcast(FSDPTestMultiThread):
     @property

--- a/test/distributed/_composable/fsdp/test_fully_shard_overlap.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_overlap.py
@@ -332,7 +332,7 @@ class TestFullyShardPerParamMeshOverlap(FSDPTest):
                 *args,
                 **kwargs,
             )
-            rs_input, rs_event, *rest = result
+            rs_input, rs_event, post_reduce_stream, *rest = result
             if reduce_scatter_group not in delay_streams:
                 delay_streams[reduce_scatter_group] = device_module.Stream()
             ds = delay_streams[reduce_scatter_group]
@@ -340,7 +340,7 @@ class TestFullyShardPerParamMeshOverlap(FSDPTest):
             with device_module.stream(ds):
                 device_module._sleep(int(sleep_ms * get_cycles_per_ms()))
                 delayed_event = ds.record_event()
-            return (rs_input, delayed_event, *rest)
+            return (rs_input, delayed_event, post_reduce_stream, *rest)
 
         dist.barrier()
         _pg_mod.foreach_reduce = wrapped

--- a/test/distributed/_composable/fsdp/test_fully_shard_overlap.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_overlap.py
@@ -189,6 +189,135 @@ class TestFullyShardOverlap(FSDPTest):
         # )
         self.assertLessEqual(fwd_bwd_time, ref_fwd_bwd_time)
 
+    @skip_if_rocm_arch_multiprocess(MI200_ARCH)
+    @skip_if_lt_x_gpu(2)
+    def test_fully_shard_backward_comm_overlap(self):
+        """Exercise backward with reduce-scatter sharing the shard process
+        group and with reduce-scatter opted in to a dedicated process group via
+        set_separate_reduce_scatter_group.
+
+        Uses real compute (large matmuls) and real collectives (large
+        parameter tensors) instead of CUDA sleeps.
+
+        ref_bwd: RS forced back onto the shard PG (single communicator),
+        serializing it with all-gather.
+
+        fsdp_bwd: RS on its own communicator (the opt-in), enabling overlap.
+        """
+        torch.manual_seed(42)
+
+        # Large dim for non-trivial collective time, small batch so
+        # comm dominates compute; AG becomes back-to-back on its stream
+        dim, num_linears, batch = 16384, 3, 4
+        model = nn.Sequential(
+            *[nn.Linear(dim, dim, bias=False) for _ in range(num_linears)]
+        )
+        for lin in model:
+            fully_shard(lin, reshard_after_forward=True)
+        fully_shard(model, reshard_after_forward=True)
+        # Opt in: give reduce-scatter its own process group (the change under test)
+        model.set_separate_reduce_scatter_group()
+
+        optim = torch.optim.SGD(model.parameters(), lr=1e-2)
+        inp = torch.randn((batch, dim), device=device_type.type)
+        loss = model(inp).sum()
+        loss.backward()
+        with implicit_replication():
+            optim.step()
+        optim.zero_grad()  # warmup
+
+        # Collect FSDP param groups to toggle PG config
+        fsdp_param_groups = []
+        for module in model.modules():
+            state = fully_shard.state(module)
+            if state is not None:
+                fsdp_param_groups.extend(state._fsdp_param_groups)
+
+        # The opt-in created a dedicated RS group per mesh (distinct from shard)
+        for pg in fsdp_param_groups:
+            self.assertIsNotNone(pg.mesh_info.reduce_scatter_process_group)
+            self.assertIsNot(
+                pg.mesh_info.reduce_scatter_process_group,
+                pg.mesh_info.shard_process_group,
+            )
+
+        # ref_bwd: force RS to use the same PG as AG (serialized)
+        saved_rs_pgs = []
+        for pg in fsdp_param_groups:
+            saved_rs_pgs.append(pg.mesh_info.reduce_scatter_process_group)
+            pg.mesh_info.reduce_scatter_process_group = pg.mesh_info.shard_process_group
+
+        def ref_bwd():
+            loss = model(inp).sum()
+            loss.backward()
+            with implicit_replication():
+                optim.step()
+            optim.zero_grad()
+
+        _time_fn(ref_bwd)
+
+        # Restore separate PGs for fsdp_bwd
+        for pg, saved_pg in zip(fsdp_param_groups, saved_rs_pgs):
+            pg.mesh_info.reduce_scatter_process_group = saved_pg
+
+        def fsdp_bwd():
+            loss = model(inp).sum()
+            loss.backward()
+            with implicit_replication():
+                optim.step()
+            optim.zero_grad()
+
+        # Exercise both shared-PG and separate-RS-PG backward paths. We do not
+        # assert timing here since real collective overlap is hardware/backend
+        # sensitive.
+        _time_fn(fsdp_bwd)
+
+    @skip_if_lt_x_gpu(2)
+    def test_set_separate_reduce_scatter_group(self):
+        """Reduce-scatter shares the shard PG by default; enabling gives it a
+        dedicated PG (one communicator shared across same-rank-set meshes), and
+        disabling resets to the shared PG."""
+        model = nn.Sequential(nn.Linear(8, 8), nn.Linear(8, 8))
+        for lin in model:
+            fully_shard(lin)
+        fully_shard(model)
+        param_groups = []
+        for module in model.modules():
+            state = fully_shard.state(module)
+            if state is not None:
+                param_groups.extend(state._fsdp_param_groups)
+
+        def _assert_shares_all_gather():
+            for pg in param_groups:
+                self.assertIsNone(pg.mesh_info.reduce_scatter_process_group)
+                self.assertIs(
+                    pg._reduce_scatter_process_group,
+                    pg.mesh_info.shard_process_group,
+                )
+
+        # Default shares the all-gather (shard) PG
+        _assert_shares_all_gather()
+
+        # Enable: one dedicated PG shared across same-rank-set meshes (dedup),
+        # distinct from the shard PG
+        model.set_separate_reduce_scatter_group()
+        rs_pgs = {id(pg.mesh_info.reduce_scatter_process_group) for pg in param_groups}
+        self.assertEqual(len(rs_pgs), 1)  # one communicator for the single rank set
+        for pg in param_groups:
+            self.assertIsNotNone(pg.mesh_info.reduce_scatter_process_group)
+            self.assertIs(
+                pg._reduce_scatter_process_group,
+                pg.mesh_info.reduce_scatter_process_group,
+            )
+            self.assertIsNot(
+                pg._reduce_scatter_process_group, pg.mesh_info.shard_process_group
+            )
+
+        # Disable: reset back to sharing the shard PG
+        model.set_separate_reduce_scatter_group(False)
+        _assert_shares_all_gather()
+
+    @unittest.skipIf(IS_LINUX, "https://github.com/pytorch/pytorch/issues/131081")
     @skip_if_lt_x_gpu(2)
     @unittest.skipIf(TEST_HPU, "Sleep is not supported on HPU")
     def test_fully_shard_post_optim_event_overlap(self):

--- a/test/distributed/_composable/fsdp/test_fully_shard_training.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_training.py
@@ -1987,6 +1987,7 @@ class TestFullyShardShareCommContext(FSDPTest):
             fully_shard(layer)
             layer._get_fsdp_state()._lazy_init()
         share_comm_ctx(list(model))
+        shared_comm_ctx = model[0]._get_fsdp_state()._comm_ctx
 
         torch.manual_seed(42 + self.rank + 1)
         inp = torch.randn(4, 3, lin_dim, device=device_type.type)
@@ -2076,6 +2077,7 @@ class TestFullyShardShareCommContext(FSDPTest):
                 dist.all_reduce(param.grad, op=dist.ReduceOp.AVG)
         self.assertEqual(len(all_gather_streams), 1)
         self.assertEqual(len(reduce_scatter_streams), 1)
+        self.assertEqual(len(shared_comm_ctx._last_post_reduce_events), 0)
         check_sharded_parity(self, ref_model, model)
 
 

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_collectives.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_collectives.py
@@ -540,6 +540,7 @@ def foreach_reduce(
 ) -> tuple[
     torch.Tensor,
     torch.Event,
+    torch.Stream,
     torch.Event,
     torch.Tensor | None,
     torch.Event | None,
@@ -642,6 +643,7 @@ def foreach_reduce(
                 return (
                     reduce_scatter_input,
                     reduce_scatter_event,
+                    post_reduce_stream,
                     post_reduce_stream.record_event(),
                     all_reduce_input,
                     all_reduce_event,
@@ -740,6 +742,7 @@ def foreach_reduce(
     return (
         reduce_scatter_input,
         reduce_scatter_event,
+        post_reduce_stream,
         post_reduce_event,
         all_reduce_input,
         all_reduce_event,

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_common.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_common.py
@@ -57,6 +57,10 @@ class FSDPMeshInfo(DataParallelMeshInfo):
         self.shard_mesh_size: int = self.mesh.size(self.shard_mesh_dim)
         self.shard_process_group = self.mesh.get_group(self.shard_mesh_dim)
         self.shard_mesh_rank: int = self.shard_process_group.rank()
+        # Reduce-scatter shares the shard PG (one NCCL communicator) by default;
+        # FSDPModule.set_separate_reduce_scatter_group assigns a dedicated PG
+        # here so reduce-scatter can overlap all-gather in backward.
+        self.reduce_scatter_process_group: dist.ProcessGroup | None = None
 
 
 @dataclass

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
@@ -102,6 +102,11 @@ class FSDPCommContext:
         # CUDA events for synchronization
         self.all_gather_state: AllGatherState | None = None
         self.reduce_scatter_states: list[ReduceScatterState] = []
+        # Effective cap on retained reduce_scatter_states, resolved from the
+        # per-group reduce_scatter_max_input_buffers in
+        # FSDPState._init_shared_state. It lives here, not per group, because
+        # reduce_scatter_states is a single shared list governed by one cap.
+        self.reduce_scatter_max_input_buffers: int = 1
         # Post-forward order for explicit backward prefetching
         self.post_forward_order: list[FSDPParamGroup] = []  # will cause ref cycles
 
@@ -208,6 +213,12 @@ class FSDPParamGroup:
         # Whether to reshard parameters after backward (only useful for
         # gradient accumulation)
         self.reshard_after_backward: bool = True
+        # Per-group input for the reduce-scatter copy-in (chunk_cat) buffer
+        # cap-K, set via FSDPModule.set_reduce_scatter_max_input_buffers (see
+        # its docstring). FSDP keeps 1 by default. These per-group values are
+        # resolved into the single shared
+        # comm_ctx.reduce_scatter_max_input_buffers that post_backward reads.
+        self.reduce_scatter_max_input_buffers: int = 1
         # Optional custom factor for the gradient reduction op (e.g. to divide
         # by a factor other than the world size)
         self.gradient_divide_factor: float | None = None
@@ -280,6 +291,7 @@ class FSDPParamGroup:
             self._reset_sharded_params = True
         self._validate_no_meta_params()
         self._validate_cpu_offload_params()
+        self._validate_reduce_scatter_max_input_buffers()
         # Initialize mixed precision attributes lazily in case the user changes
         # the parameter dtypes after construction time but before forward
         self._init_mp_dtypes()
@@ -554,17 +566,26 @@ class FSDPParamGroup:
                     fsdp_param.unsharded_param.grad = None
             if self.reshard_after_backward:
                 self.reshard()
-        # Wait on prior module's RS states (assumes backward fires groups
-        # N-1 first; if not, overlap degrades but correctness is preserved).
+        # Recycle prior modules' reduce-scatter input buffers, keeping at most
+        # `max_input_buffers` in flight: reclaim the oldest (wait on its
+        # reduce-scatter, then drop the keepalive ref that was deferring the
+        # allocator's reuse of its memory) until fewer than that remain, before
+        # this module's reduce appends one more. See
+        # set_reduce_scatter_max_input_buffers for the memory/overlap tradeoff.
+        # (Assumes backward fires groups N-1 first; if not, overlap degrades but
+        # correctness is preserved.)
+        max_input_buffers = self.comm_ctx.reduce_scatter_max_input_buffers
+        states = self.comm_ctx.reduce_scatter_states
         if (
             self._param_group_index == self._num_param_groups - 1
-            and self.comm_ctx.reduce_scatter_states
+            and len(states) >= max_input_buffers
         ):
             with record_function(f"FSDP::post_backward_rs_wait ({self._module_fqn})"):
-                for rs_state in self.comm_ctx.reduce_scatter_states:
-                    if rs_state.event is not None:
-                        self.device_handle.current_stream().wait_event(rs_state.event)
-                self.comm_ctx.reduce_scatter_states.clear()
+                while len(states) >= max_input_buffers:
+                    oldest = states.pop(0)
+                    if oldest.event is not None:
+                        self.device_handle.current_stream().wait_event(oldest.event)
+                    del oldest
         if len(fsdp_params_with_grad) == 0:
             return
         with record_function(self._with_fqn("FSDP::post_backward_reduce")):
@@ -889,6 +910,27 @@ class FSDPParamGroup:
                 'For example, load a CPU state dict or call module.to_empty(device="cpu"). '
                 "Found following parameters on non-CPU device: "
                 f"{[(fsdp_param._param_fqn, fsdp_param.sharded_param.device) for fsdp_param in fsdp_params_not_on_cpu]}\n"
+            )
+
+    def _validate_reduce_scatter_max_input_buffers(self):
+        # Reject max_input_buffers > 1 with the symmetric-memory reduce-scatter
+        # comm: retaining >1 input buffers relies on the allocator handing out a
+        # fresh buffer while prior ones are ref-held, but the symmetric-memory
+        # pool reuses a single buffer, so retaining K would force K symmetric
+        # segments and can exhaust symmetric memory. Read the per-group cap (set
+        # in __init__) so this is safe to call before the comm context is lazily
+        # initialized (e.g. unshard before the first forward).
+        if self.reduce_scatter_max_input_buffers > 1 and isinstance(
+            self._reduce_scatter_comm, SymmMemReduceScatter
+        ):
+            raise ValueError(
+                "set_reduce_scatter_max_input_buffers(>1) is not supported with "
+                "the symmetric-memory reduce-scatter comm, but got "
+                f"{self.reduce_scatter_max_input_buffers} for module "
+                f"'{self._module_fqn}' using "
+                f"{self._reduce_scatter_comm.__class__.__name__}. Keep "
+                "max_input_buffers=1 with symmetric memory, or use the default "
+                "reduce-scatter comm."
             )
 
 

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
@@ -862,7 +862,46 @@ class FSDPParamGroup:
             raise AssertionError(
                 f"Expected mesh_info to be FSDPMeshInfo, got {type(self.mesh_info)}"
             )
-        return self.mesh_info.shard_process_group
+        # Falls back to the shard PG (shared with all-gather) unless
+        # set_separate_reduce_scatter_group opted in to a dedicated PG.
+        return (
+            self.mesh_info.reduce_scatter_process_group
+            or self.mesh_info.shard_process_group
+        )
+
+    def _set_separate_reduce_scatter_group(
+        self, enable: bool, new_groups: dict[tuple[int, ...], dist.ProcessGroup]
+    ) -> None:
+        # Give reduce-scatter its own process group (separate from the shared
+        # all-gather/shard PG) so the two can overlap in backward, or reset to
+        # the shared group. ``new_groups`` caches groups by shard ranks within
+        # one set_separate_reduce_scatter_group call so meshes sharding over the
+        # same ranks share one communicator (typically one total) rather than one
+        # per mesh. HSDP ranks may create only their local shard subgroup, so
+        # use local synchronization to avoid waiting for nonmember ranks in
+        # new_group's post-init barrier.
+        mesh_info = self.mesh_info
+        if not isinstance(mesh_info, FSDPMeshInfo):
+            raise AssertionError(
+                f"Expected mesh_info to be FSDPMeshInfo, got {type(mesh_info)}"
+            )
+        if not enable:
+            mesh_info.reduce_scatter_process_group = None
+            return
+        ranks = tuple(dist.get_process_group_ranks(mesh_info.shard_process_group))
+        if ranks not in new_groups:
+            # Reuse the mesh's existing group if already enabled (idempotent),
+            # else create one for this rank set.
+            existing = mesh_info.reduce_scatter_process_group
+            if existing is not None:
+                new_groups[ranks] = existing
+            else:
+                new_groups[ranks] = dist.new_group(
+                    list(ranks),
+                    use_local_synchronization=True,
+                    group_desc="fsdp_reduce_scatter",
+                )
+        mesh_info.reduce_scatter_process_group = new_groups[ranks]
 
     @property
     def _all_reduce_process_group(self) -> dist.ProcessGroup:

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
@@ -87,6 +87,12 @@ class FSDPCommContext:
         # Reduce-scatter stream gives separate execution "thread" for post-
         # backward logic like pre/post-gradient division and reduce-scatter
         self.reduce_scatter_stream = self.device_handle.Stream(priority=high_priority)
+        # The most recent post-reduce event across all param groups, recorded
+        # on reduce_scatter_stream (FSDP) or all_reduce_stream (HSDP). Since
+        # later events subsume earlier ones on the same stream, a single wait
+        # on the last event recorded on each stream used in the post backward
+        # hook covers all groups.
+        self._last_post_reduce_events: dict[torch.Stream, torch.Event] = dict()
         # Run the HSDP all-reduces concurrently with all-gather/reduce-scatter
         # since collectives use different network resources and can overlap
         # in the typical intra-node sharding / inter-node replication case
@@ -583,6 +589,7 @@ class FSDPParamGroup:
             (
                 reduce_scatter_input,
                 reduce_scatter_event,
+                post_reduce_stream,
                 self._post_reduce_event,
                 all_reduce_input,
                 all_reduce_event,
@@ -613,6 +620,9 @@ class FSDPParamGroup:
                 self._all_reduce_hook,
                 self.force_sum_reduction_for_comms,
             )
+            self.comm_ctx._last_post_reduce_events[post_reduce_stream] = (
+                self._post_reduce_event
+            )
             self.comm_ctx.reduce_scatter_states.append(
                 ReduceScatterState(reduce_scatter_input, reduce_scatter_event)
             )
@@ -627,7 +637,11 @@ class FSDPParamGroup:
                 )
 
     def finalize_backward(self):
-        self._wait_for_post_backward()
+        for event in self.comm_ctx._last_post_reduce_events.values():
+            self.device_handle.current_stream().wait_event(event)
+        self.comm_ctx._last_post_reduce_events = dict()
+        self._post_reduce_event = None
+        self._all_reduce_state = None
         for fsdp_param in self.fsdp_params:
             if fsdp_param.grad_offload_event is not None:
                 fsdp_param.grad_offload_event.synchronize()

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_state.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_state.py
@@ -232,6 +232,18 @@ class FSDPState(_State):
                 fsdp_param_group.comm_ctx = self._comm_ctx
                 fsdp_param_group._param_group_index = i
                 fsdp_param_group._num_param_groups = num_groups
+        # The reduce-scatter input-buffer cap governs the single shared
+        # reduce_scatter_states list, so resolve the per-group caps into one
+        # effective value (the most aggressive); a lower-cap group must not
+        # silently undo a higher-cap group's retention.
+        self._comm_ctx.reduce_scatter_max_input_buffers = max(
+            (
+                fsdp_param_group.reduce_scatter_max_input_buffers
+                for state in self._state_ctx.all_states
+                for fsdp_param_group in state._fsdp_param_groups
+            ),
+            default=1,
+        )
 
     def _init_fqns(self) -> None:
         """Sets module and parameter FQN attributes for debugging."""
@@ -364,8 +376,11 @@ class FSDPState(_State):
                     state._finalize_backward()
             if self._state_ctx.is_last_backward:
                 self._comm_ctx.post_forward_order.clear()
-                # Catch the last module's RS states that no subsequent
-                # module's group N-1 wait will clear.
+                # Wait on and release any retained reduce-scatter input buffers:
+                # the last module's (which no later module's rs_wait clears) and,
+                # when set_reduce_scatter_max_input_buffers retains more than
+                # one in flight, the rest. The compute stream (which reuses the
+                # memory) is ordered past each reduce-scatter first.
                 for rs_state in self._comm_ctx.reduce_scatter_states:
                     if rs_state.event is not None:
                         self._device_handle.current_stream().wait_event(rs_state.event)

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_state.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_state.py
@@ -406,6 +406,37 @@ class FSDPState(_State):
             self._root_post_backward_final_callback
         )
 
+    def _reset_iter_state(self) -> None:
+        # Iteration-wide recovery after a mid-forward or mid-backward
+        # exception. Waits on in-flight collectives, reshards every param
+        # group, and clears per-iteration trackers so the next forward can
+        # start from a clean state. Any in-flight gradients (reduce-scatter
+        # results, HSDP partial reduce outputs, grad-accum state) are
+        # discarded: the failed iteration is treated as lost.
+        if self._is_root is False:
+            raise RuntimeError(
+                "reset_iter_state must be called on the root FSDP module"
+            )
+        current_stream = self._device_handle.current_stream()
+        if ag_state := self._comm_ctx.all_gather_state:
+            if ag_state.event is not None:
+                current_stream.wait_event(ag_state.event)
+            self._comm_ctx.all_gather_state = None
+        for rs_state in self._comm_ctx.reduce_scatter_states:
+            if rs_state.event is not None:
+                current_stream.wait_event(rs_state.event)
+        self._comm_ctx.reduce_scatter_states.clear()
+        for event in self._comm_ctx._last_post_reduce_events.values():
+            current_stream.wait_event(event)
+        self._comm_ctx._last_post_reduce_events.clear()
+        self._comm_ctx.post_forward_order.clear()
+        for state in self._state_ctx.all_states:
+            state._modules_to_run_forward.clear()
+            state._training_state = TrainingState.IDLE
+            for fsdp_param_group in state._fsdp_param_groups:
+                fsdp_param_group._reset_iter_state()
+        self._state_ctx.iter_forward_root = None
+        self._state_ctx.post_backward_final_callback_queued = False 0e6d87bca43 ([fsdp] Remove redundant stream waits (#183983))
 
 def _get_module_fsdp_state(module: nn.Module) -> FSDPState | None:
     state = _get_module_state(module)

--- a/torch/distributed/fsdp/_fully_shard/_fully_shard.py
+++ b/torch/distributed/fsdp/_fully_shard/_fully_shard.py
@@ -703,6 +703,44 @@ class FSDPModule:
                         max_input_buffers
                     )
 
+    def set_separate_reduce_scatter_group(
+        self, enable: bool = True, *, recurse: bool = True
+    ) -> None:
+        """
+        Enables (or disables) running gradient reduce-scatter on its own process
+        group so it can overlap with all-gather in the backward pass
+        (experimental).
+
+        By default FSDP runs all-gather and reduce-scatter on separate CUDA
+        streams but through the **same** process group -- one NCCL communicator,
+        which processes one collective at a time and so serializes them on the
+        wire. When enabled, FSDP creates a dedicated process group over the shard
+        ranks (``dist.new_group(..., use_local_synchronization=True)``) -- one
+        per distinct set of shard ranks, typically a single communicator -- so
+        the two collectives can progress concurrently when the network can
+        sustain it. This is collective for each shard rank set: like other FSDP
+        comm setup, call it consistently across ranks using this FSDP mesh.
+
+        Args:
+            enable (bool): ``True`` (default) gives reduce-scatter its own
+                process group; ``False`` resets it to the shared shard/all-gather
+                group.
+            recurse (bool): Whether to set for all FSDP submodules or just the
+                passed-in module.
+        """
+        self_module = cast(nn.Module, self)
+        modules = list(self_module.modules()) if recurse else [self_module]
+        # Cache created groups by shard ranks so meshes that shard over the same
+        # ranks share one communicator (typically one total), not one per mesh.
+        new_groups: dict = {}
+        for module in modules:
+            if isinstance(module, FSDPModule):
+                state = module._get_fsdp_state()
+                for fsdp_param_group in state._fsdp_param_groups:
+                    fsdp_param_group._set_separate_reduce_scatter_group(
+                        enable, new_groups
+                    )
+
     def set_unshard_in_backward(self, unshard_in_backward: bool) -> None:
         """
         Sets whether the FSDP module's parameters need to be unsharded in

--- a/torch/distributed/fsdp/_fully_shard/_fully_shard.py
+++ b/torch/distributed/fsdp/_fully_shard/_fully_shard.py
@@ -625,6 +625,84 @@ class FSDPModule:
         for fsdp_param_group in state._fsdp_param_groups:
             fsdp_param_group.force_sum_reduction_for_comms = enable
 
+    def set_reduce_scatter_unused_params(
+        self, reduce_scatter_unused_params: bool, *, recurse: bool = True
+    ) -> None:
+        """
+        Sets whether to include zero gradients for parameters that did not
+        receive a gradient in backward. This is needed when different ranks
+        use different parameters due to conditional control flow (e.g.
+        multi-modal models, mixture of experts), causing mismatched
+        reduce-scatter collectives. Similar to DDP's
+        ``find_unused_parameters``.
+
+        Args:
+            reduce_scatter_unused_params (bool): Whether to include zero
+                gradients for unused parameters in gradient reduction.
+            recurse (bool): Whether to set for all FSDP submodules or just
+                the passed-in module.
+        """
+        self_module = cast(nn.Module, self)
+        modules = list(self_module.modules()) if recurse else [self_module]
+        for module in modules:
+            if isinstance(module, FSDPModule):
+                state = module._get_fsdp_state()
+                for fsdp_param_group in state._fsdp_param_groups:
+                    fsdp_param_group.reduce_scatter_unused_params = (
+                        reduce_scatter_unused_params
+                    )
+
+    def set_reduce_scatter_max_input_buffers(
+        self, max_input_buffers: int, *, recurse: bool = True
+    ) -> None:
+        """
+        Sets how many gradient reduce-scatter input buffers may be in flight at
+        once -- the copy-in (``chunk_cat``) buffer cap-K (experimental).
+
+        FSDP keeps **1** such buffer in flight by default, so the compute stream
+        must wait on the previous reduce-scatter before the next copy-in can
+        reuse that buffer. When the reduce-scatter is exposed (communication
+        slower than the backward compute meant to hide it), that recycle wait
+        stalls the compute stream. Raising the cap lets the next copy-in write a
+        **fresh** buffer instead of waiting -- removing the stall -- at the cost
+        of extra peak memory for the retained buffers. The copy-in stays on the
+        compute stream; there is no extra stream and no ``record_stream``. This
+        helps only when the reduce-scatter is exposed.
+
+        Args:
+            max_input_buffers (int): Max reduce-scatter input buffers retained in
+                flight (the memory<->overlap dial); must be ``>= 1``. ``1`` is
+                FSDP's default behavior (single buffer; the exposed-RS stall). A
+                small value (e.g. ``2``) bounds peak memory and adds no stall as
+                long as it is ``>=`` the reduce-scatter pipeline depth (otherwise
+                an exposed reduce-scatter trades back a tail stall); a larger
+                value retains more buffers for deeper overlap at higher peak
+                memory.
+            recurse (bool): Whether to set for all FSDP submodules or just the
+                passed-in module.
+        """
+        # bool is an int subclass; reject it so True does not silently mean 1.
+        if isinstance(max_input_buffers, bool) or not isinstance(
+            max_input_buffers, int
+        ):
+            raise TypeError(
+                "max_input_buffers must be an int, got "
+                f"{type(max_input_buffers).__name__}"
+            )
+        if max_input_buffers < 1:
+            raise ValueError(
+                f"max_input_buffers must be a positive int, got {max_input_buffers}"
+            )
+        self_module = cast(nn.Module, self)
+        modules = list(self_module.modules()) if recurse else [self_module]
+        for module in modules:
+            if isinstance(module, FSDPModule):
+                state = module._get_fsdp_state()
+                for fsdp_param_group in state._fsdp_param_groups:
+                    fsdp_param_group.reduce_scatter_max_input_buffers = (
+                        max_input_buffers
+                    )
+
     def set_unshard_in_backward(self, unshard_in_backward: bool) -> None:
         """
         Sets whether the FSDP module's parameters need to be unsharded in


### PR DESCRIPTION
## Fix FSDP2 reduce-scatter memory & performance regression on release/2.12

https://amd-hub.atlassian.net/browse/ROCM-27061
[Regression] PyTorch 2.12 causes ~12% TFLOP/s drop for Llama-3.1-405B BF16 (torchtitan, 4-node) on MI325X vs PyTorch 2.11 — same ROCm 7.14.0 build

### Problem

Training with FSDP2 on per-param-mesh / MoE-style models (e.g. DeepSeek V3) regressed
after commit `49a3f54d2d27` ("[FSDP2] overlap reduce-scatter with compute for per-param-mesh
#177319") was integrated into `release/2.12`:

- Peak GPU memory increased: **243.86 GiB (95.3%) → 249–252 GiB (97–98.6%)**
- CUDA memory allocation retries appeared every step
- Throughput dropped: **tps 648 → 566, MFU 29.8% → 26%**
- Gradient norm spikes observed (e.g. grad_norm 16.6 → 95.5), indicating a potential
  buffer-reuse race corrupting in-flight reduce-scatter inputs

### Root cause

`#177319` changed `FSDPCommContext.reduce_scatter_state: ReduceScatterState | None`
to `reduce_scatter_states: list[ReduceScatterState]`. For modules with more than one
param group (per-param-mesh models with separate meshes for dense vs. expert params),
only the param group whose `_param_group_index == _num_param_groups - 1` drains the
shared list. This relies on an explicitly documented but unenforced assumption about
autograd hook firing order. When the assumption is violated, reduce-scatter input buffers
accumulate across param groups without being recycled, increasing peak memory and
potentially causing buffer-reuse races before in-flight collectives complete.

This feature had already been reverted once in upstream `pytorch/pytorch` for consistently
failing tests before being re-landed, confirming its fragility.

### Fix

Cherry-picked three upstream `pytorch/pytorch` fixes that were already present in
`ROCm/pytorch`'s `release/2.13` and `develop` branches but missing from `release/2.12`:

| Commit | Upstream PR | Description |
|---|---|---|
| `dbf46743869` | [#183983](https://github.com/pytorch/pytorch/pull/183983) | Remove redundant stream waits |
| `8d97f0cf156` | [#186000](https://github.com/pytorch/pytorch/pull/186000) | Add `set_reduce_scatter_max_input_buffers` |
| `b5ff92918f4` | [#186335](https://github.com/pytorch/pytorch/pull/186335) | Add `set_separate_reduce_scatter_group` |

The key fix is **#186000**: it replaces the unbounded `list.clear()` with a bounded
`pop(0)` recycle loop gated on `reduce_scatter_max_input_buffers` (default `1`).
At the default, this is byte-identical to the pre-regression behavior — at most one
reduce-scatter input buffer in flight at any time — eliminating both the memory
accumulation and the race condition. The opt-in APIs
(`set_reduce_scatter_max_input_buffers`, `set_separate_reduce_scatter_group`) are
available for deliberately enabling overlap once validated on target hardware.

### Files changed

- `torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py`
- `torch/distributed/fsdp/_fully_shard/_fsdp_state.py`
- `torch/distributed/fsdp/_fully_shard/_fsdp_collectives.py`
- `torch/distributed/fsdp/_fully_shard/_fully_shard.py`
- `test/distributed/_composable/fsdp/test_fully_shard_overlap.py`
- `test/distributed/_composable/fsdp/test_fully_shard_comm.py`
- `test/distributed/_composable/fsdp/test_fully_shard_training.py`
- `test/distributed/_composable/fsdp/test_fully_shard_init.py`
## Test Plan

Run full build and tested model with regression.

## Test Result



## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
