### PR TITLE
[release/2.12] skip test_hip_device_count due to rocprofiler-sdk issue

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -4286,6 +4286,7 @@ with torch.cuda.graph(g):
             )
             self.assertEqual(rc, "3")
 
+    @unittest.skipIf(TEST_WITH_ROCM, "Failed onr ROCm due to rocprofiler-sdk issue AIPROFSDK-840")
     @unittest.skipIf(not TEST_WITH_ROCM, "not relevant for CUDA testing")
     def test_hip_device_count(self):
         """Validate device_count works with both CUDA/HIP visible devices"""


### PR DESCRIPTION
Skip for `test_cuda.py::TestCuda::test_hip_device_count` due to rocprofiler-sdk issue `AIPROFSDK-840`

Cherry-picked to release/2.11 branch via https://github.com/ROCm/pytorch/pull/3508

Cherry-picked to release/2.13 branch via https://github.com/ROCm/pytorch/pull/3509