### PR TITLE
[release/2.11] Skip FSDP post-optim event test 

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_training.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_training.py
@@ -53,6 +53,7 @@ from torch.testing._internal.common_utils import (
     get_cycles_per_ms,
     MI200_ARCH,
     run_tests,
+    skipIfRocm,
     TEST_CUDA_GRAPH,
     TEST_HPU,
     TEST_XPU,
@@ -656,6 +657,7 @@ class TestFullyShard1DTrainingCore(FSDPTest):
             self.assertEqual(losses[0], losses[1])
 
     @skip_if_lt_x_gpu(2)
+    @skipIfRocm(msg="Skipped to stabilize release/2.11 on TheRock CI")
     @unittest.skipIf(TEST_HPU or TEST_XPU, "Sleep is not supported on HPU/XPU")
     def test_post_optim_event(self):
         torch.manual_seed(42)


### PR DESCRIPTION
Skip the consistently failing test to stabilize TheRock CI.

## Summary 

Skip TestFullyShard1DTrainingCore::test_post_optim_event on ROCm to stabilize release/2.11 TheRock CI. The test consistently failed with a scalar parity mismatch across all retries. Other backends remain enabled.


Cherry-picked to release/2.12 branch via https://github.com/ROCm/pytorch/pull/3543