### PR TITLE
[release/2.13] Bump numpy version

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -138,9 +138,7 @@ numba==0.64.0 ; python_version == "3.12" and platform_machine != "s390x"
 #test_nn.py, test_namedtensor.py, test_linalg.py, test_jit_cuda_fuser.py,
 #test_jit.py, test_indexing.py, test_datapipe.py, test_dataloader.py,
 #test_binary_ufuncs.py
-numpy==1.23.2; python_version == "3.10"
-numpy==1.26.2; python_version == "3.11" or python_version == "3.12"
-numpy==2.1.2; python_version >= "3.13" and python_version < "3.14"
+numpy==2.1.2 ; python_version < "3.14"
 numpy==2.3.4; python_version >= "3.14"
 
 pandas==2.0.3; python_version < "3.12"


### PR DESCRIPTION
Use the same numpy pins as other release branches