### PR TITLE
[release/2.13] Fix coordinate cache in `LocalDeviceMesh` (#187052)

### DIFF
--- a/torch/distributed/_local_tensor/__init__.py
+++ b/torch/distributed/_local_tensor/__init__.py
@@ -1261,9 +1261,12 @@ class LocalTensorMode(TorchDispatchMode):
         self._per_rank_rng_states: dict[
             int, tuple[torch.Tensor, dict[int, torch.Tensor]]
         ] = {}
-        # Cache for get_coordinate results, keyed by mesh id
-        # Protected by _coordinate_cache_lock for thread safety in MPMD contexts
-        self._coordinate_cache: dict[int, list[SymInt]] = {}
+        # Cache for get_coordinate results, keyed by the inputs used to compute them:
+        # (ndim, flattened rank map, layout).
+        # Protected by _coordinate_cache_lock for thread safety in MPMD contexts.
+        self._coordinate_cache: dict[
+            tuple[int, tuple, torch.distributed._mesh_layout._MeshLayout], list[SymInt]
+        ] = {}
         self._coordinate_cache_lock = threading.Lock()
 
     def __enter__(self) -> "LocalTensorMode":
@@ -1632,16 +1635,17 @@ class _LocalDeviceMesh:
         if lm is None:
             raise AssertionError("Unexpectedly not in LocalTensorMode")
 
+        # Include all attributes used below in the cache key
+        cache_key = (self.ndim, self._flatten_rank_map, self._layout)
         # Check cache first (fast path without lock)
-        mesh_id = id(self)
-        if mesh_id in lm._coordinate_cache:
-            return lm._coordinate_cache[mesh_id]
+        if cache_key in lm._coordinate_cache:
+            return lm._coordinate_cache[cache_key]
 
         # Acquire lock for thread safety in MPMD contexts
         with lm._coordinate_cache_lock:
             # Double-check after acquiring lock
-            if mesh_id in lm._coordinate_cache:
-                return lm._coordinate_cache[mesh_id]
+            if cache_key in lm._coordinate_cache:
+                return lm._coordinate_cache[cache_key]
 
             coords: list[dict[int, int]] = [{} for _ in range(self.ndim)]
             # Clone rank_map to avoid "Cannot set version_counter for inference tensor"
@@ -1657,7 +1661,7 @@ class _LocalDeviceMesh:
 
             out = [torch.SymInt(LocalIntNode(c)) for c in coords]
             # Cache the result
-            lm._coordinate_cache[mesh_id] = out
+            lm._coordinate_cache[cache_key] = out
             # The output contains coordinates for each of the ranks with respect to
             # their meshes formed from root mesh and selecting the same dimensions
             # as the current mesh.


### PR DESCRIPTION
Cherry-pick of upstream commit 2314113635b7755ceea54b28fc22ba59d5b63bcb (pytorch/pytorch#187052) onto release/2.13.

The LocalTensorMode coordinate cache was keyed by the mesh's Python object id, which is not unique over the lifetime of the mode: when a temporary submesh is destroyed, Python may reuse its id for the next submesh, silently returning stale coordinates for a different mesh dimension. This fixes the cache key to use the actual inputs to the coordinate calculation (ndim, flattened rank map, layout) instead.

Fixes ROCM-28605, pytorch/pytorch#184526.

Verified locally: test/distributed/tensor/test_utils.py::TestStridedShardingWithLocalTensor: {test_2d_mesh_strided_sharding,test_2d_mesh_2d_tensor_strided_sharding} fail before this commit and pass after it.