### PR TITLE
Fix uninitialized embedding indices in test_embedding_meta_indices (#188002)

### DIFF
--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -1571,11 +1571,14 @@ def forward(self, x_1):
     def test_embedding_meta_indices(self):
         with FakeTensorMode():
             weight = torch.empty(20, 8)
-            indices = torch.empty(2, 3, dtype=torch.long, device="meta")
+            # Indices must be in range: under propagate_real_tensors the real
+            # embedding gather runs, and uninitialized (torch.empty) indices read
+            # out of bounds -- a hard GPU fault on some backends (e.g. ROCm).
+            indices = torch.zeros(2, 3, dtype=torch.long, device="meta")
             out = torch.nn.functional.embedding(indices, weight)
 
             meta_weight = torch.empty(20, 8, dtype=torch.float64, device="meta")
-            cpu_indices = torch.empty(4, 5, dtype=torch.long)
+            cpu_indices = torch.zeros(4, 5, dtype=torch.long)
             meta_weight_out = torch.nn.functional.embedding(cpu_indices, meta_weight)
 
             run_cuda_cases = (
@@ -1584,7 +1587,7 @@ def forward(self, x_1):
             )
             if run_cuda_cases:
                 cuda_weight = torch.empty(20, 8, device="cuda")
-                cuda_indices = torch.empty(2, 3, dtype=torch.long, device="cuda")
+                cuda_indices = torch.zeros(2, 3, dtype=torch.long, device="cuda")
                 cuda_out = torch.nn.functional.embedding(cuda_indices, cuda_weight)
 
         self.assertIsInstance(out, FakeTensor)


### PR DESCRIPTION
Cherry-pick the upstream commit to fix MI450 test crash caused by following:
test_fake_tensor.py::PropagateRealTensorsFakeTensorTest::test_embedding_meta_indices_propagate_real_tensors

Verified test is passed after this fix.