### PR TITLE
Modify CUDA shard counts in parity job config

### DIFF
--- a/.automation_scripts/pytorch-unit-test-scripts/parity_job_config.json
+++ b/.automation_scripts/pytorch-unit-test-scripts/parity_job_config.json
@@ -15,7 +15,7 @@
     "distributed": [{ "workflow": "trunk", "job_prefix": "linux-jammy-cuda13.0-py3.10-gcc11" }],
     "inductor": [{ "workflow": "inductor", "job_prefix": "unit-test / inductor-test" }],
     "test_kinds": ["test-osdc", "test"],
-    "shard_counts": { "default": 5, "distributed": 3, "inductor": 2 },
+    "shard_counts": { "default": 14, "distributed": 10, "inductor": 2 },
     "checkrun_regex": "(linux-jammy-cuda13[.]0-py3[.]10-gcc11 / (test-osdc|test) [(](default|distributed),|unit-test / inductor-test / (test-osdc|test) [(]inductor,)"
   },
   "rocm": {


### PR DESCRIPTION
## Motivation

Updated shard counts for CUDA and ROCm configurations in the job config.

## Validation

https://github.com/ROCm/pytorch/actions/runs/30730179443