### PR TITLE
[release/2.12] Fix rocm test replicate device

### DIFF
--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -1948,7 +1948,10 @@ class MultiProcContinuousTest(TestCase):
         This supports instantiate_device_type_tests which calls setUpClass during
         class creation (before any tests run), when spawning would be premature.
         """
-        if cls._processes_spawned:
+        # Check the class's own dict: a subclass must not inherit the flag from
+        # a base test class that already ran and tore down its workers, else it
+        # would dispatch tests to the base class's dead worker processes.
+        if cls.__dict__.get("_processes_spawned", False):
             return
 
         # Handle method, property, and string attribute for device_type
@@ -1996,8 +1999,10 @@ class MultiProcContinuousTest(TestCase):
         Class-scope test fixture. Run once for entire test class, after all tests finish.
         Tear down the process group if spawned.
         """
-        # If processes were never spawned (e.g., all tests were skipped), nothing to tear down
-        if not cls._processes_spawned:
+        # If processes were never spawned (e.g., all tests were skipped), nothing to tear down.
+        # Check the class's own dict to avoid tearing down an already-finished
+        # base class's workers (see _ensure_processes_spawned).
+        if not cls.__dict__.get("_processes_spawned", False):
             super().tearDownClass()
             return
 


### PR DESCRIPTION
## Motivation

It is a portion of upstream commit 5812ecc (https://github.com/pytorch/pytorch/commit/5812ecc6384ed417986c8ed822a1bd85ffbdc299) - Backport of the test-infra portion of pytorch/pytorch#189362.

Fix MultiProcContinuousTest subclass hanging on its base class's dead workers

A subclass of a concrete MultiProcContinuousTest test class inherits the base class's `_processes_spawned` flag through ordinary attribute lookup, so it never spawns its own workers and instead dispatches tests onto the base class's already torn-down queues, blocking forever in `completion_queue.get()`. Consult the class's own `__dict__` in both the spawn and the teardown guard so that every leaf class owns its worker pool.

This makes test_replicate.py order-independent. Under pytest the base class ReplicateTest runs before ReplicateFullyShardInit, which then hangs until the harness timeout; under unittest the subclass happens to sort first, which is why the bug stayed latent in CUDA CI.

## Test Plan

- Testing offline: `python -m pytest distributed/_composable/test_replicate.py -k test_replicate_device_id`

## Test Result

- Before the change: the test was failing: Timeout (>900.0s)
- After the change: the test passes

<!-- Briefly summarize test outcomes. -->


Cherry-picked to release/2.11 branch via https://github.com/ROCm/pytorch/pull/3540