### PR TITLE
[release/2,13] Fixed memory errors in SymmetricMemory caused by repeated call of hipMemMap 

### DIFF
--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryUtils.cpp
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryUtils.cpp
@@ -291,12 +291,6 @@ void map_block(
       0,
       reinterpret_cast<hipMemGenericAllocationHandle_t>(handle),
       0ULL));
-  C10_CUDA_CHECK(hipMemMap(
-      *ptr,
-      size,
-      0,
-      reinterpret_cast<hipMemGenericAllocationHandle_t>(handle),
-      0ULL));
 
   hipMemAccessDesc desc;
   desc.location.type = hipMemLocationTypeDevice;


### PR DESCRIPTION
Repeated call of hipMemMap is causing the errors in SymmetricMemory. Fixing that.

Pull Request resolved: https://github.com/pytorch/pytorch/pull/188673
Approved by: https://github.com/Skylion007, https://github.com/jeffdaily

(cherry picked from commit 25825f66540295c6fad0f10e20d48f1462f756b0)