### PR TITLE
[release/2.12] Skip rocm test virtual local rank

### DIFF
--- a/test/distributed/launcher/test_run.py
+++ b/test/distributed/launcher/test_run.py
@@ -29,6 +29,7 @@ from torch.distributed.elastic.utils.distributed import get_free_port
 from torch.testing._internal.common_utils import (
     run_tests,
     skip_but_pass_in_sandcastle_if,
+    skipIfRocm,
     TEST_CUDA,
     TEST_WITH_DEV_DBG_ASAN,
     TestCase,
@@ -680,6 +681,7 @@ class ElasticLaunchTest(TestCase):
         for i in range(nproc_per_node):
             self.assertTrue(f"[rank{i}]: creating " in captured_out.getvalue())
 
+    @skipIfRocm(msg="Skipped to stabilize TheRock CI")
     @skip_but_pass_in_sandcastle_if(
         TEST_WITH_DEV_DBG_ASAN, "test incompatible with dev/dbg asan"
     )


### PR DESCRIPTION
## Summary 
Skip `ElasticLaunchTest.test_virtual_local_rank` on ROCm after it consistently aborted with SIGABRT. CUDA coverage remains unchanged. The purpose of this PR is to stabilize TheRock CI.
    
## Testing
- CI failure: https://github.com/ROCm/rockrel/actions/runs/30973844382
- Tested locally using `python3 test/distributed/launcher/test_run.py -v -k test_virtual_local_rank`
  - Passed with the expected ROCm skip.