### PR TITLE
[CI][release/2.13] Cherry-pick dependency pins from 2.12

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -17,11 +17,11 @@ build==1.3.0
 
 click==8.3.3
 #Description: Command Line Interface Creation Kit
-#Pinned versions:
+#Pinned versions: 8.3.1
 #test that import:
 
 coremltools==5.0b5 ; python_version < "3.12"
-coremltools==8.3 ; python_version == "3.12"
+coremltools==8.3.0 ; python_version == "3.12"
 #Description: Apple framework for ML integration
 #Pinned versions: 5.0b5
 #test that import:
@@ -119,8 +119,9 @@ ninja==1.13.0
 #Pinned versions: 1.13.0
 #test that import: run_test.py, test_cpp_extensions_aot.py,test_determination.py
 
-numba==0.57.1 ; python_version == "3.10" and platform_machine != "s390x"
-numba==0.64.0 ; python_version == "3.12" and platform_machine != "s390x"
+numba==0.61.2 ; python_version < "3.14" and platform_machine != "s390x"
+numba==0.64.0 ; python_version >= "3.14" and platform_machine != "s390x"
+
 #Description: Just-In-Time Compiler for Numerical Functions
 #Pinned versions: 0.55.2, 0.60.0
 #test that import: test_numba_integration.py
@@ -141,8 +142,7 @@ numba==0.64.0 ; python_version == "3.12" and platform_machine != "s390x"
 numpy==2.1.2 ; python_version < "3.14"
 numpy==2.3.4; python_version >= "3.14"
 
-pandas==2.0.3; python_version < "3.12"
-pandas==2.2.3; python_version >= "3.12" and python_version < "3.14"
+pandas==2.2.3; python_version < "3.14"
 pandas==2.3.3; python_version >= "3.14"
 
 #onnxruntime
@@ -150,9 +150,9 @@ pandas==2.3.3; python_version >= "3.14"
 #Pinned versions: 1.9.0
 #test that import:
 
-opt-einsum==3.3
+opt-einsum==3.3.0
 #Description: Python library to optimize tensor contraction order, used in einsum
-#Pinned versions: 3.3
+#Pinned versions: 3.3.0
 #test that import: test_linalg.py
 
 optree==0.13.0 ; python_version < "3.14"
@@ -181,7 +181,7 @@ protobuf==6.33.5
 
 psutil==7.2.2
 #Description: information on running processes and system utilization
-#Pinned versions:
+#Pinned versions: 7.2.2
 #test that import: test_profiler.py, test_openmp.py, test_dataloader.py
 
 pytest==7.3.2
@@ -201,7 +201,7 @@ pytest-flakefinder==1.1.0
 
 pytest-rerunfailures==14.0
 #Description: plugin for rerunning failure tests in pytest
-#Pinned versions:
+#Pinned versions: 14.0
 #test that import:
 
 pytest-subtests==0.13.1
@@ -254,9 +254,9 @@ scikit-image==0.22.0
 #Pinned versions: 0.20.3
 #test that import:
 
-scipy==1.10.1 ; python_version <= "3.11"
-scipy==1.14.1 ; python_version > "3.11" and python_version < "3.14"
+scipy==1.14.1 ; python_version < "3.14"
 scipy==1.16.2 ; python_version >= "3.14"
+
 # Pin SciPy because of failing distribution tests (see #60347)
 #Description: scientific python
 #Pinned versions: 1.10.1
@@ -270,8 +270,7 @@ scipy==1.16.2 ; python_version >= "3.14"
 #test that import:
 
 # needed by torchgen utils
-typing-extensions==4.12.2 ; python_version < "3.14"
-typing-extensions==4.15.0 ; python_version >= "3.14"
+typing-extensions==4.15.0
 #Description: type hints for python
 #Pinned versions:
 #test that import:
@@ -321,8 +320,7 @@ z3-solver==4.15.1.0 ; platform_machine != "s390x"
 #Pinned versions:
 #test that import:
 
-tensorboard==2.13.0 ; python_version < "3.13"
-tensorboard==2.18.0 ; python_version >= "3.13"
+tensorboard==2.18.0
 #Description: Also included in .ci/docker/requirements-docs.txt
 #Pinned versions:
 #test that import: test_tensorboard


### PR DESCRIPTION
Cherry picked .ci/docker/requirements-ci.txt from 5379cbe4a99daf7241eff5c7012da1b71221df9d, resolved conflict by accepting changes explicitly made in https://github.com/ROCm/pytorch/pull/3445/changes.

Test run: https://github.com/ROCm/TheRock/actions/runs/30402630662/job/90424764289
Successfully installs dependency