### PR TITLE
[release/2.13] IFU dedup: backport refined release/2.12 ROCm commits

### DIFF
--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -661,11 +661,33 @@ if(USE_ROCM)
     ${native_quantized_hip_hip}
     ${native_transformers_hip_hip} ${native_transformers_src_hip_hip}
   )
+  file(GLOB native_hip_bgemm CONFIGURE_DEPENDS "native/hip/bgemm_kernels/*.hip")
+  file(GLOB native_hip_ck CONFIGURE_DEPENDS "native/hip/ck*.hip")
   if(NOT USE_ROCM_CK_GEMM)
-    file(GLOB native_hip_bgemm CONFIGURE_DEPENDS "native/hip/bgemm_kernels/*.hip")
-    file(GLOB native_hip_ck CONFIGURE_DEPENDS "native/hip/ck*.hip")
     exclude(ATen_HIP_SRCS "${ATen_HIP_SRCS}"
       ${native_hip_bgemm} ${native_hip_ck})
+  else()
+    # composable_kernel has no gfx1250 support yet, so its CK GEMM kernels fail to
+    # compile for that arch. Build CK GEMM as a separate library with gfx1250
+    # filtered out of HIP_ARCHITECTURES so every other requested arch still gets
+    # CK GEMM. Remove this filtering once the CK submodule supports gfx1250.
+    exclude(ATen_HIP_SRCS "${ATen_HIP_SRCS}"
+      ${native_hip_bgemm} ${native_hip_ck})
+    set(_ck_gemm_hip_arches ${PYTORCH_ROCM_ARCH})
+    list(REMOVE_ITEM _ck_gemm_hip_arches "gfx1250")
+    set_source_files_properties(${native_hip_bgemm} ${native_hip_ck} PROPERTIES LANGUAGE HIP)
+    add_library(ck_gemm STATIC ${native_hip_bgemm} ${native_hip_ck})
+    set_target_properties(ck_gemm PROPERTIES
+      POSITION_INDEPENDENT_CODE ON
+      HIP_ARCHITECTURES "${_ck_gemm_hip_arches}")
+    target_compile_options(ck_gemm PRIVATE ${HIP_CXX_FLAGS})
+    target_include_directories(ck_gemm PRIVATE
+      ${CMAKE_CURRENT_SOURCE_DIR}/hip
+      ${CMAKE_CURRENT_SOURCE_DIR}/../../../third_party/composable_kernel/include
+      ${CMAKE_CURRENT_SOURCE_DIR}/../../../third_party/composable_kernel/library/include
+      ${CMAKE_CURRENT_BINARY_DIR}/composable_kernel)
+    # Ensure torch_cpu (and its codegen) is built before ck_gemm to avoid race conditions
+    add_dependencies(ck_gemm torch_cpu)
   endif()
 
   # TODO: Codegen separate files for HIP and use those (s/cuda_generated_sources/hip_generated_sources)

