### PR TITLE
[release/2.12] Skip flaky test_reentrant_parent_error_on_cpu

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -58,6 +58,7 @@ from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     onlyCPU,
     onlyCUDA,
+    skipCUDAIf,
     skipMeta,
 )
 from torch.testing._internal.common_dtype import floating_types_and
@@ -12623,6 +12624,10 @@ class TestAutogradDeviceType(TestCase):
         self.assertIsNone(t1.grad)
         self.assertIsNone(t3.grad)
 
+    @skipCUDAIf(
+        True,
+        "Flaky test: https://github.com/pytorch/pytorch/issues/86735",
+    )
     @onlyCUDA
     def test_reentrant_parent_error_on_cpu(self, device):
         def _get_cuda_memory_usage():


### PR DESCRIPTION
PyTorch does not today promise transactional backward. If backward() throws, .grad is generally undefined. The test asserts a strong rule: no leaf grads after a failed combined backward, including nested reentrant work. That is stricter than what engine behavior gives.

Track upstream https://github.com/pytorch/pytorch/issues/86735

Cherry-picked to release/2.11 branch via https://github.com/ROCm/pytorch/pull/3527

Cherry-picked to release/2.13 branch via https://github.com/ROCm/pytorch/pull/3528