### PR TITLE
[releae/2.11] remove xfailCUDAIfSM89OrLaterOnWindows decorator

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -16,11 +16,11 @@ import threading
 import time
 import unittest
 import warnings
-from unittest.mock import patch
 from collections import defaultdict
 from copy import deepcopy
 from itertools import product
 from random import randint
+from unittest.mock import patch
 
 import psutil
 
@@ -44,7 +44,6 @@ from torch.testing._internal.common_cuda import (
     TEST_CUDNN,
     TEST_MULTIGPU,
     tf32_on_and_off,
-    xfailCUDAIfSM89OrLaterOnWindows,
 )
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
@@ -2329,7 +2328,6 @@ torch.cuda.synchronize()
             self.assertEqual(random_values, graphed_random_values)
 
     @skipIfRocmVersionLessThan((7, 14))
-    @xfailCUDAIfSM89OrLaterOnWindows
     @unittest.skipIf(
         not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
     )


### PR DESCRIPTION
Remove @xfailCUDAIfSM89OrLaterOnWindows from test_graph_capture_error_releases_reserved_segments and drop its import from `test/test_cuda.py`.

That decorator was added when cherry-picking the CUDAGraph pool-leak fix (#190348) onto release/2.12. On this branch, `xfailCUDAIfSM89OrLaterOnWindows` is not available in `torch.testing._internal.common_cuda`, so importing it raises `ImportError` and the test module fails to load.

The upstream test used the decorator for a Windows+SM89+xfail that does not apply to our 2.12 backport context. Removing the decorator and import restores a valid import path

(cherry picked from commit 6cf0f0a66d95ff4703e4e6dc007d78eeb9339f10)

