### PR TITLE
[release/2.11] Skip flaky distributed tests

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_overlap.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_overlap.py
@@ -24,6 +24,7 @@ from torch.testing._internal.common_utils import (
     get_cycles_per_ms,
     MI200_ARCH,
     run_tests,
+    skipIfRocm,
     TEST_HPU,
 )
 
@@ -51,6 +52,7 @@ class TestFullyShardOverlap(FSDPTest):
     def world_size(self) -> int:
         return min(2, torch.get_device_module(device_type).device_count())
 
+    @skipIfRocm(msg="Skipped to stabilize PyTorch on TheRock CI")
     @skip_if_rocm_arch_multiprocess(MI200_ARCH)
     @skip_if_lt_x_gpu(2)
     @unittest.skipIf(TEST_HPU, "Sleep is not supported on HPU")

--- a/test/distributed/fsdp/test_fsdp_core.py
+++ b/test/distributed/fsdp/test_fsdp_core.py
@@ -40,6 +40,7 @@ from torch.testing._internal.common_utils import (
     run_tests,
     TEST_HPU,
     TEST_WITH_DEV_DBG_ASAN,
+    TEST_WITH_ROCM,
 )
 
 
@@ -230,6 +231,12 @@ class TestParityWithDDP(FSDPTest):
         cpu_offload: CPUOffload,
         sharding_strategy: Optional[ShardingStrategy],
     ):
+        if (
+            TEST_WITH_ROCM
+            and cpu_offload.offload_params
+            and sharding_strategy == ShardingStrategy.NO_SHARD
+        ):
+            self.skipTest("Skipped to stabilize PyTorch on TheRock CI")
         fsdp_kwargs = {"device_id": device_type.type}
         self.run_subtests(
             self._get_subtest_config(cpu_offload),

--- a/test/distributed/test_distributed_spawn.py
+++ b/test/distributed/test_distributed_spawn.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+import unittest
 
 import torch
 import torch.distributed as dist
@@ -13,7 +14,11 @@ if not dist.is_available():
     print("Distributed not available, skipping tests", file=sys.stderr)
     sys.exit(0)
 
-from torch.testing._internal.common_utils import run_tests, TEST_WITH_DEV_DBG_ASAN
+from torch.testing._internal.common_utils import (
+    run_tests,
+    TEST_WITH_DEV_DBG_ASAN,
+    TEST_WITH_ROCM,
+)
 from torch.testing._internal.distributed.distributed_test import (
     DistributedTest,
     TestDistBackend,
@@ -51,6 +56,12 @@ if BACKEND in _allowed_backends:
             super().setUp()
             self._spawn_processes()
             torch.backends.cudnn.flags(enabled=True, allow_tf32=False).__enter__()
+
+        @unittest.skipIf(
+            TEST_WITH_ROCM, "Skipped to stabilize PyTorch on TheRock CI"
+        )
+        def test_monitored_barrier_allreduce_hang_wait_all_ranks(self):
+            super().test_monitored_barrier_allreduce_hang_wait_all_ranks()
 
 else:
     print(f"Invalid backend {BACKEND}. Tests will not be run!")


### PR DESCRIPTION
## Summary
Skip three flaky distributed tests on ROCm to stabilize `release/2.11` TheRock CI. This disables the FSDP overlap and monitored-barrier tests on ROCm while narrowly skipping only the failing mixture-of-experts variant. Non-ROCm configurations remain enabled.