--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -2101,7 +2101,11 @@ void scaled_gemm(
   }
   else if (mat1_scale_dtype == kFloat8_e8m0fnu && mat2_scale_dtype == kFloat8_e8m0fnu) {
   #if ROCM_VERSION >= 70000
-            if (at::detail::getCUDAHooks().isGPUArch({"gfx950"})) {
+            std::vector<std::string> mx_archs{"gfx950"};
+  #if ROCM_VERSION >= 71400
+            mx_archs.push_back("gfx1250");
+  #endif
+            if (at::detail::getCUDAHooks().isGPUArch(mx_archs)) {
                 // TODO: add constraints based on hipblaslt internals
                 TORCH_CHECK((m % 16 == 0) && (n % 16 == 0) && (k % 128 == 0),
                            "M, N must be multiples of 16 and K should be multiple of 128 for MX format. "

--- a/aten/src/ATen/cuda/CublasHandlePool.cpp
+++ b/aten/src/ATen/cuda/CublasHandlePool.cpp
@@ -172,9 +172,9 @@ size_t parseChosenWorkspaceSize() {
     // for extra convenience
     val = c10::utils::get_env("ROCBLAS_WORKSPACE_CONFIG");
   }
-  /* 32MiB default, 128MiB for gfx94x/gfx95x */
-  const bool gfx94_95 = at::detail::getCUDAHooks().isGPUArch({"gfx94", "gfx95"});
-  const size_t default_size = gfx94_95 ? 1024 * 128 * 1024 : 1024 * 32 * 1024;
+  /* 32MiB default, 128MiB for gfx942/gfx950/gfx1250 */
+  const bool gfx942_950_1250 = at::detail::getCUDAHooks().isGPUArch({"gfx942", "gfx950", "gfx1250"});
+  const size_t default_size = gfx942_950_1250 ? 1024 * 128 * 1024 : 1024 * 32 * 1024;
 #else
   /* :4096:2:16:8 default, 32MiB for Hopper and Blackwell */
   cudaDeviceProp* properties = at::cuda::getCurrentDeviceProperties();

--- a/aten/src/ATen/cuda/detail/CUDAHooks.cpp
+++ b/aten/src/ATen/cuda/detail/CUDAHooks.cpp
@@ -557,7 +557,10 @@ const std::vector<std::string>& CUDAHooks::getHipblasltPreferredArchs() const {
     "gfx950",
 #endif
 #if ROCM_VERSION >= 71300
-    "gfx1100", "gfx1101", "gfx1151"
+    "gfx1100", "gfx1101", "gfx1151",
+#endif
+#if ROCM_VERSION >= 71400
+    "gfx1250",
 #endif
   };
   return archs;
@@ -572,7 +575,7 @@ const std::vector<std::string>& CUDAHooks::getHipblasltSupportedArchs() const {
 #if ROCM_VERSION >= 70000
     "gfx950", "gfx1150", "gfx1151",
 #endif
-#if ROCM_VERSION >= 70200
+#if ROCM_VERSION >= 71400
     "gfx1250"
 #endif
   };

--- a/aten/src/ATen/native/cuda/CUDAScalar.cu
+++ b/aten/src/ATen/native/cuda/CUDAScalar.cu
@@ -35,6 +35,7 @@ void _local_scalar_dense_cuda_impl(const Tensor& self, Scalar& r) {
       at::cuda::getCurrentDeviceProperties()->isLargeBar &&
       is_cuda_caching_allocator_tensor(self)) {
     cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+#if ROCM_VERSION < 71400
     hipStreamCaptureStatus captureStatus;
     C10_CUDA_CHECK(hipStreamGetCaptureInfo(stream, &captureStatus, nullptr));
     if (C10_LIKELY(captureStatus == hipStreamCaptureStatusNone)) {
@@ -43,6 +44,12 @@ void _local_scalar_dense_cuda_impl(const Tensor& self, Scalar& r) {
     } else {
       C10_CUDA_CHECK(hipErrorStreamCaptureUnsupported);
     }
+#else // ROCM_VERSION
+    // HIP reports the errors during graph capture in ROCm 7.14+
+    // no StreamCaptureStatus check required
+    at::cuda::stream_synchronize(stream);
+    r = Scalar(*self.template const_data_ptr<scalar_t>());
+#endif // ROCM_VERSION
     return;
   }
 #endif

--- a/aten/src/ATen/native/cuda/MemoryAccess.cuh
+++ b/aten/src/ATen/native/cuda/MemoryAccess.cuh
@@ -192,6 +192,11 @@ __device__ aligned_vector<scalar_t, vec_size> load_vector(const scalar_t *base_p
   using vec_t = aligned_vector<scalar_t, vec_size>;
   auto *from = reinterpret_cast<const vec_t *>(base_ptr);
 #if defined(USE_ROCM)
+  // NOTE: This nontemporal vectorized load is tuned for gfx942 (CDNA3, Wave64).
+  // Do NOT extend to gfx1250 (GFX12.5, Wave32) without first validating
+  // intrinsic codegen and re-benchmarking — the register layout and wave
+  // width differ. gfx1250 falls through to the generic path below, which
+  // is correctness-safe.
   if(__builtin_amdgcn_processor_is("gfx942")) {
     using longx2 = __attribute__((__vector_size__(4*sizeof(int)))) int;
     if constexpr (sizeof(vec_t) == sizeof(int)) {

--- a/aten/src/ATen/native/cuda/ScaledBlas.cpp
+++ b/aten/src/ATen/native/cuda/ScaledBlas.cpp
@@ -16,6 +16,7 @@
 #include <ATen/cuda/tunable/TunableGemm.h>
 #include <ATen/native/Resize.h>
 #include <c10/util/MaybeOwned.h>
+#include <c10/util/StringUtil.h>
 #include <ATen/native/GroupedMMUtils.h>
 #include <ATen/native/cuda/RowwiseScaledMM.h>
 #include <ATen/native/cuda/ScaledGroupMM.h>
@@ -77,7 +78,10 @@ bool _scaled_mm_allowed_device(bool sm90_only=false, bool sm100_only=false) {
         "gfx1200", "gfx1201",
 #endif
 #if ROCM_VERSION >= 60500
-        "gfx950"
+        "gfx950",
+#endif
+#if ROCM_VERSION >= 71400
+        "gfx1250",
 #endif
     };
     return at::detail::getCUDAHooks().isGPUArch(archs);
@@ -96,6 +100,19 @@ bool _scaled_mm_allowed_device(bool sm90_only=false, bool sm100_only=false) {
 bool _scaled_mm_is_fnuz() {
     return at::detail::getCUDAHooks().isGPUArch({"gfx942"});
 }
+
+#if ROCM_VERSION >= 70000
+static void check_blockwise_e8m0fnu_arch_supported() {
+  std::vector<std::string> mx_archs{"gfx950"};
+#if ROCM_VERSION >= 71400
+  mx_archs.push_back("gfx1250");
+#endif
+  TORCH_CHECK_NOT_IMPLEMENTED(
+      at::detail::getCUDAHooks().isGPUArch(mx_archs),
+      "Block-wise scaling for Float8_e8m0fnu is only supported on ",
+      c10::Join(",", mx_archs));
+}
+#endif
 #endif
 
 /*
@@ -620,9 +637,8 @@ _scaled_mm_out_cuda(const Tensor& mat1, const Tensor& mat2,
   }
   else if (scaling_choice_a == ScalingType::BlockWise1x32 && scaling_choice_b == ScalingType::BlockWise1x32) {
 #ifdef USE_ROCM
-    #if ROCM_VERSION >= 70000
-    TORCH_CHECK_NOT_IMPLEMENTED(at::detail::getCUDAHooks().isGPUArch({"gfx950"}),
-                "Block-wise scaling for Float8_e8m0fnu is only supported on gfx950");
+#if ROCM_VERSION >= 70000
+    check_blockwise_e8m0fnu_arch_supported();
 
     int packed_factor = 1;
     if (mat1.scalar_type() == ScalarType::Float4_e2m1fn_x2) {
@@ -1063,8 +1079,7 @@ _scaled_mxfp8_mxfp8(
 
 #ifdef USE_ROCM
 #if ROCM_VERSION >= 70000
-  TORCH_CHECK_NOT_IMPLEMENTED(at::detail::getCUDAHooks().isGPUArch({"gfx950"}),
-              "Block-wise scaling for Float8_e8m0fnu is only supported on gfx950");
+  check_blockwise_e8m0fnu_arch_supported();
 
   TORCH_CHECK_VALUE(mat_a.size(0) % 32 == 0 && mat_a.size(1) % 32 == 0 &&
               mat_b.size(0) % 32 == 0 && mat_b.size(1) % 32 == 0,
@@ -1150,8 +1165,7 @@ _scaled_mxfp4_mxfp4(
   auto scaling_choice_b = ScalingType::BlockWise1x32;
 
 #if ROCM_VERSION >= 70000
-  TORCH_CHECK_NOT_IMPLEMENTED(at::detail::getCUDAHooks().isGPUArch({"gfx950"}),
-              "Block-wise scaling for Float8_e8m0fnu is only supported on gfx950");
+  check_blockwise_e8m0fnu_arch_supported();
 
   TORCH_CHECK_VALUE(mat_a.size(0) % 32 == 0 && mat_a.size(1) % 32 == 0 &&
               mat_b.size(0) % 32 == 0 && mat_b.size(1) % 32 == 0,

--- a/aten/src/ATen/native/cuda/UpSampleNearest2d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleNearest2d.cu
@@ -79,7 +79,18 @@ __global__ void upsample_nearest2d_out_frame(
   }
 }
 
-template <typename scalar_t, nn_compute_source_index_fn_t nn_compute_source_index_fn>
+// NHWC (channels-last) forward kernel.
+//
+// `kGridStride` selects the launch contract:
+//   - false: one element per thread; the launch grid covers `out_numel` exactly.
+//            The loop body executes once and the trailing `break` lets the
+//            compiler drop the loop entirely, preserving the original fast path.
+//   - true : grid is host-clamped (currently only on ROCm/HIP, see the comment
+//            on upsample_nearest2d_out_cuda_template) and threads stride over
+//            the output to cover the full range.
+template <typename scalar_t,
+          nn_compute_source_index_fn_t nn_compute_source_index_fn,
+          bool kGridStride>
 C10_LAUNCH_BOUNDS_1(1024)
 __global__ void upsample_nearest2d_nhwc_out_frame(
     const scalar_t* idata,
@@ -92,19 +103,28 @@ __global__ void upsample_nearest2d_nhwc_out_frame(
     float height_scale,
     float width_scale,
     const size_t out_numel) {
+  const int64_t start = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const int64_t step  = static_cast<int64_t>(gridDim.x) * blockDim.x;
+  const int64_t end   = static_cast<int64_t>(out_numel);
 
-    const int64_t index = ((int64_t) blockIdx.x) * blockDim.x + threadIdx.x;
-
-    if (index < out_numel) {
-    const auto c = index % channels;
+  for (int64_t index = start; index < end; index += step) {
+    const auto c  = index % channels;
     const auto w2 = (index / channels) % width2;
     const auto h2 = (index / channels / width2) % height2;
-    const auto n = index / channels / width2 / height2;
+    const auto n  = index / channels / width2 / height2;
 
-    const size_t h1 = height1 == height2 ? h2 : nn_compute_source_index_fn(height_scale, h2, height1);
-    const size_t w1 = width1 == width2 ? w2 : nn_compute_source_index_fn(width_scale, w2, width1);
+    const size_t h1 = height1 == height2
+        ? h2
+        : nn_compute_source_index_fn(height_scale, h2, height1);
+    const size_t w1 = width1 == width2
+        ? w2
+        : nn_compute_source_index_fn(width_scale, w2, width1);
 
     odata[index] = idata[idx_cl(n, h1, w1, c, height1, width1, channels)];
+
+    if constexpr (!kGridStride) {
+      break;
+    }
   }
 }
 
@@ -202,6 +222,13 @@ __global__ void upsample_nearest2d_backward_nhwc_out_frame(
   }
 }
 
+// On ROCm/HIP, gridDim.x * blockDim.x must fit in uint32_t per dimension (the
+// HSA AQL dispatch packet stores grid_size_{x,y,z} as uint32_t); violating it
+// returns hipErrorInvalidConfiguration.  Only the NHWC 1D-grid forward launch
+// can hit this in practice: with output.numel() near 2^32, a one-element-per-
+// thread grid overflows that field.  The contiguous (NCHW) 3D launch derives
+// grid_x/grid_y from int output_width/output_height, so per-dimension grids
+// are bounded well below the HIP limit.  See PR pytorch/pytorch#180310.
 template<nn_compute_source_index_fn_t nn_compute_source_index_fn>
 static void upsample_nearest2d_out_cuda_template(
     const Tensor& output,
@@ -234,6 +261,9 @@ static void upsample_nearest2d_out_cuda_template(
     return;
   }
 
+  // =================================================
+  // PATH 1: NHWC (channels-last) layout -- 1D grid
+  // =================================================
   // heuristic: only use channels_last path when it's faster than the contiguous path
   if (memory_format == at::MemoryFormat::ChannelsLast && channels >= 4 && \
         output.is_contiguous(memory_format)) {
@@ -247,25 +277,47 @@ static void upsample_nearest2d_out_cuda_template(
     const int64_t num_kernels = output.numel();
     const int64_t num_threads = std::min(at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock, 1024);
 
+    const int64_t grid = ceil_div(num_kernels, num_threads);
+#ifdef USE_ROCM
+    constexpr int64_t kHipMaxGlobalWorkSize = 4294967295LL;  // UINT32_MAX
+    const int64_t safe_max_grid = kHipMaxGlobalWorkSize / num_threads;
+    const bool use_grid_stride = grid > safe_max_grid;
+    const unsigned int launch_grid =
+        static_cast<unsigned int>(use_grid_stride ? safe_max_grid : grid);
+#else
+    constexpr bool use_grid_stride = false;
+    const int64_t launch_grid = grid;
+#endif
+
     AT_DISPATCH_FLOATING_TYPES_AND3(ScalarType::Half, ScalarType::BFloat16, ScalarType::Byte, input.scalar_type(), "upsample_nearest2d_nhwc_out_frame", [&] {
       const scalar_t* idata = input.const_data_ptr<scalar_t>();
       scalar_t* odata = output.mutable_data_ptr<scalar_t>();
-      upsample_nearest2d_nhwc_out_frame<scalar_t, nn_compute_source_index_fn>
-        <<<ceil_div(num_kernels, num_threads), num_threads, 0, at::cuda::getCurrentCUDAStream()>>>(
-          idata,
-          odata,
-          channels,
-          input_height,
-          input_width,
-          output_height,
-          output_width,
-          height_scale,
-          width_scale,
-          output.numel()
-      );
+      auto launch = [&](auto kgrid_stride) {
+        constexpr bool kGridStride = decltype(kgrid_stride)::value;
+        upsample_nearest2d_nhwc_out_frame<scalar_t, nn_compute_source_index_fn, kGridStride>
+          <<<launch_grid, num_threads, 0, at::cuda::getCurrentCUDAStream()>>>(
+            idata,
+            odata,
+            channels,
+            input_height,
+            input_width,
+            output_height,
+            output_width,
+            height_scale,
+            width_scale,
+            output.numel());
+      };
+      if (use_grid_stride) {
+        launch(std::true_type{});
+      } else {
+        launch(std::false_type{});
+      }
       C10_CUDA_KERNEL_LAUNCH_CHECK();
     });
   }
+  // ==============================================
+  // PATH 2: Contiguous (NCHW) layout -- 3D grid
+  // ==============================================
   else {
     // This is needed for non-contiguous tensors.
     Tensor output_c = output.is_contiguous() ? output : at::empty(output.sizes(), output.options());
@@ -292,15 +344,17 @@ static void upsample_nearest2d_out_cuda_template(
     int grid_y = ceil_div(output_height, block_y);
     int grid_z = std::min<int>(
         maxGridSize[2], ceil_div(nc, (int64_t) block_z * 4));
-    const dim3 grid(grid_x, grid_y, grid_z);
-    // Error out on cases where grid_x & grid_y exceeds limit of launch config, as
-    // the current kernel implementation doesn't loop over the two dimensions.
-    // This is unlikely to happen.
+
+    // output_height / output_width are int, so grid_x and grid_y are bounded
+    // by INT_MAX/block_dim - well below both the CUDA maxGridSize and the
+    // ROCm/HIP uint32_t per-dimension limit.  No HIP-specific clamp needed.
     // TODO: kernel implementation could stride on spatial dimension. We probably
     //       need to overhaul the kernel.
     TORCH_CHECK(
         grid_x <= maxGridSize[0] && grid_y <= maxGridSize[1],
         "input tensor has spatial dimension larger than the kernel capacity");
+
+    const dim3 grid(grid_x, grid_y, grid_z);
     cudaStream_t stream = at::cuda::getCurrentCUDAStream();
     AT_DISPATCH_FLOATING_TYPES_AND3(ScalarType::Half, ScalarType::BFloat16, ScalarType::Byte, input.scalar_type(), "upsample_nearest2d_out_frame", [&] {
           using accscalar_t = at::acc_type<scalar_t, true>;
@@ -328,6 +382,12 @@ static void upsample_nearest2d_out_cuda_template(
   }
 }
 
+// TODO(pytorch/pytorch#180310): Apply the same ROCm/HIP grid clamp to the
+// backward path.  The backward NHWC launch is bounded by
+// TORCH_CHECK(grad_input.numel() < INT_MAX), so its grid stays under 2^32.
+// The backward contiguous (NCHW) launch derives `n = grad_input.numel() /
+// nbatch`, which can exceed UINT32_MAX / bdim.x and therefore still needs a
+// host-side clamp + grid-stride fallback for completeness.
 template<nn_bw_compute_source_index_fn_t nn_bw_compute_source_index_fn>
 static void upsample_nearest2d_backward_out_cuda_template(
     const Tensor& grad_input,

--- a/aten/src/ATen/native/cuda/int4mm.cu
+++ b/aten/src/ATen/native/cuda/int4mm.cu
@@ -144,6 +144,10 @@ static bool isCDNA2orLater(int index) {
     return at::detail::getCUDAHooks().isGPUArch({"gfx90a", "gfx942", "gfx950"}, index);
 }
 
+static bool isCDNA5orLater(int index) {
+  return at::detail::getCUDAHooks().isGPUArch({"gfx1250"}, index);
+}
+
 #else
 constexpr int32_t kWarpSize = 32;
 #endif
@@ -1105,6 +1109,11 @@ at::Tensor _weight_int4pack_mm_cuda(
       A.device() == B.device() && A.device() == qScaleAndZeros.device());
 
 #if defined(USE_ROCM)
+  if (isCDNA5orLater(A.device().index())) {
+    TORCH_CHECK(false,
+                "_weight_int4pack_mm_cuda is not yet supported on gfx1250. "
+                "A WMMA-based implementation is required for gfx1250.");
+  }
   if (!isCDNA2orLater(A.device().index())) {
     TORCH_CHECK(false, "_weight_int4pack_mm_cuda is only supported on AMD gpu arch greater than or equal to CDNA2");
   }
@@ -1299,6 +1308,11 @@ at::Tensor _convert_weight_to_int4pack_cuda(
   TORCH_CHECK(innerKTiles == 2 || innerKTiles == 4 || innerKTiles == 8);
 
 #if defined(USE_ROCM)
+  if (isCDNA5orLater(in.device().index())) {
+    TORCH_CHECK(false,
+                "_convert_weight_to_int4pack_cuda is not yet supported on gfx1250. "
+                "A WMMA-based implementation is required for gfx1250.");
+  }
   if (!isCDNA2orLater(in.device().index())) {
     TORCH_CHECK(false, "_convert_weight_to_int4pack_cuda is only supported on AMD gpu arch greater than or equal to CDNA2");
   }

--- a/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
+++ b/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
@@ -2,6 +2,9 @@
 #include <unordered_map>
 #include <mutex>
 #include <string_view>
+#include <unordered_map>
+#include <vector>
+#include <c10/util/StringUtil.h>
 #if AT_CUSPARSELT_ENABLED()
 
 namespace at::native {
@@ -22,37 +25,51 @@ thread_local bool handle_initialized = false;
 c10::once_flag g_hipSparseLtSupportInitFlag;
 static bool g_hipSparseLtSupported = false;
 
+static const std::vector<std::string>& hipSparseLtSupportedArchs() {
+#if ROCM_VERSION >= 71400
+  static const std::vector<std::string> archs = {"gfx950", "gfx942", "gfx1250"};
+#elif ROCM_VERSION >= 71200
+  static const std::vector<std::string> archs = {"gfx950", "gfx942"};
+#else
+  static const std::vector<std::string> archs = {};
+#endif
+  return archs;
+}
+
 // Initialize the hipSparseLt support status once for the platform
 static void initHipSparseLtSupport() {
-    // Default to not supported
-    g_hipSparseLtSupported = false;
+  // Default to not supported
+  g_hipSparseLtSupported = false;
 
-    // Check only the first available device
-    try {
-        if (at::cuda::device_count() > 0) {
-            g_hipSparseLtSupported = at::detail::getCUDAHooks().isGPUArch({"gfx950", "gfx942"}, 0);
-        }
-    } catch (const std::exception&) {
-        // If an exception occurs during device property check, we assume hipSparseLt is not supported
-        // This could happen due to driver issues, device access problems, or other runtime errors
-        g_hipSparseLtSupported = false;
-        TORCH_WARN("Exception occurred while checking hipSparseLt support. Assuming not supported.");
+  // Check only the first available device
+  try {
+    if (at::cuda::device_count() > 0) {
+      g_hipSparseLtSupported = at::detail::getCUDAHooks().isGPUArch(
+          hipSparseLtSupportedArchs(), 0);
     }
+  } catch (const std::exception&) {
+    // If an exception occurs during device property check, we assume
+    // hipSparseLt is not supported This could happen due to driver issues,
+    // device access problems, or other runtime errors
+     g_hipSparseLtSupported = false;
+    TORCH_WARN(
+        "Exception occurred while checking hipSparseLt support. Assuming not supported.");
+  }
 }
 
 static bool isHipSparseLtSupported() {
     // Initialize support check only once
     c10::call_once(g_hipSparseLtSupportInitFlag, initHipSparseLtSupport);
 
-    // Return cached result (platform-wide)
-    if (!g_hipSparseLtSupported) {
-        TORCH_CHECK(
-            false,
-            "hipSparseLt not supported on this device, supported architectures: "
-            "gfx950, gfx942. "
-            "required ROCM version: 6.4.0 or later.");
-    }
-    return g_hipSparseLtSupported;
+  // Return cached result (platform-wide)
+  if (!g_hipSparseLtSupported) {
+    TORCH_CHECK(
+        false,
+        "hipSparseLt not supported on this device. Supported architectures: ",
+        c10::Join(", ", hipSparseLtSupportedArchs()),
+        ". hipSparseLt on ROCm requires ROCm 7.12 or newer.");
+  }
+  return g_hipSparseLtSupported;
 }
 #endif
 

--- a/c10/cuda/CUDAFunctions.h
+++ b/c10/cuda/CUDAFunctions.h
@@ -91,8 +91,9 @@ C10_CUDA_API void __inline__ memcpy_and_sync(
         c10::kCUDA, reinterpret_cast<uintptr_t>(stream));
   }
 #if defined(USE_ROCM) && USE_ROCM
-  // As of ROCm 6.4.1, HIP runtime does not raise an error during capture of
-  // hipMemcpyWithStream which is a synchronous call. Thus, we add a check
+#if ROCM_VERSION < 71400
+  // As of ROCm 6.4.1-7.13.x, HIP runtime does not raise an error during capture
+  // of hipMemcpyWithStream which is a synchronous call. Thus, we add a check
   // here explicitly.
   hipStreamCaptureStatus captureStatus;
   C10_CUDA_CHECK(hipStreamGetCaptureInfo(stream, &captureStatus, nullptr));
@@ -101,6 +102,11 @@ C10_CUDA_API void __inline__ memcpy_and_sync(
   } else {
     C10_CUDA_CHECK(hipErrorStreamCaptureUnsupported);
   }
+#else // ROCM_VERSION
+  // HIP reports the errors during graph capture in ROCm 7.14+
+  // no StreamCaptureStatus check required
+  C10_CUDA_CHECK(hipMemcpyWithStream(dst, src, nbytes, kind, stream));
+#endif // ROCM_VERSION
 #else
   C10_CUDA_CHECK(cudaMemcpyAsync(dst, src, nbytes, kind, stream));
   C10_CUDA_CHECK(cudaStreamSynchronize(stream));

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1854,6 +1854,10 @@ if(USE_ROCM)
     target_link_libraries(torch_hip PRIVATE ck_sdpa)
   endif()
 
+  if(TARGET ck_gemm)
+    target_link_libraries(torch_hip PRIVATE ck_gemm)
+  endif()
+
   if(USE_MSLK)
     if(USE_ROCM)
       target_link_libraries(torch_hip PRIVATE mslk)

--- a/cmake/External/aotriton.cmake
+++ b/cmake/External/aotriton.cmake
@@ -9,29 +9,35 @@ if(NOT __AOTRITON_INCLUDED)
   # Replaces .ci/docker/aotriton_version.txt
   # Note packages information may have versions skipped (due to no ABI breaks)
   # But they must be listed from lower version to higher version
-  set(__AOTRITON_VER "0.12b")
+  set(__AOTRITON_VER "0.13b")
   set(__AOTRITON_MANYLINUX_LIST
       "manylinux_2_28"  # rocm6.4
       "manylinux_2_28"  # rocm7.0
       "manylinux_2_28"  # rocm7.1
       "manylinux_2_28"  # rocm7.2
+      "manylinux_2_28"  # rocm7.14
+      "manylinux_2_28"  # rocm7.15
       )
   set(__AOTRITON_ROCM_LIST
       "rocm6.4"
       "rocm7.0"
       "rocm7.1"
       "rocm7.2"
+      "rocm7.14"
+      "rocm7.15"
       )
   if(DEFINED ENV{PYTORCH_AOTRITON_COMMIT})
     set(__AOTRITON_CI_COMMIT "$ENV{PYTORCH_AOTRITON_COMMIT}")
   else()
-    set(__AOTRITON_CI_COMMIT "269036897bcee4292f4e928767df1e3dd0e3c8bd")
+    set(__AOTRITON_CI_COMMIT "6e00ef3e335b45dfb49065259533b59c68995bfe")
   endif()
   set(__AOTRITON_SHA256_LIST
-      "e57ad080bd87fdaf7fe5bbff49ab80222be3bc8eb56a197d5781bfae8c116c33"  # rocm6.4
-      "f6aba1fe59312004ccd13dfda4d0a9e35457527fec18348d2e75a294a1051ef5"  # rocm7.0
-      "a1d731745929b61598d088eeaad31d8a82a27032aa51e3a7c831e45a99e095c2"  # rocm7.1
-      "5b97e8d041b160c84085961f3d3bd7b9890642b146bacb04c991aa9ad6a8dca8"  # rocm7.2
+      "2fafa80953d9a49bd20e794bb8c0e1646e8aa815be2fb161deaa849a47547b17"  # rocm6.4
+      "7409f7c974cc79be731a419818bdb2ed6b8a3640fd40665baa76ec3c2a537204"  # rocm7.0
+      "f061a997679d8529a7b196b0ffb39912145ede217e515e1ee9ef5673b56d9e41"  # rocm7.1
+      "1cdeebb7ef61ab691fba1d81da919b9db5d8bef28269c892a30bd13a0495b7a0"  # rocm7.2
+      "7a139797c16b002fd5d9bcd706d36dc9819bb108877150f8186da21d0590eaa6"  # rocm7.14
+      "f024225d8b6063f7d95974e5957cb20893a1579a9a73b22b60426441331bc021"  # rocm7.15
       )
   set(__AOTRITON_IMAGE_LIST
       "amd-gfx90a"
@@ -40,14 +46,16 @@ if(NOT __AOTRITON_INCLUDED)
       "amd-gfx110x"
       "amd-gfx115x"
       "amd-gfx120x"
+      "amd-gfx1250"
      )
   set(__AOTRITON_IMAGE_SHA256_LIST
-     "bb8bf2237b77fc503bc2967ea0d99d6ca419126c479e951ea42b712737128086" # amd-gfx90a
-     "f08edacf83c9ccf1c4bdcb51f1cab052d1680abea31c9e035f3f9fadb2f13ba4" # amd-gfx942
-     "307a37d729cda3a2120449909e5192cd71c2badccbd37f0222786098e69c7a91" # amd-gfx950
-     "c9cac7cf6f277168e1659ac2f04706f8823580b7c7e3e895f5a5503ed6bdd55f" # amd-gfx110x
-     "3177387a15c678b30057f4584d1fc1b8f8db56163890cb5c98f27450209f5a7b" # amd-gfx115x
-     "68572511ce6487a83f9014bd255bd69c8943f87d0c93bd57b2daac5fbc6c79c1" # amd-gfx120x
+     "a3d1a6868ce290ba8118618207093e785252eff4e18a64f495752cb5a03ffed6" # amd-gfx90a
+     "ccdbc7e3d96839be4895ee004f21531cc55d590c9018937b9e314bba363b3927" # amd-gfx942
+     "518fd072eb05948fc0a6c25a20832591c6406df865e3b691a2aeff3fd4c5ce1d" # amd-gfx950
+     "efe773e7a2c8adc995d90ecd0daca2db801285445ee10432df2b29c67d5b11d2" # amd-gfx110x
+     "1bc50e8aa8b6bda3410e92886ccca8fd45df3e60a6cbda9ffc58b2c541efd5c2" # amd-gfx115x
+     "6a465dbc03148bba8a2d78c4c2a3cb83155eca00f4f7f749e676402d7660968c" # amd-gfx120x
+     "4aaf71d6e510549d593757e5f88598df1e4a29cbcd91f70750ee8a76f65c027f" # amd-gfx1250
      )
   set(__AOTRITON_BASE_URL "$ENV{PYTORCH_AOTRITON_BASE_URL}")
   if(NOT __AOTRITON_BASE_URL)

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -46,6 +46,7 @@ from torch.testing import FileCheck
 from torch.testing._internal import common_utils
 from torch.testing._internal.common_cuda import (
     CDNA2OrLater,
+    CDNA5OrLater,
     PLATFORM_SUPPORTS_FLASH_ATTENTION,
     PLATFORM_SUPPORTS_FP8,
     PLATFORM_SUPPORTS_FP8_GROUPED_GEMM,
@@ -7700,6 +7701,8 @@ class AOTInductorTestsTemplate:
             raise unittest.SkipTest("requires GPU")
 
         if TEST_WITH_ROCM:
+            if CDNA5OrLater():
+                self.skipTest("int4 mm not yet implemented for gfx1250 (needs WMMA)")
             if not CDNA2OrLater():
                 self.skipTest("_int4_mm is supported only for CDNA2 or later")
 
@@ -7737,6 +7740,8 @@ class AOTInductorTestsTemplate:
             raise unittest.SkipTest("requires Intel GPU")
 
         if TEST_WITH_ROCM:
+            if CDNA5OrLater():
+                self.skipTest("int4 mm not yet implemented for gfx1250 (needs WMMA)")
             if not CDNA2OrLater():
                 self.skipTest("_int4_mm is supported only for CDNA2 or later")
 

--- a/test/inductor/test_autoheuristic.py
+++ b/test/inductor/test_autoheuristic.py
@@ -10,7 +10,7 @@ from torch._inductor.autoheuristic.autoheuristic_utils import AHContext
 from torch._inductor.runtime.runtime_utils import cache_dir
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import get_gpu_shared_memory
-from torch.testing._internal.common_utils import skipIfXpu
+from torch.testing._internal.common_utils import skipIfRocm, skipIfXpu
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU, IS_A100, IS_H100
 
 
@@ -69,6 +69,7 @@ class AutoHeuristicTest(TestCase):
         # this test ensures that data is collected for pad_mm when autoheuristic_collect.pad_mm=True
         self.assert_autoheuristic_collected_data()
 
+    @skipIfRocm(msg="AutoHeuristic doesn't currently work on the ROCm stack")
     @skipIfXpu(msg="AutoHeuristic doesn't currently work on the XPU stack")
     @patch.dict(os.environ, {"TORCHINDUCTOR_AUTOHEURISTIC_COLLECT": "test"})
     def test_autoheuristic(self):

--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -189,7 +189,18 @@ class TestMaxAutotune(TestCase):
         Verify that `max_autotune` includes all pointwise configs from
         `max_autotune_pointwise` for 1D, 2D, and 3D pointwise kernels.
         """
-        triton_meta = {"device": DeviceProperties.create(torch.device(GPU_TYPE, 0))}
+        # Fake device properties for this unit test; no CUDA state is needed.
+        triton_meta = {
+            "device": DeviceProperties(
+                type="cuda",
+                index=0,
+                multi_processor_count=1,
+                cc=80,
+                major=8,
+                max_threads_per_block=1024,
+                warp_size=32,
+            )
+        }
         inductor_meta_common = {"autotune_pointwise": False}
 
         for size_hints in (

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -2326,13 +2326,15 @@ class CommonTemplate:
         triton reduction configs for large size hints. #128826 introduced a scaling XBLOCK
         feature to resolve the issue in reduction configs which may exceed the maxGridSize
         """
+        from torch._inductor.runtime.hints import get_warp_size
         from torch._inductor.runtime.runtime_utils import next_power_of_2
         from torch._inductor.runtime.triton_heuristics import triton_config_reduction
 
+        warp_size = get_warp_size(torch.device(self.device))
         size_hints = {"x": 67108864, "r0_": 8192}
         for _ in range(4):
             size_hints["x"] = next_power_of_2(size_hints["x"])
-            triton_config_reduction(size_hints, 1, 2048, 1, 8)
+            triton_config_reduction(size_hints, 1, 2048, 1, 8, warp_size=warp_size)
 
     def test_prod(self):
         def fn(a):

--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -1116,7 +1116,7 @@ class TestFastLauncherDeviceSupport(TestCase):
         return CachingAutotuner(
             fn=triton_,
             triton_meta=triton_meta,
-            configs=[triton_config({"x": 1}, 1)],
+            configs=[triton_config({"x": 1}, 1, warp_size=device.warp_size_or_default)],
             save_cache_hook=False,
             mutated_arg_names=[],
             reset_to_zero_arg_names=[],
@@ -1427,7 +1427,15 @@ class TestWarpSizeUnification(TestCase):
         none_props = DeviceProperties(
             type="cuda", index=0, multi_processor_count=80, cc=80, warp_size=None
         )
-        self.assertEqual(none_props.warp_size_or_default, 32)
+        with self.assertRaisesRegex(
+            RuntimeError, "cuda device properties must report warp_size"
+        ):
+            none_props.warp_size_or_default
+
+        cpu_props = DeviceProperties(
+            type="cpu", index=0, multi_processor_count=80, cc=80, warp_size=None
+        )
+        self.assertEqual(cpu_props.warp_size_or_default, 32)
 
         w32 = DeviceProperties(
             type="cuda", index=0, multi_processor_count=80, cc=80, warp_size=32

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -919,7 +919,7 @@ print(t.is_pinned())
             gcn_arch = str(
                 torch.cuda.get_device_properties(0).gcnArchName.split(":", 1)[0]
             )
-            if "gfx94" in gcn_arch or "gfx95" in gcn_arch:
+            if gcn_arch in ["gfx942", "gfx950", "gfx1250"]:
                 default_workspace_size = 1024 * 128 * 1024  # :1024:128
         else:
             default_workspace_size = (
@@ -9716,9 +9716,13 @@ class TestCompileKernel(TestCase):
 
         # Test error handling with more than supported shared memory size
         if torch.version.hip:
-            max_smem = (
-                65536 if get_device_properties().gcnArchName != "gfx950" else 160 * 1024
-            )
+            gcn_arch = get_device_properties().gcnArchName.split(":", 1)[0]
+            if gcn_arch == "gfx1250":
+                max_smem = 320 * 1024
+            elif gcn_arch == "gfx950":
+                max_smem = 160 * 1024
+            else:
+                max_smem = 65536
         else:
             max_smem = get_device_properties().shared_memory_per_block_optin
         excessive_shared_mem = max_smem * 2

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -4163,7 +4163,6 @@ exit(2)
             model_graphed({"x": real_inputs[0]}), model_control({"x": real_inputs[0]})
         )
 
-    @skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/179961")
     @unittest.skipIf(
         not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
     )

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -4839,6 +4839,7 @@ print(f"{{r1}}, {{r2}}")
     @unittest.skipIf(
         IS_WINDOWS, "test relies on fork; Windows multiprocessing uses spawn"
     )
+    @unittest.skipIf(sys.version_info >= (3, 14), "test fails on Python 3.14+")
     def test_is_pinned_no_context(self):
         test_script = """\
 import torch

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -2797,7 +2797,7 @@ torch.cuda.synchronize()
             # Compare the states generated outside and inside the graph
             self.assertEqual(random_values, graphed_random_values)
 
-    @skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/180232")
+    @skipIfRocmVersionLessThan((7, 14))
     @xfailCUDAIfSM89OrLaterOnWindows
     @unittest.skipIf(
         not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -93,7 +93,7 @@ class ForeachFuncWrapper:
 
         # Skip profiler check for CUDA 12.6, 12.8 as the upgrade makes profiler results flaky
         # https://github.com/pytorch/pytorch/issues/148681. TODO: ADD IT BACK!!!
-        skip_profiler_check = _get_torch_cuda_version() in [(12, 6), (12, 8)]
+        skip_profiler_check = _get_torch_cuda_version() in [(12, 6), (12, 8)] or TEST_WITH_ROCM
         if (
             is_cuda
             and not skip_profiler_check

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -40,7 +40,7 @@ from torch.testing._internal.common_dtype import (
     all_types, all_types_and_complex_and, floating_and_complex_types, integral_types,
     floating_and_complex_types_and, floating_types_and, complex_types,
 )
-from torch.testing._internal.common_cuda import CDNA2OrLater, SM80OrLater, SM90OrLater, tf32_on_and_off, _get_magma_version, \
+from torch.testing._internal.common_cuda import CDNA2OrLater, CDNA5OrLater, SM80OrLater, SM90OrLater, tf32_on_and_off, _get_magma_version, \
     _get_torch_cuda_version, TEST_MULTIGPU, PLATFORM_SUPPORTS_FP8, blas_library_context, ROCM_VERSION
 from torch.testing._internal.common_quantization import _group_quantize_tensor, _dynamically_quantize_per_channel, \
     _group_quantize_tensor_symmetric
@@ -72,6 +72,8 @@ def blaslt_supported_device():
                 archs.extend(['gfx110', 'gfx120'])
             if ROCM_VERSION >= (6, 5):
                 archs.append('gfx95')
+            if ROCM_VERSION >= (7, 14):
+                archs.append('gfx1250')
             for arch in archs:
                 if arch in torch.cuda.get_device_properties(0).gcnArchName:
                     return True
@@ -6607,6 +6609,9 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
         if self.device_type == 'cuda' and not SM80OrLater:
             self.skipTest("requires SM80 or later")
 
+        if TEST_WITH_ROCM and self.device_type == 'cuda' and CDNA5OrLater():
+            self.skipTest("int4 mm not yet implemented for gfx1250 (needs WMMA)")
+
         if TEST_WITH_ROCM and self.device_type == 'cuda' and not CDNA2OrLater():
             self.skipTest("_convert_weight_to_int4pack_cuda is supported only for CDNA2 or later")
 
@@ -6675,6 +6680,9 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
     def test_compile_int4_mm(self, device, m, k, n):
         if self.device_type == 'cuda' and not SM80OrLater:
             self.skipTest("requires SM80 or later")
+
+        if TEST_WITH_ROCM and self.device_type == 'cuda' and CDNA5OrLater():
+            self.skipTest("int4 mm not yet implemented for gfx1250 (needs WMMA)")
 
         if TEST_WITH_ROCM and self.device_type == 'cuda' and not CDNA2OrLater():
             self.skipTest("_convert_weight_to_int4pack_cuda supported only for CDNA2 or later")

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -13306,7 +13306,9 @@ if __name__ == '__main__':
         # CUDA says "device-side assert triggered"
         # ROCm says "unspecified launch failure", or HSA_STATUS_ERROR_EXCEPTION
         has_cuda_assert = 'CUDA error: device-side assert triggered' in stderr
-        has_hip_assert = 'launch failure' in stderr or 'HSA_STATUS_ERROR_EXCEPTION' in stderr
+        has_hip_assert = ('launch failure' in stderr
+                          or 'HSA_STATUS_ERROR_EXCEPTION' in stderr
+                          or 'illegal memory access' in stderr)
         self.assertTrue(has_cuda_assert or has_hip_assert,
                         f"Expected device assert error in stderr, got: {stderr}")
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -47,7 +47,7 @@ from torch.testing._internal.common_nn import NNTestCase, NewModuleTest, Criteri
     ctcloss_reference, get_new_module_tests, single_batch_reference_fn, _test_bfloat16_ops, _test_module_empty_input
 from torch.testing._internal.common_device_type import dtypesIfMPS, instantiate_device_type_tests, dtypes, \
     dtypesIfCUDA, precisionOverride, onlyCUDA, onlyCPU, \
-    skipCUDAIfRocm, skipCUDAIf, skipMPSIf, \
+    skipCUDAIfRocm, skipCUDAIf, skipMPSIf, skipCUDAIfNotRocm, \
     onlyNativeDeviceTypes, deviceCountAtLeast, largeTensorTest, expectedFailureMeta, expectedFailureMPS, \
     skipMeta, get_all_device_types
 from torch.testing._internal.common_modules import module_inputs_torch_nn_LinearCrossEntropyLoss
@@ -11389,16 +11389,19 @@ class TestNNDeviceType(NNTestCase):
             gradgradcheck(lambda x: F.interpolate(x, out_size, **kwargs), [input])
 
     @onlyCUDA
-    @skipCUDAIfRocm(msg="launch bounds error out on ROCM")
     @dtypes(torch.half, torch.bfloat16)
     @largeTensorTest('40GB')
     def test_upsampling_64bit_indexing_channels_last(self, device, dtype):
+        # Path 1 (NHWC): channels-last 1D grid. output.numel() = 2^31, below UINT32_MAX,
+        # but exercises the allclose correctness check between channels-last and contiguous.
         x = torch.rand((32, 64, 512, 512), dtype=dtype, device=device)
         out = torch.nn.functional.interpolate(x.to(memory_format=torch.channels_last), scale_factor=2, mode='nearest')
         out_ref = torch.nn.functional.interpolate(x, scale_factor=2, mode='nearest')
         del x
         self.assertTrue(torch.allclose(out, out_ref))
 
+        # Path 1 (NHWC): output.numel() = 17*256*1024*1024 ~ 4.56e9 > UINT32_MAX.
+        # Exercises the ROCm grid-stride clamp in the NHWC kernel.
         x = torch.ones((17, 256, 512, 512), dtype=dtype).cuda().to(memory_format=torch.channels_last)
         out = torch.nn.functional.interpolate(x, scale_factor=2, mode='nearest')
         self.assertEqual(out[0], out[-1])

--- a/test/test_scatter_gather_ops.py
+++ b/test/test_scatter_gather_ops.py
@@ -16,7 +16,7 @@ from torch.testing._internal.common_device_type import \
 from torch.testing._internal.common_dtype import \
     (get_all_dtypes,)
 
-from torch.testing._internal.common_cuda import CDNA3OrLater, SM90OrLater
+from torch.testing._internal.common_cuda import gfx_arch_supports_opportunistic_fastatomics, SM90OrLater
 
 # Protects against includes accidentally setting the default dtype
 if torch.get_default_dtype() is not torch.float32:
@@ -225,7 +225,7 @@ class TestScatterGather(TestCase):
         else:
             # When we are running opportunistic_fastatomics, we will expect some floating point rounding
             # errors as the order of operation is not guaranteed.
-            if TEST_WITH_ROCM and CDNA3OrLater() \
+            if TEST_WITH_ROCM and gfx_arch_supports_opportunistic_fastatomics() \
                     and not torch.are_deterministic_algorithms_enabled():
                 self.assertEqual(actual, expected, atol=1e-9, rtol=1e-6)
             else:

--- a/torch/_inductor/codegen/cuda/device_op_overrides.py
+++ b/torch/_inductor/codegen/cuda/device_op_overrides.py
@@ -56,6 +56,8 @@ class CUDADeviceOpOverrides(DeviceOpOverrides):
     def kernel_driver(self) -> str:
         """Return C++ host-side helpers (loadKernel, launchKernel, CUDA_DRIVER_CHECK)
         embedded in AOTI-generated wrapper code."""
+        # NVIDIA devices have a warp size of 32, while AMD devices can have a
+        # warp size of 32 or 64 depending on the architecture.
         source_codes = """
             #define CUDA_DRIVER_CHECK(EXPR)                    \\
             do {                                               \\
@@ -135,16 +137,16 @@ class CUDADeviceOpOverrides(DeviceOpOverrides):
                     void* args[],
                     cudaStream_t stream) {
                 CUDA_DRIVER_CHECK(cuLaunchKernel(
-                    func, gridX, gridY, gridZ, 32*numWarps, 1, 1, sharedMemBytes, stream, args, nullptr
+                    func, gridX, gridY, gridZ, __WARP_SIZE__*numWarps, 1, 1, sharedMemBytes, stream, args, nullptr
                 ));
             }
         """
-        if torch.version.hip is not None:
-            # Adjusting the warp size to GPU supported wavefront size on AMD GPU
+        if torch.version.hip is not None and torch.cuda.is_available():
             device = torch.device("cuda", torch.cuda.current_device())
             warp_size = get_warp_size(device)
-            source_codes = source_codes.replace("32*numWarps", f"{warp_size}*numWarps")
-        return source_codes
+        else:
+            warp_size = 32
+        return source_codes.replace("__WARP_SIZE__", str(warp_size))
 
     def tma_descriptor_helpers(self) -> str:
         """

--- a/torch/_inductor/runtime/hints.py
+++ b/torch/_inductor/runtime/hints.py
@@ -166,7 +166,11 @@ class DeviceProperties(typing.NamedTuple):
 
     @property
     def warp_size_or_default(self) -> int:
-        return self.warp_size if self.warp_size is not None else 32
+        if self.warp_size is not None:
+            return self.warp_size
+        if self.type in ("cuda", "hip"):
+            raise RuntimeError(f"{self.type} device properties must report warp_size")
+        return 32
 
     @classmethod
     @functools.cache
@@ -201,17 +205,17 @@ class DeviceProperties(typing.NamedTuple):
                 props, "max_threads_per_multi_processor", None
             ),
             max_threads_per_block=getattr(props, "max_threads_per_block", 1024),
-            warp_size=getattr(props, "warp_size", 32 if device_type != "cpu" else None),
+            warp_size=getattr(props, "warp_size", None),
         )
 
 
 def get_warp_size(device) -> int:
     """Return the wave/warp size in threads for the given device.
 
-    Reads from torch.cuda.get_device_properties(device).warp_size via the
-    cached DeviceProperties.create(). Correct on both AMD (64 for CDNA/gfx9,
-    32 for RDNA/gfx10+) and NVIDIA (always 32). Falls back to 32 only when
-    the field is unavailable.
+    Reads from torch.cuda.get_device_properties(device).warp_size via the cached
+    DeviceProperties.create(). Correct on both AMD (64 for CDNA/gfx9, 32 for
+    RDNA/gfx10+) and NVIDIA (always 32). Missing cuda/hip warp_size metadata is
+    treated as an error rather than silently falling back.
     """
     return DeviceProperties.create(device).warp_size_or_default
 

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -195,6 +195,13 @@ def autotune_hints_to_configs(
     configs: list[Config] = []
     for hint in hints:
         if hint == AutotuneHint.ONE_ELEMENT_PER_THREAD:
+            if device_props.warp_size is None:
+                log.debug(
+                    "Skipping %s autotune hint because device %s does not report warp_size",
+                    AutotuneHint.ONE_ELEMENT_PER_THREAD,
+                    device_props.type,
+                )
+                continue
             if len(size_hints) == 1:
                 xyz_options = ((block_size // 4, None, None),)
             elif len(size_hints) == 2:
@@ -711,6 +718,7 @@ class CachingAutotuner(KernelInterface):
             and bool(device_prop.major)
             and (device_prop.major >= 8 or torch.version.hip)
             and device_prop.regs_per_multiprocessor is not None
+            and device_prop.warp_size is not None
         )
 
     def _iter_rblock_scale_candidates(self):
@@ -721,11 +729,18 @@ class CachingAutotuner(KernelInterface):
         # TODO(jansel): we should find a way to move this extra compile into the worker process
         # Currently it relies on _make_launchers(), which requires a cuda context, to populate nreg.
         device_prop = self.device_props
-        assert device_prop.regs_per_multiprocessor
-        assert device_prop.max_threads_per_multi_processor
-        assert device_prop.multi_processor_count
+        if not device_prop.regs_per_multiprocessor:
+            raise AssertionError("device_prop.regs_per_multiprocessor is not set")
+        if not device_prop.max_threads_per_multi_processor:
+            raise AssertionError(
+                "device_prop.max_threads_per_multi_processor is not set"
+            )
+        if not device_prop.multi_processor_count:
+            raise AssertionError("device_prop.multi_processor_count is not set")
+        if device_prop.warp_size is None:
+            raise AssertionError("device_prop.warp_size is not set")
         seen_config_hashes: OrderedSet[Hashable] | None = None
-        warp_size = device_prop.warp_size_or_default
+        warp_size = device_prop.warp_size
         for result in self.compile_results:
             triton_config = result.config
             compiled_binary = result.kernel
@@ -764,14 +779,14 @@ class CachingAutotuner(KernelInterface):
             nreg_per_warp = nreg * warp_size
             nreg_per_block = nreg_per_warp * triton_config.num_warps
 
-            # Previously we set max_blocks_per_sm to 'max_threads_per_multi_processo / (32 * num_warps)'
+            # Previously we set max_blocks_per_sm to 'max_threads_per_multi_processor / (warp_size * num_warps)'
             # The formula below is a tighter upper bound since we have the assumption that
             #   nreg > device_prop.regs_per_multiprocessor // device_prop.max_threads_per_multi_processor
             # due to the if condition above and:
             #   regs_per_multiprocessor / nreg_per_block
-            #   = regs_per_multiprocessor / (nreg * 32 * num_warps)
-            #   < regs_per_multiprocessor / ((regs_per_multiprocessor / max_threads_per_multi_processor) * 32 * num_warps)
-            #   = max_threads_per_multi_processor / (32 * num_warps)
+            #   = regs_per_multiprocessor / (nreg * warp_size * num_warps)
+            #   < regs_per_multiprocessor / ((regs_per_multiprocessor / max_threads_per_multi_processor) * warp_size * num_warps)
+            #   = max_threads_per_multi_processor / (warp_size * num_warps)
             # Using a tighter upper bound can reveal more optimization opportunities.
             max_blocks_per_sm = max(
                 device_prop.regs_per_multiprocessor // nreg_per_block, 1

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -3715,11 +3715,13 @@ def _occupancy_before_and_after_fusion(
 
     # # Need device info to calculate occupancy
     regs_per_sm = device_props.regs_per_multiprocessor
-    if regs_per_sm is None:
+    warp_size = device_props.warp_size
+    if regs_per_sm is None or warp_size is None:
         return 1, 1  # Can't calculate, allow fusion
 
-    assert num_warps
-    threads_per_block = num_warps * device_props.warp_size_or_default
+    if not num_warps:
+        raise AssertionError("expected num_warps to be truthy")
+    threads_per_block = num_warps * warp_size
 
     regs_per_block_unfused = unfused_n_regs * threads_per_block
     regs_per_block_fused = fused_n_regs * threads_per_block

--- a/torch/_inductor/template_heuristics/triton.py
+++ b/torch/_inductor/template_heuristics/triton.py
@@ -1074,11 +1074,22 @@ class BaseConfigHeuristic(metaclass=BaseHeuristicSingleton):
         self,
         configs: list[BaseConfig],
     ) -> list[BaseConfig]:
+        try:
+            device = torch.cuda.current_device()
+            props = torch.cuda.get_device_properties(device)
+            warp_size = props.warp_size
+        except (RuntimeError, AttributeError, AssertionError):
+            return configs
+
         pruned_configs = []
+        # NVIDIA-oriented approximation for the per-thread register limit.
+        # TODO: generalize this threshold for ROCm devices.
+        NUM_REG = 255
         for gemm_config in configs:
-            NUM_REG = 255
             acc_regs = math.ceil(
-                gemm_config.block_m * gemm_config.block_n / (gemm_config.num_warps * 32)
+                gemm_config.block_m
+                * gemm_config.block_n
+                / (gemm_config.num_warps * warp_size)
             )
             # Lower bound for register spillage, if exceeds the kernel will certainly spill
             if acc_regs > NUM_REG:

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -3199,12 +3199,12 @@ def get_max_numwarps() -> int:
         props = DeviceProperties.create(device)
         warp_size = props.warp_size_or_default
         max_threads_per_block = props.max_threads_per_block
-        assert max_threads_per_block is not None
-    else:
-        # Defaults
-        warp_size = 32
-        max_threads_per_block = 1024
-    return max_threads_per_block // warp_size
+        if max_threads_per_block is None:
+            raise AssertionError("expected max_threads_per_block to be set")
+        return max_threads_per_block // warp_size
+
+    log.debug("CUDA is not available; defaulting max num warps to 32")
+    return 32
 
 
 def is_welford_reduction(reduction_type: str) -> bool:

--- a/torch/csrc/distributed/c10d/symm_mem/nccl_dev_cap.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/nccl_dev_cap.hpp
@@ -16,7 +16,8 @@
 #endif
 #endif
 
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 29, 0)
+#if defined(NCCL_HAS_SYMMEM_DEVICE_SUPPORT) && \
+    NCCL_VERSION_CODE >= NCCL_VERSION(2, 29, 0)
 #define NCCL_HAS_ONE_SIDED_API
 #endif
 

--- a/torch/cuda/_utils.py
+++ b/torch/cuda/_utils.py
@@ -475,11 +475,15 @@ class _CudaKernel:
         device_props = torch.cuda.get_device_properties()
         # HIP doesn't have shared_memory_per_block_optin in device properties, so we hard-code it here
         if torch.version.hip:
-            # navi, CDNA1-CDNA3 allows a max of 64KB shared memory
-            # CDNA4 allows a max of 160KB shared memory
-            max_shared_mem = (
-                65536 if device_props.gcnArchName != "gfx950" else 160 * 1024
-            )
+            # navi, CDNA1-CDNA3 allows a max of 64KB shared memory,
+            # CDNA4 (gfx950) 160KB, and CDNA5 (gfx1250) 320KB.
+            gcn_arch = device_props.gcnArchName.split(":", 1)[0]
+            if gcn_arch == "gfx950":
+                max_shared_mem = 160 * 1024
+            elif gcn_arch == "gfx1250":
+                max_shared_mem = 320 * 1024
+            else:
+                max_shared_mem = 65536
         else:
             max_shared_mem = getattr(
                 device_props, "shared_memory_per_block_optin", 49152

--- a/torch/cuda/graphs.py
+++ b/torch/cuda/graphs.py
@@ -644,7 +644,10 @@ def make_graphed_callables(
     # Hopefully prevents cudnn benchmarking and other lazy-initialization cuda work
     # from ending up in any captures.
     torch.cuda.synchronize()
-    with torch.cuda.stream(torch.cuda.Stream()):
+    # hipBLASLt handles are per-(device, stream) on ROCm and lazily created.
+    # Need to use the same stream for warmup and capture to avoid capture errors.
+    stream = torch.cuda.Stream()
+    with torch.cuda.stream(stream):
         for func, args, static_input_surface in zip(
             callables, _sample_args, per_callable_static_input_surfaces
         ):
@@ -677,7 +680,7 @@ def make_graphed_callables(
     per_callable_static_outputs = []
     per_callable_output_unflatten_spec = []
     for func, args, fwd_graph in zip(callables, _sample_args, fwd_graphs):
-        with torch.cuda.graph(fwd_graph, pool=mempool):
+        with torch.cuda.graph(fwd_graph, stream=stream, pool=mempool):
             func_outputs = func(*args)
 
         flatten_outputs, spec = torch.utils._pytree.tree_flatten(func_outputs)
@@ -701,7 +704,7 @@ def make_graphed_callables(
         outputs_grad = tuple(o for o in static_outputs if o.requires_grad)
         grad_inputs = None
         if len(outputs_grad) > 0:
-            with torch.cuda.graph(bwd_graph, pool=mempool):
+            with torch.cuda.graph(bwd_graph, stream=stream, pool=mempool):
                 grad_inputs = torch.autograd.grad(
                     outputs=outputs_grad,
                     inputs=tuple(i for i in static_input_surface if i.requires_grad),

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -64,14 +64,38 @@ def evaluate_gfx_arch_within(arch_list):
     # Hence the matching should be done reversely
     return any(arch in effective_arch for arch in arch_list)
 
+# Per-generation gfx targets, ordered oldest -> newest. Each "OrLater" helper
+# below unions its own generation with every newer one, so the predicates are
+# nested by construction: CDNA5OrLater => CDNA3OrLater => CDNA2OrLater.
+_CDNA2_ARCHS = ["gfx90a"]
+_CDNA3_ARCHS = ["gfx942", "gfx950"]
+# GFX1250 (CDNA 5)
+_CDNA5_ARCHS = ["gfx1250"]
+
+def CDNA5OrLater():
+    return evaluate_gfx_arch_within(_CDNA5_ARCHS)
+
 def CDNA3OrLater():
-    return evaluate_gfx_arch_within(["gfx942", "gfx950"])
+    return evaluate_gfx_arch_within(_CDNA3_ARCHS + _CDNA5_ARCHS)
 
 def CDNA2OrLater():
-    return evaluate_gfx_arch_within(["gfx90a", "gfx942", "gfx950"])
+    return evaluate_gfx_arch_within(_CDNA2_ARCHS + _CDNA3_ARCHS + _CDNA5_ARCHS)
+
+# Archs that take the opportunistic_fastAtomicAdd path (packed 2x16 atomics + DPP
+# lane coalescing) in ScatterGatherKernel.cu. Keep in sync with that kernel's arch
+# gate; this is intentionally not CDNA3OrLater (gfx1250 uses plain fastAtomicAdd).
+def gfx_arch_supports_opportunistic_fastatomics():
+    return evaluate_gfx_arch_within(["gfx942", "gfx950"])
 
 def evaluate_platform_supports_flash_attention():
     if TEST_WITH_ROCM:
+        # NOTE: gfx1250 is omitted until flash-attention artifacts ship for it.
+        # The AOTriton path needs the gfx1250 GPU image from AOTriton 0.12.1b,
+        # which is wired up by PR #188242 (which also adds gfx1250 to this list);
+        # this gate-only PR leaves it out so the two changes do not conflict
+        # (see cmake/External/aotriton.cmake). The CK FAv3/AITER codegen is
+        # separately not yet wired for gfx1250
+        # (see aten/src/ATen/native/transformers/hip/flash_attn/ck/fav_v3/CMakeLists.txt).
         arch_list = ["gfx90a", "gfx942", "gfx1100", "gfx1201", "gfx950"]
         if os.environ.get("TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL", "0") != "0":
             arch_list += ["gfx1101", "gfx1102", "gfx1150", "gfx1151", "gfx1200"]
@@ -90,6 +114,11 @@ def evaluate_platform_supports_ck_sdpa():
 
 def evaluate_platform_supports_efficient_attention():
     if TEST_WITH_ROCM:
+        # NOTE: gfx1250 is omitted until mem-efficient-attention artifacts ship
+        # for it. The AOTriton gfx1250 image (from AOTriton 0.12.1b) is wired up
+        # by PR #188242, which also adds gfx1250 here; this gate-only PR leaves
+        # it out to avoid conflicting with that change. The CK FAv3/AITER codegen
+        # is separately not yet wired for gfx1250.
         arch_list = ["gfx90a", "gfx942", "gfx1100", "gfx1201", "gfx950"]
         if os.environ.get("TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL", "0") != "0":
             arch_list += ["gfx1101", "gfx1102", "gfx1150", "gfx1151", "gfx1200"]
@@ -176,6 +205,8 @@ def evaluate_platform_supports_fp8():
                 archs.extend(['gfx120'])
             if ROCM_VERSION >= (6, 5):
                 archs.append('gfx95')
+            if ROCM_VERSION >= (7, 14):
+                archs.append('gfx1250')
             for arch in archs:
                 if arch in torch.cuda.get_device_properties(0).gcnArchName:
                     return True
@@ -192,6 +223,8 @@ def evaluate_platform_supports_fp8_grouped_gemm():
         if torch.version.hip:
             if "USE_MSLK" not in torch.__config__.show():
                 return False
+            # gfx1250 omitted: MSLK only builds gfx942/gfx950 kernels (see the arch
+            # filter in aten/src/ATen/CMakeLists.txt). Add gfx1250 here once MSLK does.
             archs = ['gfx942', 'gfx950']
             for arch in archs:
                 if arch in torch.cuda.get_device_properties(0).gcnArchName:
@@ -204,7 +237,8 @@ def evaluate_platform_supports_mx_gemm():
     if torch.cuda.is_available():
         if torch.version.hip:
             if ROCM_VERSION >= (7, 0):
-                return 'gfx950' in torch.cuda.get_device_properties(0).gcnArchName
+                gcn_name = torch.cuda.get_device_properties(0).gcnArchName
+                return 'gfx950' in gcn_name or ('gfx1250' in gcn_name and ROCM_VERSION >= (7, 14))
         else:
             return SM100OrLater
     return False

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -89,14 +89,7 @@ def gfx_arch_supports_opportunistic_fastatomics():
 
 def evaluate_platform_supports_flash_attention():
     if TEST_WITH_ROCM:
-        # NOTE: gfx1250 is omitted until flash-attention artifacts ship for it.
-        # The AOTriton path needs the gfx1250 GPU image from AOTriton 0.12.1b,
-        # which is wired up by PR #188242 (which also adds gfx1250 to this list);
-        # this gate-only PR leaves it out so the two changes do not conflict
-        # (see cmake/External/aotriton.cmake). The CK FAv3/AITER codegen is
-        # separately not yet wired for gfx1250
-        # (see aten/src/ATen/native/transformers/hip/flash_attn/ck/fav_v3/CMakeLists.txt).
-        arch_list = ["gfx90a", "gfx942", "gfx1100", "gfx1201", "gfx950"]
+        arch_list = ["gfx90a", "gfx942", "gfx1100", "gfx1201", "gfx950", "gfx1250"]
         if os.environ.get("TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL", "0") != "0":
             arch_list += ["gfx1101", "gfx1102", "gfx1150", "gfx1151", "gfx1200"]
         return evaluate_gfx_arch_within(arch_list)
@@ -114,12 +107,7 @@ def evaluate_platform_supports_ck_sdpa():
 
 def evaluate_platform_supports_efficient_attention():
     if TEST_WITH_ROCM:
-        # NOTE: gfx1250 is omitted until mem-efficient-attention artifacts ship
-        # for it. The AOTriton gfx1250 image (from AOTriton 0.12.1b) is wired up
-        # by PR #188242, which also adds gfx1250 here; this gate-only PR leaves
-        # it out to avoid conflicting with that change. The CK FAv3/AITER codegen
-        # is separately not yet wired for gfx1250.
-        arch_list = ["gfx90a", "gfx942", "gfx1100", "gfx1201", "gfx950"]
+        arch_list = ["gfx90a", "gfx942", "gfx1100", "gfx1201", "gfx950", "gfx1250"]
         if os.environ.get("TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL", "0") != "0":
             arch_list += ["gfx1101", "gfx1102", "gfx1150", "gfx1151", "gfx1200"]
         return evaluate_gfx_arch_within(arch_list)


### PR DESCRIPTION
Commits List Sheet : [pr3465-commit-outcomes_2.xlsx](https://github.com/user-attachments/files/30474277/pr3465-commit-outcomes_2.xlsx)


## Summary

IFU (integrate-from-upstream) dedup pick: backports the refined set of `release/2.12` ROCm commits that are still missing from `release/2.13`, on top of the current `release/2.13` tip (`2396d450def`).

Started from a ~79-commit candidate set, deduplicated by patch-id and semantic overlap against what `release/2.13` already carries. The branch was rewritten as a **linear history** (11 commits) rebased onto current `release/2.13` so it can be merged with **Rebase and Merge**. Conflicts were resolved keeping `release/2.13`'s newer logic where it already superseded 2.12 (test decorators, SDPA constraints, dependency pins, CK/mslk build config).

## Commits (top = newest)

1. `2eb3523ac74` [ROCm][Inductor] Make missing GPU warp-size metadata explicit (#183014)
2. `06380be4079` Bump AOTriton from 0.11.2b to 0.13b (#3419)
3. `9e97d702b26` [ROCm] Add initial support for gfx1250 (#188597) (#3421)
4. `8728fd33d0d` Skip test_is_pinned_no_context on python 3.14+ (behavior change)
5. `ec82a286d47` Backport upstream PR 180310 (#3352)
6. `9e5fc2fe200` reuse one stream for warmup and captures in make_graphed_callables (#3354)
7. `a4577b0f450` [ROCm] Fix test_cross_entropy_loss_2d_out_of_bounds_class (#187613)
8. `2747c909504` Fix graph capture error handling for ROCm 7.14+ (#3323)
9. `0919f8d1183` Guard NCCL one-sided API behind device support (#3295)
10. `634ba0e2749` [ROCm] Skip profiler check for foreach tests on ROCm (ROCM-21749) (#3262)
11. `789ce58b53a` [ROCm][RELEASE_ONLY] skip test_autoheuristic in-code (already disabled via issue) (#180927)

## Already on `release/2.13` (not duplicated on this branch)

These were in the original 13-commit pick but are already carried by the base and were skipped as empty cherry-picks during the rebase:

- `640f125845e` Rename duplicate hiprtc names for jit to avoid symbol collision (#3303)
- `8f26b5065cd` [ROCm] Use portable compiler names in cpp_extension compatibility tests (#188580)
- `3a7e84c7cdb` Fixed memory errors in SymmetricMemory caused by repeated calls (#3403 / #3517)

## Notes

- `.ci/docker/requirements-ci.txt` verified **unchanged** from the `release/2.13` base — dependency pins from #3445 preserved, no unintended pin drift.
- Branch history was force-pushed to drop the merge commit and linearize for rebase-and-merge.
- Deferred (not in this pick): #3416 (CK/mslk refined filter) and the `mix_order_reduction_allow_multi_stages` ROCm evaluation.

## Test plan

- [x] ROCm CI green on `release/2.13` (with pre-linear history branch commit [2b89329](https://github.com/ROCm/pytorch/commit/2b89329c30c534e2b5f070eab10e51b4472cf0de))

3.12 — [run 30492390174](https://github.com/ROCm/TheRock/actions/runs/30492390174)
3.10 — [run 30492393655](https://github.com/ROCm/TheRock/actions/runs/30492393655)
3.11 — [run 30492396947](https://github.com/ROCm/TheRock/actions/runs/30492396947)
3.13 — [run 30492400428](https://github.com/ROCm/TheRock/actions/runs/30492400428)
3.14 — [run 30492403631](https://github.com/ROCm/TheRock/actions/runs/30492403631)

Authored with assistance from Cursor