### PR TITLE
[release/2.13] Skip ROCm-failing tests in test_cuda/test_nn

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1355,6 +1355,7 @@ print(t.is_pinned())
             self.assertEqual(a, b)
             self.assertEqual(torch.cuda.initial_seed(), 2)
 
+    @skipIfRocm(msg="ROCm cold HIP init causes 15s subprocess timeout on CI; flaky/slow-init, not a confirmed deadlock")
     def test_lazy_call_reentrant_set_rng_state_does_not_deadlock(self):
         # Separate process: a regression deadlocks the interpreter (non-reentrant lock).
         # Happy path is usually a few seconds; allow margin for slow CI / CUDA init.
@@ -2835,7 +2836,8 @@ torch.cuda.synchronize()
         torch.cuda.synchronize()
         self.assertFalse(torch.allclose(buf, torch.zeros_like(buf)))
 
-    @skipIfRocmVersionLessThan((7, 14))
+    @skipIfRocm(msg="HIPCachingAllocator does not release reserved segments after a failed "
+                "graph capture; memory_reserved() does not recover to baseline")
     @xfailCUDAIfSM89OrLaterOnWindows
     @unittest.skipIf(
         not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
@@ -5927,6 +5929,7 @@ class TestCudaAllocator(TestCase):
                 "throw_on_cudamalloc_oom:False,per_process_memory_fraction:1.0"
             )
 
+    @skipIfRocm(msg="subprocess spawned with env={} drops LD_LIBRARY_PATH; dynamically-linked venv python cannot find libpython3.12.so.1.0 on CI (exit 127 before test body)")
     def test_allocator_backend(self):
         def check_output(script: str) -> str:
             return subprocess.check_output(

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -15144,6 +15144,8 @@ if __name__ == '__main__':
         self.assertLessEqual(maximal_linear_bias_grad_max_ulp_diff, expected_linear_bias_grad_max_ulp_diff,
                              msg=f"worst linear_bias-grad ULP {maximal_linear_bias_grad_max_ulp_diff} from kwargs={worst_linear_bias_grad_kwargs}")
 
+    @skipIfRocm(msg="ROCm fp32 GEMM ULP divergence: input-grad 952 > 854 tolerance bound "
+                "(TheRock math-lib build, rocBLAS/hipBLASLt accumulation)")
     @parametrize_test("bias", [False, True])
     @dtypes(torch.float32)
     def test_linear_cross_entropy_loss_default(self, device, dtype, bias):


### PR DESCRIPTION
Adds @skipIfRocm to 4 tests that consistently fail in the TheRock wheel test lane (test_pytorch_wheels.yml) on gfx94X/MI300 with torch==2.13.0a0+rocm7.14.0.

  - test_allocator_backend 
  - test_graph_capture_error_releases_reserved_segments
  - test_lazy_call_reentrant_set_rng_state_does_not_deadlock
  - test_linear_cross_entropy_loss_default 

  Also removes the now-dead @skipIfRocmVersionLessThan((7, 14)) from test_graph_capture_error_releases_reserved_segments — with @skipIfRocm on top it is unreachable on ROCm.

  Test plan

  - Validated via ROCm/TheRock test_pytorch_wheels.yml run #30218037322 on gfx94X-dcgpu with torch==2.13.0a0+rocm7.14.0 — all 4 tests
  now SKIPPED, run passes
- Core UTs passing on 2.13: https://github.com/ROCm/TheRock/actions/runs/30218037322