### PR TITLE
Add missing gfx1250 support in GroupedBlas

### DIFF
--- a/aten/src/ATen/native/cuda/GroupedBlas.cpp
+++ b/aten/src/ATen/native/cuda/GroupedBlas.cpp
@@ -77,7 +77,10 @@ bool _scaled_mm_allowed_device(bool sm90_only=false, bool sm100_only=false) {
     "gfx1200", "gfx1201",
 #endif
 #if ROCM_VERSION >= 60500
-    "gfx950"
+    "gfx950",
+#endif
+#if ROCM_VERSION >= 71400
+        "gfx1250",
 #endif
 };
   return at::detail::getCUDAHooks().isGPUArch(archs);


### PR DESCRIPTION
Porting only missing code (gfx1250) from https://github.com/pytorch/pytorch/pull/190703/changes