### PR TITLE
skip flaky test_Embedding_discontiguous_cuda

### DIFF
--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -17,7 +17,7 @@ import torch.nn.functional as F
 from torch.nn import _reduction as _Reduction
 from torch.testing._internal import common_utils
 from torch.testing._internal.common_utils import TestCase, to_gpu, freeze_rng_state, is_iterable, \
-    gradcheck, gradgradcheck, set_default_dtype, skipIfTorchDynamo, TEST_WITH_ROCM
+    gradcheck, gradgradcheck, set_default_dtype, skipIfTorchDynamo, skipIfRocm, TEST_WITH_ROCM
 from torch.testing._internal.common_cuda import TEST_CUDA, SM90OrLater
 from torch.autograd.gradcheck import _get_numerical_jacobian, _iter_tensors
 from torch.autograd import Variable
@@ -1727,7 +1727,9 @@ def get_new_module_tests():
             check_gradgrad=False,
             desc='discontiguous',
             default_dtype=torch.double,
-            decorator=skipIfTorchDynamo("https://github.com/pytorch/pytorch/issues/117971")
+            decorator=lambda fn: skipIfTorchDynamo("https://github.com/pytorch/pytorch/issues/117971")(
+                skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/186910")(fn)
+            ),
         ),
         dict(
             module_name='EmbeddingBag',


### PR DESCRIPTION
Skip for `test_nn.py::TestNN::test_Embedding_discontiguous_cuda`
The test is flaky and disabled on upstream https://github.com/pytorch/pytorch/issues/186910

```
python test/test_nn.py -v TestNN.test_Embedding_discontiguous_cuda

test_Embedding_discontiguous_cuda (__main__.TestNN.test_Embedding_discontiguous_cuda) skipped 'skipIfRocm: https://github.com/pytorch/pytorch/issues/186910'
```



Cherry-picked to release/2.11 branch via https://github.com/ROCm/pytorch/pull/3519

Cherry-picked to release/2.13 branch via https://github.com/ROCm/pytorch/pull/3520