### PR TITLE
[release/2.12] [ROCm] Require libhipcxx in LoadHIP.cmake for ROCm 10+

### DIFF
--- a/cmake/public/LoadHIP.cmake
+++ b/cmake/public/LoadHIP.cmake
@@ -227,9 +227,14 @@ if(HIP_FOUND)
 
   # Optional components.
   find_package_and_print_version(hipsparselt)  # Will be required when ready.
-  # ROCm 8.0 and later requires libhipcxx! This should be marked as
-  # 'REQUIRED' once minimal ROCm version is bumped to 8.0 or later.
-  find_package_and_print_version(libhipcxx)
+  # ROCm 10+ ships hipCUB against CCCL 3.x via libhipcxx; require the CMake
+  # package so ROCM_INCLUDE_DIRS picks up libhipcxx headers. Optional on
+  # older ROCm where hipCUB still bundles its own limits backports.
+  if(ROCM_VERSION_DEV VERSION_GREATER_EQUAL "10.0")
+    find_package_and_print_version(libhipcxx REQUIRED)
+  else()
+    find_package_and_print_version(libhipcxx)
+  endif()
 
   list(REMOVE_DUPLICATES ROCM_INCLUDE_DIRS)
 


### PR DESCRIPTION
## Summary

ROCm 10 ships hipCUB against CCCL 3.x via **libhipcxx**. PyTorch should resolve that dependency directly in `cmake/public/LoadHIP.cmake` via `find_package(libhipcxx)` so `ROCM_INCLUDE_DIRS` includes libhipcxx headers at configure time.

Release/2.12 already had optional `find_package(libhipcxx)` from #3441; this follow-up marks it **REQUIRED** when `ROCM_VERSION_DEV >= 10.0` (optional on older ROCm).

> Okay. So adding find_package(libhipcxx) in pytorch directly is the way to go then.

## Changes

- Gate `find_package_and_print_version(libhipcxx REQUIRED)` on `ROCM_VERSION_DEV VERSION_GREATER_EQUAL "10.0"`.
- Keep optional `find_package(libhipcxx)` on ROCm < 10.

## TheRock validation

| Input | Value |
|-------|-------|
| Workflow | `Multi-Arch Build Portable Linux PyTorch Wheels` |
| TheRock ref | `users/ethanwee/pytorch-gitrepo-origin` |
| PyTorch fork | `ethanwee1/pytorch` @ `ethanwee/rocm10-libhipcxx-2.12` |
| `rocm_version` | `10.0.0a20260729` |
| `rocm_package_index_url` | `https://rocm.nightlies.amd.com/whl-multi-arch/` |
| `amdgpu_families` | `gfx942` |
| `cache_type` | `none` |
| `test_amdgpu_families` | `none` |

**Run:** https://github.com/ROCm/TheRock/actions/runs/30661825174
